### PR TITLE
hailo-re(qemu-stub): impersonate Hailo-8 NPU for BAR capture — #795 Phase 0 Task 0.2

### DIFF
--- a/host-tools/qemu-hailo8-stub/README.md
+++ b/host-tools/qemu-hailo8-stub/README.md
@@ -1,0 +1,213 @@
+# qemu-hailo8-stub
+
+QEMU PCIe stub device impersonating a Hailo-8 NPU. Captures every BAR
+R/W operation HailoRT performs against the device from inside the VM,
+answering reads from a JSONL corpus and halting on unknown reads so a
+driver script can extend the corpus from real hardware.
+
+This is Phase 0 Task 0.2 of the Hailo BAR4 protocol reverse-engineering
+plan ([issue #795](https://github.com/SLM-OS/SLM-Operating-System/issues/795)).
+Corpus format spec: [`docs/hailo-re-corpus-format.md`](../../docs/hailo-re-corpus-format.md).
+
+## Layout
+
+```
+host-tools/qemu-hailo8-stub/
+├── README.md           — this file
+├── install.sh          — symlink sources into a QEMU source tree
+├── src/
+│   ├── hailo8.c        — QEMU device model (PCI, BAR0/2/4, MSI)
+│   ├── hailo8_corpus.c — JSONL corpus loader / lookup / append
+│   └── hailo8_corpus.h — public API for the corpus module
+├── tests/
+│   ├── Makefile        — standalone unit-test build
+│   └── test_corpus.c   — unit tests for the corpus module
+└── sample/
+    └── empty.jsonl     — minimal corpus (header only) for smoke tests
+```
+
+The corpus module is QEMU-independent: pure C11 with a POSIX feature
+test macro. The unit tests link against it directly so they run without
+a QEMU build.
+
+## Build
+
+### 1. Build deps
+
+```sh
+sudo apt install libglib2.0-dev libpixman-1-dev libslirp-dev \
+                 flex bison meson python3-venv ninja-build
+```
+
+### 2. Get a QEMU source tree
+
+Tested against QEMU 8.2.x (matches Ubuntu 24.04 and Pi OS bookworm
+packages). Clone shallowly:
+
+```sh
+cd ~/projects
+git clone --depth 1 --branch stable-8.2 \
+    https://gitlab.com/qemu-project/qemu.git
+```
+
+### 3. Wire the device in
+
+`install.sh` symlinks the device sources into `hw/misc/` and appends
+the Kconfig + meson.build entries the QEMU build system needs. Safe to
+re-run after a `git pull` in the QEMU tree.
+
+```sh
+./install.sh ~/projects/qemu
+```
+
+### 4. Build QEMU
+
+```sh
+cd ~/projects/qemu
+./configure --target-list=x86_64-softmmu --enable-debug --disable-werror
+make -j$(nproc) qemu-system-x86_64
+```
+
+The result is `build/qemu-system-x86_64`.
+
+### 5. Run the unit tests
+
+These exercise the corpus parser, the seq-keyed lookup, the write
+append, and the hex round-trip. They don't need QEMU built.
+
+```sh
+make -C tests test
+```
+
+## Launching
+
+```sh
+~/projects/qemu/build/qemu-system-x86_64 \
+    -nodefaults -display none -no-reboot \
+    -accel tcg \
+    -machine q35 -m 256 \
+    -device hailo8,corpus=/path/to/corpus.jsonl
+```
+
+### Properties
+
+| Property      | Type   | Default      | Meaning                                       |
+|---------------|--------|--------------|-----------------------------------------------|
+| `corpus`      | string | (required)   | Path to the JSONL corpus file                 |
+| `bar0_size`   | uint64 | `0x4000`     | BAR0 (NNC config) size in bytes               |
+| `bar2_size`   | uint64 | `0x40000`    | BAR2 (vDMA registers) size in bytes           |
+| `bar4_size`   | uint64 | `0x1000000`  | BAR4 (fw access window) size in bytes         |
+
+The defaults match the BAR sizes the Linux `hailo_pci` driver maps for
+Hailo-8 on the AI HAT+ (BAR4 = 16 MiB from `pcie_common.c`'s
+`max_size`).
+
+## Stdout / stderr protocols
+
+The stub emits three kinds of machine-parseable lines that the Task 0.5
+driver script consumes:
+
+### `HAILO_RE_CORPUS_EXTEND` (stdout, then exit 1)
+
+Emitted when a HailoRT read hits a `seq` not in the corpus. Per
+[`docs/hailo-re-corpus-format.md` §Corpus-extension request][spec]:
+
+```
+HAILO_RE_CORPUS_EXTEND seq=<N> bar=<B> offset=<X> size=<S> reason=unknown_read
+```
+
+The driver script invokes `hailo replay-step <N>` against real
+hardware, parses the resulting `HAILO_RE_CORPUS_RESPONSE`, appends the
+read entry to the corpus, and restarts QEMU.
+
+### `HAILO_RE_CORPUS_DIVERGENCE` (stdout, then exit 1)
+
+Emitted in three cases per [§Divergence report][spec]:
+
+| Reason                | Trigger                                                          |
+|-----------------------|------------------------------------------------------------------|
+| `op_shape_mismatch`   | Corpus has an entry at this `seq` but `dir`/`bar`/`offset`/`size` differs from the current op |
+| `write_value_mismatch`| Corpus has a recorded write at this `(seq, bar, offset)` whose `value` differs from what HailoRT wrote |
+
+Format:
+
+```
+HAILO_RE_CORPUS_DIVERGENCE seq=<N> bar=<B> offset=<X> size=<S> dir=<read|write> \
+    expected=<hex> observed=<hex> source=qemu reason=<tag>
+```
+
+A divergence is fatal for Phase 2 single-stepping — the driver script
+treats it as a poisoned-corpus signal and starts the rollback procedure
+per [§Re-validation rollback][spec].
+
+### `HAILO_RE_MSI_FIRE` (stderr, capture continues)
+
+Worktree extension to the corpus protocol. MSI fires are out of scope
+for v1 of the corpus format (per [§What this format does NOT cover][spec]),
+but the stub still needs a way to deliver IRQs to HailoRT. The
+mechanism: corpus read entries may carry an optional `"msi_after": V`
+field; immediately after the stub returns the recorded value, it fires
+MSI vector `V` and emits:
+
+```
+HAILO_RE_MSI_FIRE after_seq=<N> vector=<V>
+```
+
+to stderr (not stdout — IRQ events are a separate causal track from
+MMIO ops and conflating them in the corpus-extension stream would
+create ordering ambiguity).
+
+This field is additive and tolerated-but-ignored by readers that
+don't understand it, so it doesn't require bumping the corpus
+`format_version`.
+
+[spec]: ../../docs/hailo-re-corpus-format.md
+
+## Write capture
+
+Unknown writes are appended to the corpus file in place by the stub
+(one JSONL line per write, `source="qemu_capture"`,
+`validated_at_commit=null`). Writes are flushed to disk on every
+append, so the corpus is consistent even if QEMU later exits via an
+unknown-read halt. A duplicate write at the same `seq` whose value
+matches is silently accepted; a value mismatch triggers
+`write_value_mismatch` divergence as above.
+
+## Smoke tests
+
+`tests/smoke.py` exercises the three Definition-of-Done scenarios
+against a built QEMU using the qtest accelerator:
+
+1. **Empty corpus**: first BAR read produces `HAILO_RE_CORPUS_EXTEND`
+   and QEMU exits 1.
+2. **Hand-crafted lookup**: a corpus with one read entry returns the
+   recorded value to a qtest `readl`.
+3. **Write divergence**: a corpus with one write entry expecting `V1`
+   produces `HAILO_RE_CORPUS_DIVERGENCE` when qtest issues `writel V2`.
+
+Run with:
+
+```sh
+QEMU=~/projects/qemu/build/qemu-system-x86_64 python3 tests/smoke.py
+```
+
+## Limitations
+
+- DMA emulation is not modeled. HailoRT uploads firmware patches,
+  descriptor lists, and network-group parameters via DMA; those bytes
+  don't appear in BAR R/W traffic. Capture them separately as opaque
+  blobs keyed by the seq of the descriptor-program write that hands
+  the DMA address to fw. Out of scope for v1; revisit if Phase 4 finds
+  DMA blobs are the bottleneck.
+- The stub doesn't model fw timing. Real fw has settle windows (the
+  500 ms post-`BOOT_IRQ` one is the known example); the stub answers
+  reads instantly. The corpus driver compensates by interposing
+  delays on the SLM-OS replay side.
+- The stub is not migratable (`vmsd.unmigratable = 1`). The corpus +
+  seq counter pin it to its launch.
+
+## References
+
+- Issue [#795](https://github.com/SLM-OS/SLM-Operating-System/issues/795) — full RE plan, phase breakdown.
+- [`docs/hailo-re-corpus-format.md`](../../docs/hailo-re-corpus-format.md) — corpus format spec (the load-bearing contract).
+- [`docs/hailo-protocol-architecture.md`](../../docs/hailo-protocol-architecture.md) — protocol architecture, reopen criteria.

--- a/host-tools/qemu-hailo8-stub/README.md
+++ b/host-tools/qemu-hailo8-stub/README.md
@@ -122,19 +122,39 @@ read entry to the corpus, and restarts QEMU.
 
 ### `HAILO_RE_CORPUS_DIVERGENCE` (stdout, then exit 1)
 
-Emitted in three cases per [§Divergence report][spec]:
+Emitted in two cases per [§Divergence report][spec]:
 
 | Reason                | Trigger                                                          |
 |-----------------------|------------------------------------------------------------------|
 | `op_shape_mismatch`   | Corpus has an entry at this `seq` but `dir`/`bar`/`offset`/`size` differs from the current op |
 | `write_value_mismatch`| Corpus has a recorded write at this `(seq, bar, offset)` whose `value` differs from what HailoRT wrote |
 
-Format:
+Base format (always present):
 
 ```
 HAILO_RE_CORPUS_DIVERGENCE seq=<N> bar=<B> offset=<X> size=<S> dir=<read|write> \
     expected=<hex> observed=<hex> source=qemu reason=<tag>
 ```
+
+For `reason=write_value_mismatch`, `expected` and `observed` carry the
+real LE-encoded hex values of the corpus's recorded write and HailoRT's
+attempted write.
+
+For `reason=op_shape_mismatch`, the value fields aren't the divergence
+axis — the front-matter `bar=B offset=X size=S dir=W` already shows the
+observed op shape, so `expected`/`observed` are zero-filled at the
+access width and four extra tokens follow `reason=` carrying the
+corpus-side shape:
+
+```
+HAILO_RE_CORPUS_DIVERGENCE seq=<N> bar=<B> offset=<X> size=<S> dir=<W> \
+    expected=00000000 observed=00000000 source=qemu reason=op_shape_mismatch \
+    expected_bar=<E_B> expected_offset=<E_X> expected_size=<E_S> expected_dir=<E_W>
+```
+
+The extra tokens are additive and tolerated-but-ignored by readers that
+don't understand them, so they don't require a corpus `format_version`
+bump.
 
 A divergence is fatal for Phase 2 single-stepping — the driver script
 treats it as a poisoned-corpus signal and starts the rollback procedure
@@ -175,14 +195,17 @@ matches is silently accepted; a value mismatch triggers
 
 ## Smoke tests
 
-`tests/smoke.py` exercises the three Definition-of-Done scenarios
-against a built QEMU using the qtest accelerator:
+`tests/smoke.py` exercises the Definition-of-Done scenarios against a
+built QEMU using the qtest accelerator:
 
 1. **Empty corpus**: first BAR read produces `HAILO_RE_CORPUS_EXTEND`
    and QEMU exits 1.
 2. **Hand-crafted lookup**: a corpus with one read entry returns the
    recorded value to a qtest `readl`.
-3. **Write divergence**: a corpus with one write entry expecting `V1`
+3. **Shape divergence**: a corpus expecting a read at `seq=1` but the
+   guest issues a write produces `HAILO_RE_CORPUS_DIVERGENCE` with
+   `reason=op_shape_mismatch` plus the `expected_*` extension tokens.
+4. **Write divergence**: a corpus with one write entry expecting `V1`
    produces `HAILO_RE_CORPUS_DIVERGENCE` when qtest issues `writel V2`.
 
 Run with:

--- a/host-tools/qemu-hailo8-stub/install.sh
+++ b/host-tools/qemu-hailo8-stub/install.sh
@@ -34,6 +34,17 @@ if [[ ! -f "${SRC_DIR}/hailo8.c" ]]; then
 fi
 
 echo "==> Symlinking hailo8 sources into ${QEMU_SRC}/hw/misc/"
+# Refuse to clobber a regular file at the target path — guards against
+# the (unlikely but possible) future case where QEMU upstream ships its
+# own hw/misc/hailo8.c and `ln -sf` would silently destroy it.
+for f in hailo8.c hailo8_corpus.c hailo8_corpus.h; do
+    target="${QEMU_SRC}/hw/misc/${f}"
+    if [[ -e "${target}" && ! -L "${target}" ]]; then
+        echo "error: ${target} exists and is not a symlink — refusing to overwrite" >&2
+        echo "       (delete or move it manually if you intend to replace it)" >&2
+        exit 1
+    fi
+done
 ln -sf "${SRC_DIR}/hailo8.c"        "${QEMU_SRC}/hw/misc/hailo8.c"
 ln -sf "${SRC_DIR}/hailo8_corpus.c" "${QEMU_SRC}/hw/misc/hailo8_corpus.c"
 ln -sf "${SRC_DIR}/hailo8_corpus.h" "${QEMU_SRC}/hw/misc/hailo8_corpus.h"

--- a/host-tools/qemu-hailo8-stub/install.sh
+++ b/host-tools/qemu-hailo8-stub/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# install.sh — wire hailo8.c into a checked-out QEMU source tree.
+#
+# Symlinks the device sources from this directory into hw/misc/ and
+# idempotently appends the Kconfig + meson.build entries the QEMU build
+# system needs to compile the device.
+#
+# Usage: ./install.sh <path-to-qemu-source>
+#
+# Re-run after `git pull` in the QEMU tree — the symlinks survive but the
+# Kconfig/meson entries are appended only if not already present.
+#
+# Anchor: issue #795 Task 0.2.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <path-to-qemu-source>" >&2
+    exit 2
+fi
+
+QEMU_SRC="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="${SCRIPT_DIR}/src"
+
+if [[ ! -d "${QEMU_SRC}/hw/misc" ]]; then
+    echo "error: ${QEMU_SRC}/hw/misc not found — is this a QEMU source tree?" >&2
+    exit 1
+fi
+
+if [[ ! -f "${SRC_DIR}/hailo8.c" ]]; then
+    echo "error: ${SRC_DIR}/hailo8.c not found" >&2
+    exit 1
+fi
+
+echo "==> Symlinking hailo8 sources into ${QEMU_SRC}/hw/misc/"
+ln -sf "${SRC_DIR}/hailo8.c"        "${QEMU_SRC}/hw/misc/hailo8.c"
+ln -sf "${SRC_DIR}/hailo8_corpus.c" "${QEMU_SRC}/hw/misc/hailo8_corpus.c"
+ln -sf "${SRC_DIR}/hailo8_corpus.h" "${QEMU_SRC}/hw/misc/hailo8_corpus.h"
+
+KCONFIG="${QEMU_SRC}/hw/misc/Kconfig"
+if ! grep -q '^config HAILO8$' "${KCONFIG}"; then
+    echo "==> Appending CONFIG_HAILO8 to ${KCONFIG}"
+    cat >> "${KCONFIG}" <<'EOF'
+
+config HAILO8
+    bool
+    default y if TEST_DEVICES
+    depends on PCI && MSI_NONBROKEN
+EOF
+else
+    echo "==> CONFIG_HAILO8 already present in ${KCONFIG} — skipping"
+fi
+
+MESON="${QEMU_SRC}/hw/misc/meson.build"
+if ! grep -q "CONFIG_HAILO8" "${MESON}"; then
+    echo "==> Appending hailo8 to ${MESON}"
+    cat >> "${MESON}" <<'EOF'
+
+system_ss.add(when: 'CONFIG_HAILO8', if_true: files('hailo8.c', 'hailo8_corpus.c'))
+EOF
+else
+    echo "==> hailo8 entry already present in ${MESON} — skipping"
+fi
+
+echo "==> Done. To build the device, run:"
+echo "      cd ${QEMU_SRC}"
+echo "      ./configure --target-list=x86_64-softmmu --enable-debug"
+echo "      make -j\$(nproc)"
+echo "    Then launch with:"
+echo "      ./build/qemu-system-x86_64 ... \\"
+echo "        -device hailo8,corpus=/path/to/corpus.jsonl"

--- a/host-tools/qemu-hailo8-stub/sample/empty.jsonl
+++ b/host-tools/qemu-hailo8-stub/sample/empty.jsonl
@@ -1,0 +1,1 @@
+{"type":"header","format_version":1,"hailort_version":"4.23.0","fw_version":"4.23.0","capture_host":"qemu-x86_64-ubuntu24.04","slmos_base_sha":"0000000000000000000000000000000000000000","capture_started_at":"2026-05-12T00:00:00Z","notes":"empty fixture for smoke testing — first read triggers HAILO_RE_CORPUS_EXTEND"}

--- a/host-tools/qemu-hailo8-stub/src/hailo8.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8.c
@@ -1,0 +1,354 @@
+/*
+ * hailo8 — QEMU PCIe stub device impersonating a Hailo-8 NPU.
+ *
+ * Captures HailoRT's BAR0/BAR2/BAR4 MMIO traffic against a JSONL corpus
+ * defined in docs/hailo-re-corpus-format.md. Reads are answered from the
+ * corpus when (seq, bar, offset, size) matches; misses halt QEMU with
+ *   HAILO_RE_CORPUS_EXTEND seq=N bar=B offset=X size=S reason=unknown_read
+ * and exit code 1 so the Task 0.5 driver script can run hailo replay-step
+ * on real hardware and extend the corpus. Writes whose shape doesn't
+ * match a recorded entry halt with HAILO_RE_CORPUS_DIVERGENCE; unknown
+ * writes are appended to the corpus file in place.
+ *
+ * Anchor: issue #795 Task 0.2.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "qemu/error-report.h"
+#include "qapi/error.h"
+#include "hw/pci/pci.h"
+#include "hw/pci/pci_device.h"
+#include "hw/pci/msi.h"
+#include "hw/qdev-properties.h"
+#include "qom/object.h"
+#include "migration/vmstate.h"
+
+#include "hailo8_corpus.h"
+
+#define TYPE_HAILO8 "hailo8"
+
+#define HAILO8_VENDOR_ID         0x1e60
+#define HAILO8_DEVICE_ID_HAILO8  0x2864
+
+/* Defaults match the Hailo-8 silicon Linux's hailo_pci driver exposes
+ * (BAR4 = 16 MiB fw access window per pcie_common.c max_size). BAR0/BAR2
+ * sizes are reasonable placeholders — overridable via qdev properties. */
+#define HAILO8_DEFAULT_BAR0_SIZE  0x4000        /* 16 KiB — NNC config */
+#define HAILO8_DEFAULT_BAR2_SIZE  0x40000       /* 256 KiB — vDMA regs */
+#define HAILO8_DEFAULT_BAR4_SIZE  0x1000000     /* 16 MiB — fw access */
+
+#define HAILO8_MSI_NR_VECTORS     4
+
+typedef struct Hailo8State Hailo8State;
+
+typedef struct Hailo8BarCtx {
+    Hailo8State *s;
+    int bar_index;          /* 0, 2, or 4 — used in stdout lines */
+} Hailo8BarCtx;
+
+struct Hailo8State {
+    PCIDevice parent_obj;
+
+    /* Properties */
+    char    *corpus_path;
+    uint64_t bar0_size;
+    uint64_t bar2_size;
+    uint64_t bar4_size;
+
+    /* Runtime state */
+    MemoryRegion bar0_mr;
+    MemoryRegion bar2_mr;
+    MemoryRegion bar4_mr;
+    Hailo8BarCtx bar0_ctx;
+    Hailo8BarCtx bar2_ctx;
+    Hailo8BarCtx bar4_ctx;
+
+    hailo_corpus_t *corpus;
+    uint64_t        seq;    /* monotonic; first op is seq=1 */
+};
+
+OBJECT_DECLARE_SIMPLE_TYPE(Hailo8State, HAILO8)
+
+/* -------------------------------------------------------------------------- */
+/* stdout / stderr line emitters — see docs/hailo-re-corpus-format.md          */
+/* -------------------------------------------------------------------------- */
+
+static void emit_corpus_extend(uint64_t seq, int bar,
+                               uint64_t offset, uint32_t size)
+{
+    fprintf(stdout,
+            "HAILO_RE_CORPUS_EXTEND seq=%" PRIu64
+            " bar=%d offset=%" PRIu64 " size=%u reason=unknown_read\n",
+            seq, bar, offset, size);
+    fflush(stdout);
+}
+
+static void emit_corpus_divergence(uint64_t seq, int bar,
+                                   uint64_t offset, uint32_t size,
+                                   const char *dir,
+                                   uint64_t expected, uint64_t observed,
+                                   const char *reason)
+{
+    char exp_hex[32], obs_hex[32];
+    if (hailo_value_to_hex(expected, size, exp_hex, sizeof(exp_hex)) != 0) {
+        snprintf(exp_hex, sizeof(exp_hex), "??");
+    }
+    if (hailo_value_to_hex(observed, size, obs_hex, sizeof(obs_hex)) != 0) {
+        snprintf(obs_hex, sizeof(obs_hex), "??");
+    }
+    fprintf(stdout,
+            "HAILO_RE_CORPUS_DIVERGENCE seq=%" PRIu64
+            " bar=%d offset=%" PRIu64 " size=%u dir=%s "
+            "expected=%s observed=%s source=qemu reason=%s\n",
+            seq, bar, offset, size, dir, exp_hex, obs_hex, reason);
+    fflush(stdout);
+}
+
+static void emit_msi_fire(uint64_t after_seq, uint32_t vector)
+{
+    /* stderr per the worktree README: MSI events are a separate causal
+     * track and shouldn't interleave with the corpus stdout protocols. */
+    fprintf(stderr,
+            "HAILO_RE_MSI_FIRE after_seq=%" PRIu64 " vector=%u\n",
+            after_seq, vector);
+    fflush(stderr);
+}
+
+/* -------------------------------------------------------------------------- */
+/* BAR R/W callbacks                                                           */
+/* -------------------------------------------------------------------------- */
+
+static const char *bar_dir_str(bool is_write)
+{
+    return is_write ? "write" : "read";
+}
+
+static uint64_t hailo8_bar_read(void *opaque, hwaddr addr, unsigned size)
+{
+    Hailo8BarCtx *ctx = opaque;
+    Hailo8State *s = ctx->s;
+    uint64_t seq = ++s->seq;
+
+    const hailo_op_entry_t *e = hailo_corpus_get(s->corpus, seq);
+    if (!e) {
+        emit_corpus_extend(seq, ctx->bar_index, (uint64_t)addr, size);
+        exit(1);
+    }
+
+    /* Step 0 — op shape mismatch. */
+    if (e->is_write || e->bar != ctx->bar_index ||
+        e->offset != (uint64_t)addr || e->size != size) {
+        uint64_t exp_marker = ((uint64_t)e->bar << 56) | e->offset;
+        uint64_t obs_marker = ((uint64_t)ctx->bar_index << 56) | (uint64_t)addr;
+        emit_corpus_divergence(seq, ctx->bar_index, (uint64_t)addr, size,
+                               bar_dir_str(false),
+                               exp_marker, obs_marker,
+                               "op_shape_mismatch");
+        exit(1);
+    }
+
+    /* Step 1-3 — hit. Fire optional MSI after-return event. */
+    if (e->msi_after_present) {
+        emit_msi_fire(seq, e->msi_after_vector);
+        msi_notify(&s->parent_obj, e->msi_after_vector);
+    }
+    return e->value;
+}
+
+static void hailo8_bar_write(void *opaque, hwaddr addr,
+                             uint64_t data, unsigned size)
+{
+    Hailo8BarCtx *ctx = opaque;
+    Hailo8State *s = ctx->s;
+    uint64_t seq = ++s->seq;
+
+    /* Mask data to access width — QEMU passes the full uint64_t. */
+    uint64_t mask = (size == 8) ? UINT64_MAX : ((1ULL << (size * 8)) - 1);
+    data &= mask;
+
+    const hailo_op_entry_t *e = hailo_corpus_get(s->corpus, seq);
+    if (e) {
+        /* Step 1 of write logging — shape + value check. */
+        if (!e->is_write || e->bar != ctx->bar_index ||
+            e->offset != (uint64_t)addr || e->size != size) {
+            uint64_t exp_marker = ((uint64_t)e->bar << 56) | e->offset;
+            uint64_t obs_marker = ((uint64_t)ctx->bar_index << 56) | (uint64_t)addr;
+            emit_corpus_divergence(seq, ctx->bar_index, (uint64_t)addr, size,
+                                   bar_dir_str(true),
+                                   exp_marker, obs_marker,
+                                   "op_shape_mismatch");
+            exit(1);
+        }
+        if (e->value != data) {
+            emit_corpus_divergence(seq, ctx->bar_index, (uint64_t)addr, size,
+                                   bar_dir_str(true),
+                                   e->value, data,
+                                   "write_value_mismatch");
+            exit(1);
+        }
+        return;
+    }
+
+    /* Step 2 — unknown write. Append to corpus. */
+    char err[256];
+    if (hailo_corpus_append_write(s->corpus, seq, ctx->bar_index,
+                                  (uint64_t)addr, size, data,
+                                  err, sizeof(err)) != 0) {
+        error_report("hailo8: corpus append failed at seq=%" PRIu64
+                     " bar=%d offset=%" PRIu64 ": %s",
+                     seq, ctx->bar_index, (uint64_t)addr, err);
+        exit(1);
+    }
+}
+
+static const MemoryRegionOps hailo8_bar_ops = {
+    .read       = hailo8_bar_read,
+    .write      = hailo8_bar_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .impl  = { .min_access_size = 1, .max_access_size = 8 },
+    .valid = { .min_access_size = 1, .max_access_size = 8 },
+};
+
+/* -------------------------------------------------------------------------- */
+/* Lifecycle                                                                   */
+/* -------------------------------------------------------------------------- */
+
+static void hailo8_realize(PCIDevice *pci_dev, Error **errp)
+{
+    Hailo8State *s = HAILO8(pci_dev);
+    Error *local_err = NULL;
+
+    if (!s->corpus_path || !*s->corpus_path) {
+        error_setg(errp, "hailo8: 'corpus' property is required");
+        return;
+    }
+
+    char err[256];
+    s->corpus = hailo_corpus_load(s->corpus_path,
+                                  /* append_writable = */ true,
+                                  err, sizeof(err));
+    if (!s->corpus) {
+        error_setg(errp, "hailo8: failed to load corpus '%s': %s",
+                   s->corpus_path, err);
+        return;
+    }
+    s->seq = 0;
+
+    /* PCI config: enable bus-master via the kernel driver's enable path;
+     * we only need to advertise the BARs and MSI capability. */
+    pci_config_set_class(pci_dev->config, PCI_CLASS_PROCESSOR_CO);
+    pci_config_set_interrupt_pin(pci_dev->config, 1);
+
+    s->bar0_ctx.s = s;
+    s->bar0_ctx.bar_index = 0;
+    s->bar2_ctx.s = s;
+    s->bar2_ctx.bar_index = 2;
+    s->bar4_ctx.s = s;
+    s->bar4_ctx.bar_index = 4;
+
+    memory_region_init_io(&s->bar0_mr, OBJECT(s), &hailo8_bar_ops,
+                          &s->bar0_ctx, "hailo8.bar0", s->bar0_size);
+    memory_region_init_io(&s->bar2_mr, OBJECT(s), &hailo8_bar_ops,
+                          &s->bar2_ctx, "hailo8.bar2", s->bar2_size);
+    memory_region_init_io(&s->bar4_mr, OBJECT(s), &hailo8_bar_ops,
+                          &s->bar4_ctx, "hailo8.bar4", s->bar4_size);
+
+    /* Hailo-8 BARs are 64-bit memory BARs (BAR0+1, BAR2+3, BAR4+5). */
+    pci_register_bar(pci_dev, 0,
+                     PCI_BASE_ADDRESS_SPACE_MEMORY |
+                     PCI_BASE_ADDRESS_MEM_TYPE_64,
+                     &s->bar0_mr);
+    pci_register_bar(pci_dev, 2,
+                     PCI_BASE_ADDRESS_SPACE_MEMORY |
+                     PCI_BASE_ADDRESS_MEM_TYPE_64,
+                     &s->bar2_mr);
+    pci_register_bar(pci_dev, 4,
+                     PCI_BASE_ADDRESS_SPACE_MEMORY |
+                     PCI_BASE_ADDRESS_MEM_TYPE_64,
+                     &s->bar4_mr);
+
+    int rc = msi_init(pci_dev, /*offset=*/ 0,
+                      HAILO8_MSI_NR_VECTORS,
+                      /*msi64bit=*/ true,
+                      /*msi_per_vector_mask=*/ false,
+                      &local_err);
+    if (rc < 0) {
+        error_propagate(errp, local_err);
+        return;
+    }
+}
+
+static void hailo8_exit(PCIDevice *pci_dev)
+{
+    Hailo8State *s = HAILO8(pci_dev);
+    msi_uninit(pci_dev);
+    hailo_corpus_free(s->corpus);
+    s->corpus = NULL;
+}
+
+static void hailo8_reset(DeviceState *dev)
+{
+    Hailo8State *s = HAILO8(dev);
+    /* On guest-driven reset, do NOT reset the seq counter — the corpus is
+     * keyed on a session-monotonic seq, and HailoRT may reset BARs during
+     * its normal init flow without that meaning "restart the capture". */
+    (void)s;
+}
+
+static Property hailo8_properties[] = {
+    DEFINE_PROP_STRING("corpus", Hailo8State, corpus_path),
+    DEFINE_PROP_UINT64("bar0_size", Hailo8State, bar0_size,
+                       HAILO8_DEFAULT_BAR0_SIZE),
+    DEFINE_PROP_UINT64("bar2_size", Hailo8State, bar2_size,
+                       HAILO8_DEFAULT_BAR2_SIZE),
+    DEFINE_PROP_UINT64("bar4_size", Hailo8State, bar4_size,
+                       HAILO8_DEFAULT_BAR4_SIZE),
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+static const VMStateDescription vmstate_hailo8 = {
+    .name = TYPE_HAILO8,
+    /* The stub is not migratable — corpus + seq counter pin it to its
+     * launch. Provide a stub VMStateDescription so QEMU doesn't crash
+     * if someone tries; failure is loud. */
+    .unmigratable = 1,
+};
+
+static void hailo8_class_init(ObjectClass *klass, void *data)
+{
+    DeviceClass    *dc = DEVICE_CLASS(klass);
+    PCIDeviceClass *k  = PCI_DEVICE_CLASS(klass);
+
+    k->realize   = hailo8_realize;
+    k->exit      = hailo8_exit;
+    k->vendor_id = HAILO8_VENDOR_ID;
+    k->device_id = HAILO8_DEVICE_ID_HAILO8;
+    k->revision  = 0x01;
+    k->class_id  = PCI_CLASS_PROCESSOR_CO;
+
+    dc->desc    = "Hailo-8 NPU RE capture stub";
+    dc->reset   = hailo8_reset;
+    dc->vmsd    = &vmstate_hailo8;
+    dc->user_creatable = true;
+    device_class_set_props(dc, hailo8_properties);
+    set_bit(DEVICE_CATEGORY_MISC, dc->categories);
+}
+
+static const TypeInfo hailo8_info = {
+    .name          = TYPE_HAILO8,
+    .parent        = TYPE_PCI_DEVICE,
+    .instance_size = sizeof(Hailo8State),
+    .class_init    = hailo8_class_init,
+    .interfaces    = (InterfaceInfo[]) {
+        { INTERFACE_CONVENTIONAL_PCI_DEVICE },
+        { },
+    },
+};
+
+static void hailo8_register_types(void)
+{
+    type_register_static(&hailo8_info);
+}
+
+type_init(hailo8_register_types)

--- a/host-tools/qemu-hailo8-stub/src/hailo8.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8.c
@@ -84,11 +84,13 @@ static void emit_corpus_extend(uint64_t seq, int bar,
     fflush(stdout);
 }
 
-static void emit_corpus_divergence(uint64_t seq, int bar,
-                                   uint64_t offset, uint32_t size,
-                                   const char *dir,
-                                   uint64_t expected, uint64_t observed,
-                                   const char *reason)
+/* Emit a value-divergence line (reason = write_value_mismatch /
+ * inline_read_mismatch — the value fields carry the actual divergence). */
+static void emit_corpus_divergence_value(uint64_t seq, int bar,
+                                         uint64_t offset, uint32_t size,
+                                         const char *dir,
+                                         uint64_t expected, uint64_t observed,
+                                         const char *reason)
 {
     char exp_hex[32], obs_hex[32];
     if (hailo_value_to_hex(expected, size, exp_hex, sizeof(exp_hex)) != 0) {
@@ -102,6 +104,34 @@ static void emit_corpus_divergence(uint64_t seq, int bar,
             " bar=%d offset=%" PRIu64 " size=%u dir=%s "
             "expected=%s observed=%s source=qemu reason=%s\n",
             seq, bar, offset, size, dir, exp_hex, obs_hex, reason);
+    fflush(stdout);
+}
+
+/* Emit a shape-divergence line (reason = op_shape_mismatch — bar / offset /
+ * size / dir don't match the corpus entry at this seq). The value fields
+ * aren't the divergence axis here; emit zero-filled placeholders at the
+ * spec-required width, then append explicit expected_* tokens so the
+ * Task 0.5 driver script can recover the corpus-side shape without a
+ * round-trip back through the corpus file. */
+static void emit_corpus_divergence_shape(uint64_t seq,
+                                         int obs_bar, uint64_t obs_offset,
+                                         uint32_t obs_size, const char *obs_dir,
+                                         int exp_bar, uint64_t exp_offset,
+                                         uint32_t exp_size, const char *exp_dir)
+{
+    char zero_hex[32];
+    if (hailo_value_to_hex(0, obs_size, zero_hex, sizeof(zero_hex)) != 0) {
+        snprintf(zero_hex, sizeof(zero_hex), "00000000");
+    }
+    fprintf(stdout,
+            "HAILO_RE_CORPUS_DIVERGENCE seq=%" PRIu64
+            " bar=%d offset=%" PRIu64 " size=%u dir=%s "
+            "expected=%s observed=%s source=qemu reason=op_shape_mismatch "
+            "expected_bar=%d expected_offset=%" PRIu64
+            " expected_size=%u expected_dir=%s\n",
+            seq, obs_bar, obs_offset, obs_size, obs_dir,
+            zero_hex, zero_hex,
+            exp_bar, exp_offset, exp_size, exp_dir);
     fflush(stdout);
 }
 
@@ -139,12 +169,11 @@ static uint64_t hailo8_bar_read(void *opaque, hwaddr addr, unsigned size)
     /* Step 0 — op shape mismatch. */
     if (e->is_write || e->bar != ctx->bar_index ||
         e->offset != (uint64_t)addr || e->size != size) {
-        uint64_t exp_marker = ((uint64_t)e->bar << 56) | e->offset;
-        uint64_t obs_marker = ((uint64_t)ctx->bar_index << 56) | (uint64_t)addr;
-        emit_corpus_divergence(seq, ctx->bar_index, (uint64_t)addr, size,
-                               bar_dir_str(false),
-                               exp_marker, obs_marker,
-                               "op_shape_mismatch");
+        emit_corpus_divergence_shape(seq,
+                                     ctx->bar_index, (uint64_t)addr,
+                                     size, bar_dir_str(false),
+                                     e->bar, e->offset,
+                                     e->size, bar_dir_str(e->is_write));
         exit(1);
     }
 
@@ -172,19 +201,18 @@ static void hailo8_bar_write(void *opaque, hwaddr addr,
         /* Step 1 of write logging — shape + value check. */
         if (!e->is_write || e->bar != ctx->bar_index ||
             e->offset != (uint64_t)addr || e->size != size) {
-            uint64_t exp_marker = ((uint64_t)e->bar << 56) | e->offset;
-            uint64_t obs_marker = ((uint64_t)ctx->bar_index << 56) | (uint64_t)addr;
-            emit_corpus_divergence(seq, ctx->bar_index, (uint64_t)addr, size,
-                                   bar_dir_str(true),
-                                   exp_marker, obs_marker,
-                                   "op_shape_mismatch");
+            emit_corpus_divergence_shape(seq,
+                                         ctx->bar_index, (uint64_t)addr,
+                                         size, bar_dir_str(true),
+                                         e->bar, e->offset,
+                                         e->size, bar_dir_str(e->is_write));
             exit(1);
         }
         if (e->value != data) {
-            emit_corpus_divergence(seq, ctx->bar_index, (uint64_t)addr, size,
-                                   bar_dir_str(true),
-                                   e->value, data,
-                                   "write_value_mismatch");
+            emit_corpus_divergence_value(seq, ctx->bar_index, (uint64_t)addr,
+                                         size, bar_dir_str(true),
+                                         e->value, data,
+                                         "write_value_mismatch");
             exit(1);
         }
         return;
@@ -214,6 +242,11 @@ static const MemoryRegionOps hailo8_bar_ops = {
 /* Lifecycle                                                                   */
 /* -------------------------------------------------------------------------- */
 
+static bool bar_size_is_pow2(uint64_t v)
+{
+    return v != 0 && (v & (v - 1)) == 0;
+}
+
 static void hailo8_realize(PCIDevice *pci_dev, Error **errp)
 {
     Hailo8State *s = HAILO8(pci_dev);
@@ -221,6 +254,24 @@ static void hailo8_realize(PCIDevice *pci_dev, Error **errp)
 
     if (!s->corpus_path || !*s->corpus_path) {
         error_setg(errp, "hailo8: 'corpus' property is required");
+        return;
+    }
+
+    /* PCI BARs require power-of-2 sizes; reject early with a clear
+     * message rather than letting QEMU's memory subsystem complain later. */
+    if (!bar_size_is_pow2(s->bar0_size)) {
+        error_setg(errp, "hailo8: bar0_size must be a non-zero power of 2 "
+                         "(got 0x%" PRIx64 ")", s->bar0_size);
+        return;
+    }
+    if (!bar_size_is_pow2(s->bar2_size)) {
+        error_setg(errp, "hailo8: bar2_size must be a non-zero power of 2 "
+                         "(got 0x%" PRIx64 ")", s->bar2_size);
+        return;
+    }
+    if (!bar_size_is_pow2(s->bar4_size)) {
+        error_setg(errp, "hailo8: bar4_size must be a non-zero power of 2 "
+                         "(got 0x%" PRIx64 ")", s->bar4_size);
         return;
     }
 
@@ -289,11 +340,10 @@ static void hailo8_exit(PCIDevice *pci_dev)
 
 static void hailo8_reset(DeviceState *dev)
 {
-    Hailo8State *s = HAILO8(dev);
+    (void)dev;
     /* On guest-driven reset, do NOT reset the seq counter — the corpus is
      * keyed on a session-monotonic seq, and HailoRT may reset BARs during
      * its normal init flow without that meaning "restart the capture". */
-    (void)s;
 }
 
 static Property hailo8_properties[] = {

--- a/host-tools/qemu-hailo8-stub/src/hailo8.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8.c
@@ -325,6 +325,11 @@ static void hailo8_realize(PCIDevice *pci_dev, Error **errp)
                       /*msi_per_vector_mask=*/ false,
                       &local_err);
     if (rc < 0) {
+        /* QEMU does not call .exit on a failed realize, so the corpus
+         * append handle would leak across repeated `device_add` attempts
+         * from the monitor. Tear it down explicitly here. */
+        hailo_corpus_free(s->corpus);
+        s->corpus = NULL;
         error_propagate(errp, local_err);
         return;
     }

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
@@ -149,15 +149,19 @@ static int parse_key(json_cursor_t *c, char *out, size_t outlen)
     return 0;
 }
 
-/* parse_value: returns 0 on success. Fills exactly one of (str_out, int_out,
- * is_null). If is_null is non-NULL and value is `null`, sets *is_null=1.
- * Strings come back with simple escape handling for \" and \\. */
+/* parse_value: returns 0 on success consuming a JSON scalar from `c`.
+ * Sets *is_str / *is_int when the value is a string / integer (callers
+ * dispatch on these). Tokens `null`, `true`, `false` parse successfully
+ * but neither flag is set — callers naturally skip the field, which is
+ * the correct behavior since the corpus schema treats `null` for
+ * `validated_at_commit` etc. as "absent". Strings come back with
+ * simple escape handling for \" \\ \n \t. */
 static int parse_value(json_cursor_t *c,
                        char *str_out, size_t str_outlen,
                        int64_t *int_out,
-                       int *is_str, int *is_int, int *is_null, int *is_bool, int *bool_val)
+                       int *is_str, int *is_int)
 {
-    *is_str = *is_int = *is_null = *is_bool = 0;
+    *is_str = *is_int = 0;
     skip_ws(c);
     if (c->p >= c->end) return -1;
 
@@ -200,19 +204,14 @@ static int parse_value(json_cursor_t *c,
 
     if (c->end - c->p >= 4 && memcmp(c->p, "null", 4) == 0) {
         c->p += 4;
-        *is_null = 1;
         return 0;
     }
     if (c->end - c->p >= 4 && memcmp(c->p, "true", 4) == 0) {
         c->p += 4;
-        *is_bool = 1;
-        if (bool_val) *bool_val = 1;
         return 0;
     }
     if (c->end - c->p >= 5 && memcmp(c->p, "false", 5) == 0) {
         c->p += 5;
-        *is_bool = 1;
-        if (bool_val) *bool_val = 0;
         return 0;
     }
 
@@ -359,15 +358,14 @@ static int parse_op_line(const char *line, size_t linelen,
 
         char strbuf[512];
         int64_t intval = 0;
-        int is_str = 0, is_int = 0, is_null = 0, is_bool = 0, bool_val = 0;
+        int is_str = 0, is_int = 0;
         if (parse_value(&cur, strbuf, sizeof(strbuf),
-                        &intval, &is_str, &is_int, &is_null, &is_bool, &bool_val) != 0) {
+                        &intval, &is_str, &is_int) != 0) {
             set_err(errbuf, errlen, "bad value for key '%s'", key);
             return -1;
         }
 
         if (strcmp(key, "type") == 0 && is_str) {
-            copy_str(op->entry.source, sizeof(op->entry.source), "");
             if (strcmp(strbuf, "op") != 0) {
                 set_err(errbuf, errlen, "expected type='op', got '%s'", strbuf);
                 return -1;
@@ -485,9 +483,9 @@ static int parse_header_line(hailo_corpus_t *c,
 
         char strbuf[256];
         int64_t intval = 0;
-        int is_str = 0, is_int = 0, is_null = 0, is_bool = 0, bool_val = 0;
+        int is_str = 0, is_int = 0;
         if (parse_value(&cur, strbuf, sizeof(strbuf),
-                        &intval, &is_str, &is_int, &is_null, &is_bool, &bool_val) != 0) {
+                        &intval, &is_str, &is_int) != 0) {
             set_err(errbuf, errlen, "bad header value for '%s'", key);
             return -1;
         }

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
@@ -82,14 +82,24 @@ int hailo_value_from_hex(const char *hex, uint32_t size, uint64_t *out)
         int hi, lo;
         char ch_hi = hex[i * 2 + 0];
         char ch_lo = hex[i * 2 + 1];
-        if (ch_hi >= '0' && ch_hi <= '9') hi = ch_hi - '0';
-        else if (ch_hi >= 'a' && ch_hi <= 'f') hi = 10 + (ch_hi - 'a');
-        else if (ch_hi >= 'A' && ch_hi <= 'F') hi = 10 + (ch_hi - 'A');
-        else return -1;
-        if (ch_lo >= '0' && ch_lo <= '9') lo = ch_lo - '0';
-        else if (ch_lo >= 'a' && ch_lo <= 'f') lo = 10 + (ch_lo - 'a');
-        else if (ch_lo >= 'A' && ch_lo <= 'F') lo = 10 + (ch_lo - 'A');
-        else return -1;
+        if (ch_hi >= '0' && ch_hi <= '9') {
+            hi = ch_hi - '0';
+        } else if (ch_hi >= 'a' && ch_hi <= 'f') {
+            hi = 10 + (ch_hi - 'a');
+        } else if (ch_hi >= 'A' && ch_hi <= 'F') {
+            hi = 10 + (ch_hi - 'A');
+        } else {
+            return -1;
+        }
+        if (ch_lo >= '0' && ch_lo <= '9') {
+            lo = ch_lo - '0';
+        } else if (ch_lo >= 'a' && ch_lo <= 'f') {
+            lo = 10 + (ch_lo - 'a');
+        } else if (ch_lo >= 'A' && ch_lo <= 'F') {
+            lo = 10 + (ch_lo - 'A');
+        } else {
+            return -1;
+        }
         v |= ((uint64_t)((hi << 4) | lo)) << (i * 8);
     }
     *out = v;
@@ -158,22 +168,32 @@ static int parse_value(json_cursor_t *c,
             char ch = *c->p++;
             if (ch == '\\' && c->p < c->end) {
                 char esc = *c->p++;
-                if (esc == '"') ch = '"';
-                else if (esc == '\\') ch = '\\';
-                else if (esc == 'n') ch = '\n';
-                else if (esc == 't') ch = '\t';
-                else ch = esc;
+                if (esc == '"') {
+                    ch = '"';
+                } else if (esc == '\\') {
+                    ch = '\\';
+                } else if (esc == 'n') {
+                    ch = '\n';
+                } else if (esc == 't') {
+                    ch = '\t';
+                } else {
+                    ch = esc;
+                }
             }
+            /* Always advance via the loop's c->p++ above; only store into
+             * str_out when there's room. Strings beyond outlen are silently
+             * truncated — `note` fields can be arbitrarily long. */
             if (str_out && i + 1 < str_outlen) {
                 str_out[i++] = ch;
-            } else if (str_out) {
-                /* truncate quietly; long strings come from `note` fields */
             }
-            if (!str_out && i == 0) i++;     /* still consume */
         }
-        if (c->p >= c->end) return -1;
+        if (c->p >= c->end) {
+            return -1;
+        }
         c->p++;
-        if (str_out) str_out[i < str_outlen ? i : str_outlen - 1] = '\0';
+        if (str_out) {
+            str_out[i < str_outlen ? i : str_outlen - 1] = '\0';
+        }
         *is_str = 1;
         return 0;
     }
@@ -202,14 +222,26 @@ static int parse_value(json_cursor_t *c,
         neg = 1;
         c->p++;
     }
-    if (c->p >= c->end || !isdigit((unsigned char)*c->p)) return -1;
+    if (c->p >= c->end || !isdigit((unsigned char)*c->p)) {
+        return -1;
+    }
     int64_t v = 0;
     while (c->p < c->end && isdigit((unsigned char)*c->p)) {
-        v = v * 10 + (*c->p - '0');
+        int d = *c->p - '0';
+        /* Guard against int64 overflow (signed overflow is UB). 20-digit
+         * literals like 99999999999999999999 would otherwise wrap silently. */
+        if (v > (INT64_MAX - d) / 10) {
+            return -1;
+        }
+        v = v * 10 + d;
         c->p++;
     }
-    if (neg) v = -v;
-    if (int_out) *int_out = v;
+    if (neg) {
+        v = -v;
+    }
+    if (int_out) {
+        *int_out = v;
+    }
     *is_int = 1;
     return 0;
 }
@@ -240,8 +272,11 @@ static int ensure_seq_index(hailo_corpus_t *c, uint64_t seq)
 static int push_entry(hailo_corpus_t *c, const hailo_op_entry_t *e,
                       char *errbuf, size_t errlen)
 {
-    if (e->seq == 0) {
-        set_err(errbuf, errlen, "seq must be >= 1");
+    if (e->seq == 0 || e->seq >= HAILO_CORPUS_MAX_SEQ) {
+        set_err(errbuf, errlen,
+                "seq must be in [1, %u), got %llu",
+                HAILO_CORPUS_MAX_SEQ,
+                (unsigned long long)e->seq);
         return -1;
     }
     if (ensure_seq_index(c, e->seq) != 0) {
@@ -480,32 +515,44 @@ static int parse_header_line(hailo_corpus_t *c,
     return 0;
 }
 
-/* Detect the `type` field of a line — header / op / trailer / other. */
-static const char *line_type_field(const char *line, size_t linelen)
+/* Detect the `type` field of a line — header / op / trailer / other.
+ * Writes the value into the caller's buffer (null-terminated) and returns
+ * 0 on success. Returns -1 when no `"type": "..."` pair is present. The
+ * caller buffer is preferred over a static internal one so future
+ * call sites that retain two type strings concurrently don't trip on
+ * mutated state. */
+static int line_type_field(const char *line, size_t linelen,
+                           char *out, size_t outlen)
 {
-    /* Cheap pre-scan; we accept anywhere `"type"` appears followed by a
-     * string value. */
-    static char buf[16];
+    if (!out || outlen == 0) {
+        return -1;
+    }
+    out[0] = '\0';
     const char *p = line;
     const char *end = line + linelen;
-    while (p < end - 6) {
+    /* `p + 6 <= end` avoids the `end - 6` pointer-underflow case when
+     * `linelen < 6` (pointer arithmetic that lands outside the array's
+     * one-past-the-end region is implementation-defined per C11 6.5.6). */
+    while (p + 6 <= end) {
         if (*p == '"' && memcmp(p, "\"type\"", 6) == 0) {
             p += 6;
-            while (p < end && (*p == ' ' || *p == ':' || *p == '\t')) p++;
+            while (p < end && (*p == ' ' || *p == ':' || *p == '\t')) {
+                p++;
+            }
             if (p < end && *p == '"') {
                 p++;
                 size_t i = 0;
-                while (p < end && *p != '"' && i + 1 < sizeof(buf)) {
-                    buf[i++] = *p++;
+                while (p < end && *p != '"' && i + 1 < outlen) {
+                    out[i++] = *p++;
                 }
-                buf[i] = '\0';
-                return buf;
+                out[i] = '\0';
+                return 0;
             }
-            return NULL;
+            return -1;
         }
         p++;
     }
-    return NULL;
+    return -1;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -566,8 +613,8 @@ hailo_corpus_t *hailo_corpus_load(const char *path,
         if (len == 0) continue;
         if (line[0] == '#') continue;   /* tolerate hand-edited comments */
 
-        const char *type = line_type_field(line, len);
-        if (!type) {
+        char type[16];
+        if (line_type_field(line, len, type, sizeof(type)) != 0) {
             set_err(errbuf, errlen, "line %d: no 'type' field", lineno);
             goto fail;
         }

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
@@ -1,0 +1,678 @@
+/*
+ * Hailo RE corpus parser/index. See hailo8_corpus.h for the API contract.
+ *
+ * Parser scope is intentionally narrow: each line is a flat JSON object —
+ * no nesting, no arrays, no escapes beyond \" and \\. The on-disk schema
+ * in docs/hailo-re-corpus-format.md never produces anything richer, so a
+ * 300-line hand-rolled state machine beats pulling in a JSON dependency
+ * for both the standalone test binary and the in-QEMU build.
+ */
+
+#include "hailo8_corpus.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                     */
+/* -------------------------------------------------------------------------- */
+
+static void set_err(char *errbuf, size_t errlen, const char *fmt, ...)
+    __attribute__((format(printf, 3, 4)));
+static void set_err(char *errbuf, size_t errlen, const char *fmt, ...)
+{
+    if (!errbuf || errlen == 0) {
+        return;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(errbuf, errlen, fmt, ap);
+    va_end(ap);
+}
+
+static void copy_str(char *dst, size_t dstlen, const char *src)
+{
+    if (!src) {
+        dst[0] = '\0';
+        return;
+    }
+    size_t n = strlen(src);
+    if (n >= dstlen) {
+        n = dstlen - 1;
+    }
+    memcpy(dst, src, n);
+    dst[n] = '\0';
+}
+
+int hailo_value_to_hex(uint64_t value, uint32_t size, char *out, size_t outlen)
+{
+    if (size != 1 && size != 2 && size != 4 && size != 8) {
+        return -1;
+    }
+    if (outlen < (size_t)size * 2 + 1) {
+        return -1;
+    }
+    static const char hex_digits[] = "0123456789abcdef";
+    for (uint32_t i = 0; i < size; i++) {
+        uint8_t b = (uint8_t)((value >> (i * 8)) & 0xFF);
+        out[i * 2 + 0] = hex_digits[(b >> 4) & 0xF];
+        out[i * 2 + 1] = hex_digits[b & 0xF];
+    }
+    out[size * 2] = '\0';
+    return 0;
+}
+
+int hailo_value_from_hex(const char *hex, uint32_t size, uint64_t *out)
+{
+    if (!hex || !out) {
+        return -1;
+    }
+    if (size != 1 && size != 2 && size != 4 && size != 8) {
+        return -1;
+    }
+    size_t expect = (size_t)size * 2;
+    if (strlen(hex) != expect) {
+        return -1;
+    }
+    uint64_t v = 0;
+    for (uint32_t i = 0; i < size; i++) {
+        int hi, lo;
+        char ch_hi = hex[i * 2 + 0];
+        char ch_lo = hex[i * 2 + 1];
+        if (ch_hi >= '0' && ch_hi <= '9') hi = ch_hi - '0';
+        else if (ch_hi >= 'a' && ch_hi <= 'f') hi = 10 + (ch_hi - 'a');
+        else if (ch_hi >= 'A' && ch_hi <= 'F') hi = 10 + (ch_hi - 'A');
+        else return -1;
+        if (ch_lo >= '0' && ch_lo <= '9') lo = ch_lo - '0';
+        else if (ch_lo >= 'a' && ch_lo <= 'f') lo = 10 + (ch_lo - 'a');
+        else if (ch_lo >= 'A' && ch_lo <= 'F') lo = 10 + (ch_lo - 'A');
+        else return -1;
+        v |= ((uint64_t)((hi << 4) | lo)) << (i * 8);
+    }
+    *out = v;
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Flat-JSON line parser                                                       */
+/*                                                                             */
+/* Grammar accepted (each line independently):                                 */
+/*   line   := '{' WS pair (WS ',' WS pair)* WS '}' WS                         */
+/*   pair   := '"' key '"' WS ':' WS value                                     */
+/*   value  := number | string | 'null' | 'true' | 'false'                     */
+/*   number := optional '-' followed by digits                                 */
+/*   string := '"' chars '"'  (only \" and \\ escapes recognized)              */
+/* -------------------------------------------------------------------------- */
+
+typedef struct {
+    const char *p;
+    const char *end;
+} json_cursor_t;
+
+static void skip_ws(json_cursor_t *c)
+{
+    while (c->p < c->end &&
+           (*c->p == ' ' || *c->p == '\t' || *c->p == '\r' || *c->p == '\n')) {
+        c->p++;
+    }
+}
+
+static int parse_key(json_cursor_t *c, char *out, size_t outlen)
+{
+    skip_ws(c);
+    if (c->p >= c->end || *c->p != '"') return -1;
+    c->p++;
+    size_t i = 0;
+    while (c->p < c->end && *c->p != '"') {
+        if (*c->p == '\\' && c->p + 1 < c->end) {
+            c->p++;
+        }
+        if (i + 1 >= outlen) return -1;
+        out[i++] = *c->p++;
+    }
+    if (c->p >= c->end) return -1;
+    c->p++;
+    out[i] = '\0';
+    return 0;
+}
+
+/* parse_value: returns 0 on success. Fills exactly one of (str_out, int_out,
+ * is_null). If is_null is non-NULL and value is `null`, sets *is_null=1.
+ * Strings come back with simple escape handling for \" and \\. */
+static int parse_value(json_cursor_t *c,
+                       char *str_out, size_t str_outlen,
+                       int64_t *int_out,
+                       int *is_str, int *is_int, int *is_null, int *is_bool, int *bool_val)
+{
+    *is_str = *is_int = *is_null = *is_bool = 0;
+    skip_ws(c);
+    if (c->p >= c->end) return -1;
+
+    if (*c->p == '"') {
+        c->p++;
+        size_t i = 0;
+        while (c->p < c->end && *c->p != '"') {
+            char ch = *c->p++;
+            if (ch == '\\' && c->p < c->end) {
+                char esc = *c->p++;
+                if (esc == '"') ch = '"';
+                else if (esc == '\\') ch = '\\';
+                else if (esc == 'n') ch = '\n';
+                else if (esc == 't') ch = '\t';
+                else ch = esc;
+            }
+            if (str_out && i + 1 < str_outlen) {
+                str_out[i++] = ch;
+            } else if (str_out) {
+                /* truncate quietly; long strings come from `note` fields */
+            }
+            if (!str_out && i == 0) i++;     /* still consume */
+        }
+        if (c->p >= c->end) return -1;
+        c->p++;
+        if (str_out) str_out[i < str_outlen ? i : str_outlen - 1] = '\0';
+        *is_str = 1;
+        return 0;
+    }
+
+    if (c->end - c->p >= 4 && memcmp(c->p, "null", 4) == 0) {
+        c->p += 4;
+        *is_null = 1;
+        return 0;
+    }
+    if (c->end - c->p >= 4 && memcmp(c->p, "true", 4) == 0) {
+        c->p += 4;
+        *is_bool = 1;
+        if (bool_val) *bool_val = 1;
+        return 0;
+    }
+    if (c->end - c->p >= 5 && memcmp(c->p, "false", 5) == 0) {
+        c->p += 5;
+        *is_bool = 1;
+        if (bool_val) *bool_val = 0;
+        return 0;
+    }
+
+    /* Number (signed integer; the spec never uses floats). */
+    int neg = 0;
+    if (*c->p == '-') {
+        neg = 1;
+        c->p++;
+    }
+    if (c->p >= c->end || !isdigit((unsigned char)*c->p)) return -1;
+    int64_t v = 0;
+    while (c->p < c->end && isdigit((unsigned char)*c->p)) {
+        v = v * 10 + (*c->p - '0');
+        c->p++;
+    }
+    if (neg) v = -v;
+    if (int_out) *int_out = v;
+    *is_int = 1;
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Index management                                                            */
+/* -------------------------------------------------------------------------- */
+
+static int ensure_seq_index(hailo_corpus_t *c, uint64_t seq)
+{
+    if (seq < c->seq_index_cap) {
+        return 0;
+    }
+    size_t new_cap = c->seq_index_cap ? c->seq_index_cap : 64;
+    while (new_cap <= seq) {
+        new_cap *= 2;
+    }
+    int32_t *ni = realloc(c->seq_index, new_cap * sizeof(int32_t));
+    if (!ni) return -1;
+    for (size_t i = c->seq_index_cap; i < new_cap; i++) {
+        ni[i] = -1;
+    }
+    c->seq_index = ni;
+    c->seq_index_cap = new_cap;
+    return 0;
+}
+
+static int push_entry(hailo_corpus_t *c, const hailo_op_entry_t *e,
+                      char *errbuf, size_t errlen)
+{
+    if (e->seq == 0) {
+        set_err(errbuf, errlen, "seq must be >= 1");
+        return -1;
+    }
+    if (ensure_seq_index(c, e->seq) != 0) {
+        set_err(errbuf, errlen, "out of memory growing seq index");
+        return -1;
+    }
+    if (c->seq_index[e->seq] != -1) {
+        set_err(errbuf, errlen,
+                "duplicate entry at seq=%llu",
+                (unsigned long long)e->seq);
+        return -1;
+    }
+    if (c->n_entries == c->cap_entries) {
+        size_t new_cap = c->cap_entries ? c->cap_entries * 2 : 64;
+        hailo_op_entry_t *ne = realloc(c->entries,
+                                       new_cap * sizeof(hailo_op_entry_t));
+        if (!ne) {
+            set_err(errbuf, errlen, "out of memory growing entries");
+            return -1;
+        }
+        c->entries = ne;
+        c->cap_entries = new_cap;
+    }
+    c->entries[c->n_entries] = *e;
+    c->seq_index[e->seq] = (int32_t)c->n_entries;
+    c->n_entries++;
+    if (e->seq > c->max_seq) {
+        c->max_seq = e->seq;
+    }
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Line parsers (header, op, trailer)                                          */
+/* -------------------------------------------------------------------------- */
+
+typedef struct {
+    /* op-line fields populated during parsing */
+    hailo_op_entry_t entry;
+    int has_seq, has_bar, has_offset, has_size, has_dir, has_value;
+    char dir_str[16];
+    char value_hex[32];
+} op_parse_t;
+
+static int parse_op_line(const char *line, size_t linelen,
+                         op_parse_t *op,
+                         char *errbuf, size_t errlen)
+{
+    memset(op, 0, sizeof(*op));
+    json_cursor_t cur = { .p = line, .end = line + linelen };
+    skip_ws(&cur);
+    if (cur.p >= cur.end || *cur.p != '{') {
+        set_err(errbuf, errlen, "line does not start with '{'");
+        return -1;
+    }
+    cur.p++;
+
+    while (1) {
+        skip_ws(&cur);
+        if (cur.p >= cur.end) {
+            set_err(errbuf, errlen, "truncated object");
+            return -1;
+        }
+        if (*cur.p == '}') {
+            cur.p++;
+            break;
+        }
+
+        char key[64];
+        if (parse_key(&cur, key, sizeof(key)) != 0) {
+            set_err(errbuf, errlen, "bad key");
+            return -1;
+        }
+        skip_ws(&cur);
+        if (cur.p >= cur.end || *cur.p != ':') {
+            set_err(errbuf, errlen, "missing ':' after key '%s'", key);
+            return -1;
+        }
+        cur.p++;
+
+        char strbuf[512];
+        int64_t intval = 0;
+        int is_str = 0, is_int = 0, is_null = 0, is_bool = 0, bool_val = 0;
+        if (parse_value(&cur, strbuf, sizeof(strbuf),
+                        &intval, &is_str, &is_int, &is_null, &is_bool, &bool_val) != 0) {
+            set_err(errbuf, errlen, "bad value for key '%s'", key);
+            return -1;
+        }
+
+        if (strcmp(key, "type") == 0 && is_str) {
+            copy_str(op->entry.source, sizeof(op->entry.source), "");
+            if (strcmp(strbuf, "op") != 0) {
+                set_err(errbuf, errlen, "expected type='op', got '%s'", strbuf);
+                return -1;
+            }
+        } else if (strcmp(key, "seq") == 0 && is_int) {
+            op->entry.seq = (uint64_t)intval;
+            op->has_seq = 1;
+        } else if (strcmp(key, "bar") == 0 && is_int) {
+            op->entry.bar = (int)intval;
+            op->has_bar = 1;
+        } else if (strcmp(key, "offset") == 0 && is_int) {
+            op->entry.offset = (uint64_t)intval;
+            op->has_offset = 1;
+        } else if (strcmp(key, "size") == 0 && is_int) {
+            op->entry.size = (uint32_t)intval;
+            op->has_size = 1;
+        } else if (strcmp(key, "dir") == 0 && is_str) {
+            copy_str(op->dir_str, sizeof(op->dir_str), strbuf);
+            op->has_dir = 1;
+        } else if (strcmp(key, "value") == 0 && is_str) {
+            copy_str(op->value_hex, sizeof(op->value_hex), strbuf);
+            op->has_value = 1;
+        } else if (strcmp(key, "source") == 0 && is_str) {
+            copy_str(op->entry.source, sizeof(op->entry.source), strbuf);
+        } else if (strcmp(key, "validated_at_commit") == 0) {
+            if (is_str) {
+                copy_str(op->entry.validated_at_commit,
+                         sizeof(op->entry.validated_at_commit), strbuf);
+            }
+        } else if (strcmp(key, "validated_at") == 0) {
+            if (is_str) {
+                copy_str(op->entry.validated_at,
+                         sizeof(op->entry.validated_at), strbuf);
+            }
+        } else if (strcmp(key, "note") == 0 && is_str) {
+            copy_str(op->entry.note, sizeof(op->entry.note), strbuf);
+        } else if (strcmp(key, "msi_after") == 0 && is_int) {
+            op->entry.msi_after_present = true;
+            op->entry.msi_after_vector = (uint32_t)intval;
+        }
+        /* unknown keys silently tolerated per spec §Provenance */
+
+        skip_ws(&cur);
+        if (cur.p < cur.end && *cur.p == ',') {
+            cur.p++;
+            continue;
+        }
+        skip_ws(&cur);
+        if (cur.p < cur.end && *cur.p == '}') {
+            cur.p++;
+            break;
+        }
+    }
+
+    if (!op->has_seq || !op->has_bar || !op->has_offset ||
+        !op->has_size || !op->has_dir || !op->has_value) {
+        set_err(errbuf, errlen, "op line missing required field "
+                "(seq/bar/offset/size/dir/value)");
+        return -1;
+    }
+
+    if (strcmp(op->dir_str, "read") == 0) {
+        op->entry.is_write = false;
+    } else if (strcmp(op->dir_str, "write") == 0) {
+        op->entry.is_write = true;
+    } else {
+        set_err(errbuf, errlen, "bad dir '%s'", op->dir_str);
+        return -1;
+    }
+
+    if (hailo_value_from_hex(op->value_hex, op->entry.size,
+                             &op->entry.value) != 0) {
+        set_err(errbuf, errlen, "bad value hex '%s' for size=%u",
+                op->value_hex, op->entry.size);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int parse_header_line(hailo_corpus_t *c,
+                             const char *line, size_t linelen,
+                             char *errbuf, size_t errlen)
+{
+    json_cursor_t cur = { .p = line, .end = line + linelen };
+    skip_ws(&cur);
+    if (cur.p >= cur.end || *cur.p != '{') {
+        set_err(errbuf, errlen, "header line not an object");
+        return -1;
+    }
+    cur.p++;
+
+    while (1) {
+        skip_ws(&cur);
+        if (cur.p >= cur.end) {
+            set_err(errbuf, errlen, "truncated header");
+            return -1;
+        }
+        if (*cur.p == '}') {
+            cur.p++;
+            break;
+        }
+
+        char key[64];
+        if (parse_key(&cur, key, sizeof(key)) != 0) {
+            set_err(errbuf, errlen, "bad header key");
+            return -1;
+        }
+        skip_ws(&cur);
+        if (cur.p >= cur.end || *cur.p != ':') {
+            set_err(errbuf, errlen, "missing ':' in header for '%s'", key);
+            return -1;
+        }
+        cur.p++;
+
+        char strbuf[256];
+        int64_t intval = 0;
+        int is_str = 0, is_int = 0, is_null = 0, is_bool = 0, bool_val = 0;
+        if (parse_value(&cur, strbuf, sizeof(strbuf),
+                        &intval, &is_str, &is_int, &is_null, &is_bool, &bool_val) != 0) {
+            set_err(errbuf, errlen, "bad header value for '%s'", key);
+            return -1;
+        }
+        if (strcmp(key, "format_version") == 0 && is_int) {
+            c->format_version = (int)intval;
+        } else if (strcmp(key, "hailort_version") == 0 && is_str) {
+            copy_str(c->hailort_version, sizeof(c->hailort_version), strbuf);
+        } else if (strcmp(key, "fw_version") == 0 && is_str) {
+            copy_str(c->fw_version, sizeof(c->fw_version), strbuf);
+        } else if (strcmp(key, "capture_host") == 0 && is_str) {
+            copy_str(c->capture_host, sizeof(c->capture_host), strbuf);
+        }
+
+        skip_ws(&cur);
+        if (cur.p < cur.end && *cur.p == ',') {
+            cur.p++;
+            continue;
+        }
+        skip_ws(&cur);
+        if (cur.p < cur.end && *cur.p == '}') {
+            cur.p++;
+            break;
+        }
+    }
+    return 0;
+}
+
+/* Detect the `type` field of a line — header / op / trailer / other. */
+static const char *line_type_field(const char *line, size_t linelen)
+{
+    /* Cheap pre-scan; we accept anywhere `"type"` appears followed by a
+     * string value. */
+    static char buf[16];
+    const char *p = line;
+    const char *end = line + linelen;
+    while (p < end - 6) {
+        if (*p == '"' && memcmp(p, "\"type\"", 6) == 0) {
+            p += 6;
+            while (p < end && (*p == ' ' || *p == ':' || *p == '\t')) p++;
+            if (p < end && *p == '"') {
+                p++;
+                size_t i = 0;
+                while (p < end && *p != '"' && i + 1 < sizeof(buf)) {
+                    buf[i++] = *p++;
+                }
+                buf[i] = '\0';
+                return buf;
+            }
+            return NULL;
+        }
+        p++;
+    }
+    return NULL;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                  */
+/* -------------------------------------------------------------------------- */
+
+hailo_corpus_t *hailo_corpus_new_memory(void)
+{
+    hailo_corpus_t *c = calloc(1, sizeof(*c));
+    if (!c) return NULL;
+    c->format_version = 1;
+    return c;
+}
+
+void hailo_corpus_free(hailo_corpus_t *c)
+{
+    if (!c) return;
+    if (c->append_fp) {
+        fclose(c->append_fp);
+    }
+    free(c->entries);
+    free(c->seq_index);
+    free(c);
+}
+
+hailo_corpus_t *hailo_corpus_load(const char *path,
+                                  bool append_writable,
+                                  char *errbuf, size_t errlen)
+{
+    if (!path || !*path) {
+        set_err(errbuf, errlen, "path required");
+        return NULL;
+    }
+    FILE *fp = fopen(path, "r");
+    if (!fp) {
+        set_err(errbuf, errlen, "open(%s) failed: %s", path, strerror(errno));
+        return NULL;
+    }
+    hailo_corpus_t *c = hailo_corpus_new_memory();
+    if (!c) {
+        fclose(fp);
+        set_err(errbuf, errlen, "out of memory");
+        return NULL;
+    }
+    copy_str(c->path, sizeof(c->path), path);
+
+    char *line = NULL;
+    size_t cap = 0;
+    ssize_t n;
+    int header_seen = 0;
+    int lineno = 0;
+    while ((n = getline(&line, &cap, fp)) != -1) {
+        lineno++;
+        size_t len = (size_t)n;
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+            line[--len] = '\0';
+        }
+        if (len == 0) continue;
+        if (line[0] == '#') continue;   /* tolerate hand-edited comments */
+
+        const char *type = line_type_field(line, len);
+        if (!type) {
+            set_err(errbuf, errlen, "line %d: no 'type' field", lineno);
+            goto fail;
+        }
+        if (strcmp(type, "header") == 0) {
+            if (header_seen) {
+                set_err(errbuf, errlen,
+                        "line %d: duplicate header", lineno);
+                goto fail;
+            }
+            if (parse_header_line(c, line, len, errbuf, errlen) != 0) {
+                goto fail;
+            }
+            header_seen = 1;
+        } else if (strcmp(type, "op") == 0) {
+            op_parse_t op;
+            if (parse_op_line(line, len, &op, errbuf, errlen) != 0) {
+                goto fail;
+            }
+            if (push_entry(c, &op.entry, errbuf, errlen) != 0) {
+                goto fail;
+            }
+        } else if (strcmp(type, "trailer") == 0) {
+            /* Trailer is informational; ignore for now. */
+        } else {
+            /* Unknown type — tolerate forward-compat. */
+        }
+    }
+    free(line);
+    fclose(fp);
+
+    if (append_writable) {
+        c->append_fp = fopen(path, "a");
+        if (!c->append_fp) {
+            set_err(errbuf, errlen, "open(%s, 'a') failed: %s",
+                    path, strerror(errno));
+            hailo_corpus_free(c);
+            return NULL;
+        }
+    }
+    return c;
+
+fail:
+    free(line);
+    fclose(fp);
+    hailo_corpus_free(c);
+    return NULL;
+}
+
+const hailo_op_entry_t *hailo_corpus_get(const hailo_corpus_t *c, uint64_t seq)
+{
+    if (!c || seq == 0 || seq >= c->seq_index_cap) return NULL;
+    int32_t idx = c->seq_index[seq];
+    if (idx < 0) return NULL;
+    return &c->entries[idx];
+}
+
+int hailo_corpus_inject_entry(hailo_corpus_t *c,
+                              const hailo_op_entry_t *entry,
+                              char *errbuf, size_t errlen)
+{
+    if (!c || !entry) {
+        set_err(errbuf, errlen, "null arg");
+        return -1;
+    }
+    return push_entry(c, entry, errbuf, errlen);
+}
+
+int hailo_corpus_append_write(hailo_corpus_t *c,
+                              uint64_t seq, int bar,
+                              uint64_t offset, uint32_t size,
+                              uint64_t value,
+                              char *errbuf, size_t errlen)
+{
+    hailo_op_entry_t e = (hailo_op_entry_t){0};
+    e.seq = seq;
+    e.bar = bar;
+    e.offset = offset;
+    e.size = size;
+    e.is_write = true;
+    e.value = value;
+    copy_str(e.source, sizeof(e.source), "qemu_capture");
+
+    char hex[32];
+    if (hailo_value_to_hex(value, size, hex, sizeof(hex)) != 0) {
+        set_err(errbuf, errlen, "bad size=%u for hex encode", size);
+        return -1;
+    }
+
+    if (c->append_fp) {
+        int rc = fprintf(c->append_fp,
+                "{\"type\":\"op\",\"seq\":%llu,\"bar\":%d,\"offset\":%llu,"
+                "\"size\":%u,\"dir\":\"write\",\"value\":\"%s\","
+                "\"source\":\"qemu_capture\","
+                "\"validated_at_commit\":null,\"validated_at\":null}\n",
+                (unsigned long long)seq, bar,
+                (unsigned long long)offset, size, hex);
+        if (rc < 0) {
+            set_err(errbuf, errlen, "fprintf: %s", strerror(errno));
+            return -1;
+        }
+        if (fflush(c->append_fp) != 0) {
+            set_err(errbuf, errlen, "fflush: %s", strerror(errno));
+            return -1;
+        }
+    }
+
+    return push_entry(c, &e, errbuf, errlen);
+}

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
@@ -228,7 +228,11 @@ static int parse_value(json_cursor_t *c,
     while (c->p < c->end && isdigit((unsigned char)*c->p)) {
         int d = *c->p - '0';
         /* Guard against int64 overflow (signed overflow is UB). 20-digit
-         * literals like 99999999999999999999 would otherwise wrap silently. */
+         * literals like 99999999999999999999 would otherwise wrap silently.
+         * Side effect: an explicit `-9223372036854775808` (INT64_MIN as a
+         * negative literal) is rejected because we check magnitude before
+         * applying the sign. The corpus schema never uses negative
+         * integers, so this corner case is harmless. */
         if (v > (INT64_MAX - d) / 10) {
             return -1;
         }
@@ -627,6 +631,14 @@ hailo_corpus_t *hailo_corpus_load(const char *path,
             }
             header_seen = 1;
         } else if (strcmp(type, "op") == 0) {
+            /* Spec §File layout requires the header before any op lines.
+             * Reject out-of-order corpora; the driver script will not
+             * produce these, and accepting them silently masks bugs. */
+            if (!header_seen) {
+                set_err(errbuf, errlen,
+                        "line %d: op entry before header", lineno);
+                goto fail;
+            }
             op_parse_t op;
             if (parse_op_line(line, len, &op, errbuf, errlen) != 0) {
                 goto fail;

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.h
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.h
@@ -1,0 +1,140 @@
+/*
+ * Hailo RE corpus loader/lookup — pure C, no QEMU deps.
+ *
+ * Implements the on-disk JSONL schema defined in
+ * docs/hailo-re-corpus-format.md. Both the QEMU stub device
+ * (hw/misc/hailo8.c) and the standalone unit tests link against this
+ * module.
+ *
+ * Lookup is keyed on the strictly-monotonic `seq` only. The caller
+ * performs shape and value comparison against the returned entry so the
+ * device model retains policy control (when to halt, what stdout line
+ * to emit) without leaking QEMU types into the parser.
+ *
+ * Anchor: issue #795 Task 0.2.
+ */
+
+#ifndef HAILO8_CORPUS_H
+#define HAILO8_CORPUS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HAILO_CORPUS_ERRBUF_MIN 256
+
+#define HAILO_CORPUS_MAX_SOURCE  31
+#define HAILO_CORPUS_MAX_SHA     63
+#define HAILO_CORPUS_MAX_TIME    31
+#define HAILO_CORPUS_MAX_NOTE    255
+
+typedef struct hailo_op_entry {
+    uint64_t seq;                                /* >= 1 */
+    int      bar;                                /* 0, 2, 4 in practice */
+    uint64_t offset;
+    uint32_t size;                               /* 1, 2, 4, or 8 */
+    bool     is_write;                           /* true = "write", false = "read" */
+    uint64_t value;                              /* little-endian decoded value */
+
+    bool     msi_after_present;                  /* worktree extension; see README */
+    uint32_t msi_after_vector;
+
+    char source[HAILO_CORPUS_MAX_SOURCE + 1];
+    char validated_at_commit[HAILO_CORPUS_MAX_SHA + 1];
+    char validated_at[HAILO_CORPUS_MAX_TIME + 1];
+    char note[HAILO_CORPUS_MAX_NOTE + 1];
+} hailo_op_entry_t;
+
+typedef struct hailo_corpus {
+    hailo_op_entry_t *entries;
+    size_t            n_entries;
+    size_t            cap_entries;
+
+    /* O(1) seq → entries[] index. -1 sentinel for "no entry at this seq". */
+    int32_t *seq_index;
+    size_t   seq_index_cap;
+    uint64_t max_seq;
+
+    /* Header fields (informational). */
+    int  format_version;
+    char hailort_version[32];
+    char fw_version[32];
+    char capture_host[64];
+
+    /* Append handle — non-NULL when the corpus was opened writable.
+     * Owns the FILE*; closed by hailo_corpus_free. */
+    char  path[1024];
+    FILE *append_fp;
+} hailo_corpus_t;
+
+/*
+ * Load a corpus from disk. Lines that fail to parse cause the load to fail
+ * — the corpus is the load-bearing contract; we don't paper over bad data.
+ *
+ * `path` is required. If `append_writable` is true, the file is also opened
+ * for append so hailo_corpus_append_write() can extend it. Pass false from
+ * unit tests that should not mutate fixture data.
+ *
+ * Returns NULL on error and writes a short reason to errbuf.
+ */
+hailo_corpus_t *hailo_corpus_load(const char *path,
+                                  bool append_writable,
+                                  char *errbuf, size_t errlen);
+
+/*
+ * Build an empty in-memory corpus — no header, no entries. Useful for unit
+ * tests that want to drive the lookup API without touching the filesystem.
+ */
+hailo_corpus_t *hailo_corpus_new_memory(void);
+
+void hailo_corpus_free(hailo_corpus_t *c);
+
+/*
+ * Return the entry at `seq`, or NULL if none. seq must be >= 1.
+ */
+const hailo_op_entry_t *hailo_corpus_get(const hailo_corpus_t *c, uint64_t seq);
+
+/*
+ * Append a freshly-captured write entry. Writes one JSONL line to the open
+ * append handle (with fflush) and updates the in-memory index. Caller is
+ * expected to verify there is no existing entry at `seq` before calling.
+ *
+ * Returns 0 on success, -1 on failure with reason in errbuf.
+ */
+int hailo_corpus_append_write(hailo_corpus_t *c,
+                              uint64_t seq, int bar,
+                              uint64_t offset, uint32_t size,
+                              uint64_t value,
+                              char *errbuf, size_t errlen);
+
+/*
+ * In-memory variant of append_write used by tests — same effect on the
+ * index, no file I/O. Returns 0 / -1 like append_write.
+ */
+int hailo_corpus_inject_entry(hailo_corpus_t *c,
+                              const hailo_op_entry_t *entry,
+                              char *errbuf, size_t errlen);
+
+/*
+ * Encode a uint64_t value of `size` bytes as a little-endian hex string,
+ * lowercase, no `0x` prefix, exactly size*2 + 1 bytes including NUL.
+ * `out` must have room for size*2 + 1 bytes. Returns 0 on success, -1 on
+ * invalid size.
+ */
+int hailo_value_to_hex(uint64_t value, uint32_t size, char *out, size_t outlen);
+
+/*
+ * Decode the inverse of hailo_value_to_hex. Returns 0 on success.
+ */
+int hailo_value_from_hex(const char *hex, uint32_t size, uint64_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAILO8_CORPUS_H */

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.h
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.h
@@ -33,6 +33,15 @@ extern "C" {
 #define HAILO_CORPUS_MAX_TIME    31
 #define HAILO_CORPUS_MAX_NOTE    255
 
+/*
+ * Upper bound on seq values accepted by the loader / push paths. The
+ * seq_index is an int32 array sized to max_seq; without this cap, a
+ * malformed corpus with `seq=10000000000` would request tens of GB of
+ * index memory. 16M entries (64 MB index) is well above any realistic
+ * single capture session (typical configure() flows are O(10k) ops).
+ */
+#define HAILO_CORPUS_MAX_SEQ     (1u << 24)
+
 typedef struct hailo_op_entry {
     uint64_t seq;                                /* >= 1 */
     int      bar;                                /* 0, 2, 4 in practice */

--- a/host-tools/qemu-hailo8-stub/tests/.gitignore
+++ b/host-tools/qemu-hailo8-stub/tests/.gitignore
@@ -1,0 +1,3 @@
+test_corpus
+*.o
+__pycache__/

--- a/host-tools/qemu-hailo8-stub/tests/Makefile
+++ b/host-tools/qemu-hailo8-stub/tests/Makefile
@@ -1,0 +1,33 @@
+# Standalone test build for the hailo8_corpus module.
+#
+# The module is QEMU-independent; this Makefile builds a test binary
+# directly with the system toolchain so the test suite can run without
+# any QEMU build.
+
+CC      ?= gcc
+CFLAGS  ?= -O2 -g -Wall -Wextra -Wpedantic -std=c11 \
+           -D_POSIX_C_SOURCE=200809L \
+           -Wno-unused-parameter -Wno-unused-variable
+LDFLAGS ?=
+
+SRC_DIR := ../src
+OBJS    := test_corpus.o hailo8_corpus.o
+
+.PHONY: all test clean
+
+all: test_corpus
+
+test_corpus: $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS)
+
+test_corpus.o: test_corpus.c $(SRC_DIR)/hailo8_corpus.h
+	$(CC) $(CFLAGS) -I$(SRC_DIR) -c $< -o $@
+
+hailo8_corpus.o: $(SRC_DIR)/hailo8_corpus.c $(SRC_DIR)/hailo8_corpus.h
+	$(CC) $(CFLAGS) -I$(SRC_DIR) -c $< -o $@
+
+test: test_corpus
+	./test_corpus
+
+clean:
+	rm -f test_corpus $(OBJS)

--- a/host-tools/qemu-hailo8-stub/tests/smoke.py
+++ b/host-tools/qemu-hailo8-stub/tests/smoke.py
@@ -30,7 +30,7 @@ import time
 QEMU = os.environ.get("QEMU") or os.path.expanduser(
     "~/projects/qemu/build/qemu-system-x86_64"
 )
-DEFAULT_BAR0_BASE = 0xFEB00000   # Far above PCI hole so q35 can place it freely
+DEFAULT_BAR0_BASE = 0xFEB00000   # Top of the q35 PCI hole, just below LAPIC (0xFEC00000+)
 
 # -------------------------------------------------------------------------- #
 # qtest protocol — tiny client                                                #
@@ -300,6 +300,37 @@ def scenario_lookup_hit():
     )
 
 
+def scenario_shape_divergence():
+    """Corpus expects a read at seq=1 but we issue a write — exercises the
+    op_shape_mismatch path and the expected_* extension fields."""
+    entry = {
+        "type": "op", "seq": 1, "bar": 0, "offset": 0, "size": 4,
+        "dir": "read", "value": "deadbeef",
+        "source": "slmos_observed",
+        "validated_at_commit": "a" * 40,
+        "validated_at": "2026-05-12T00:00:00Z",
+    }
+    return scenario(
+        name="shape_divergence",
+        corpus_entries=[entry],
+        qtest_ops=[("writel", 0x0, 0x00000001)],
+        expect_exit_nonzero=True,
+        expect_stdout_contains=[
+            "HAILO_RE_CORPUS_DIVERGENCE",
+            "seq=1",
+            "bar=0",
+            "dir=write",
+            "expected=00000000",
+            "observed=00000000",
+            "reason=op_shape_mismatch",
+            "expected_bar=0",
+            "expected_offset=0",
+            "expected_size=4",
+            "expected_dir=read",
+        ],
+    )
+
+
 def scenario_write_divergence():
     # value="01000000" in the corpus is LE-encoded uint32 0x00000001 (matches
     # the corpus spec's worked example for hex encoding: byte 0 is the LSB).
@@ -341,6 +372,7 @@ def main():
     scenarios = [
         ("empty_corpus_extend", scenario_empty_corpus),
         ("lookup_hit",          scenario_lookup_hit),
+        ("shape_divergence",    scenario_shape_divergence),
         ("write_divergence",    scenario_write_divergence),
     ]
 

--- a/host-tools/qemu-hailo8-stub/tests/smoke.py
+++ b/host-tools/qemu-hailo8-stub/tests/smoke.py
@@ -6,13 +6,17 @@ qtest accelerator exposes a tiny text protocol that lets us program PCI
 config space, then directly read/write BAR memory addresses to exercise
 the device's MemoryRegionOps callbacks.
 
-Three scenarios mapped to the Phase 0.2 Definition of Done:
+Four scenarios mapped to the Phase 0.2 Definition of Done:
 
   1. empty corpus      → first BAR0 read produces HAILO_RE_CORPUS_EXTEND
                          and QEMU exits non-zero.
   2. hand-crafted hit  → BAR0 read at the corpus's recorded offset
                          returns the recorded value.
-  3. write divergence  → a write whose value differs from the corpus
+  3. shape divergence  → a write where the corpus expects a read produces
+                         HAILO_RE_CORPUS_DIVERGENCE with reason=
+                         op_shape_mismatch and the expected_* extension
+                         fields.
+  4. write divergence  → a write whose value differs from the corpus
                          produces HAILO_RE_CORPUS_DIVERGENCE and exit.
 
 Run:

--- a/host-tools/qemu-hailo8-stub/tests/smoke.py
+++ b/host-tools/qemu-hailo8-stub/tests/smoke.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""End-to-end smoke tests for the hailo8 QEMU stub device.
+
+Drives a built QEMU through its qtest socket — no guest OS needed. The
+qtest accelerator exposes a tiny text protocol that lets us program PCI
+config space, then directly read/write BAR memory addresses to exercise
+the device's MemoryRegionOps callbacks.
+
+Three scenarios mapped to the Phase 0.2 Definition of Done:
+
+  1. empty corpus      → first BAR0 read produces HAILO_RE_CORPUS_EXTEND
+                         and QEMU exits non-zero.
+  2. hand-crafted hit  → BAR0 read at the corpus's recorded offset
+                         returns the recorded value.
+  3. write divergence  → a write whose value differs from the corpus
+                         produces HAILO_RE_CORPUS_DIVERGENCE and exit.
+
+Run:
+    QEMU=~/projects/qemu/build/qemu-system-x86_64 python3 tests/smoke.py
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+QEMU = os.environ.get("QEMU") or os.path.expanduser(
+    "~/projects/qemu/build/qemu-system-x86_64"
+)
+DEFAULT_BAR0_BASE = 0xFEB00000   # Far above PCI hole so q35 can place it freely
+
+# -------------------------------------------------------------------------- #
+# qtest protocol — tiny client                                                #
+# -------------------------------------------------------------------------- #
+
+
+class QtestSession:
+    """A blocking text-protocol client for QEMU's qtest accelerator socket."""
+
+    def __init__(self, sock):
+        self.sock = sock
+        self.buf = b""
+
+    def _readline(self, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while b"\n" not in self.buf:
+            self.sock.settimeout(max(0.05, deadline - time.monotonic()))
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise EOFError("qtest socket closed")
+            self.buf += chunk
+        line, _, self.buf = self.buf.partition(b"\n")
+        return line.decode("utf-8", errors="replace").rstrip("\r")
+
+    def send(self, line):
+        self.sock.sendall((line + "\n").encode("utf-8"))
+
+    def cmd(self, line, expect="OK"):
+        self.send(line)
+        reply = self._readline()
+        if not reply.startswith(expect):
+            raise RuntimeError(f"qtest cmd {line!r}: reply {reply!r}")
+        return reply
+
+    # -- PCI config space via the q35 host bridge (ports 0xCF8 / 0xCFC).
+    @staticmethod
+    def _cfg_addr(bus, dev, fn, offset):
+        return (1 << 31) | (bus << 16) | (dev << 11) | (fn << 8) | (offset & 0xFC)
+
+    def pci_cfg_write32(self, bus, dev, fn, offset, value):
+        addr = self._cfg_addr(bus, dev, fn, offset)
+        self.cmd(f"outl 0xcf8 0x{addr:08x}")
+        self.cmd(f"outl 0xcfc 0x{value:08x}")
+
+    def pci_cfg_read32(self, bus, dev, fn, offset):
+        addr = self._cfg_addr(bus, dev, fn, offset)
+        self.cmd(f"outl 0xcf8 0x{addr:08x}")
+        self.send("inl 0xcfc")
+        reply = self._readline()
+        if not reply.startswith("OK"):
+            raise RuntimeError(f"pci_cfg_read32: {reply!r}")
+        return int(reply.split()[1], 16)
+
+    def writel(self, phys, value):
+        self.cmd(f"writel 0x{phys:x} 0x{value:08x}")
+
+    def readl(self, phys):
+        self.send(f"readl 0x{phys:x}")
+        reply = self._readline()
+        if not reply.startswith("OK"):
+            raise RuntimeError(f"readl: {reply!r}")
+        return int(reply.split()[1], 16)
+
+    def close(self):
+        try:
+            self.sock.close()
+        except Exception:
+            pass
+
+
+def find_hailo8_dev(qt):
+    """Walk bus 0 looking for the Hailo8 device. Returns (dev, fn)."""
+    for dev in range(32):
+        for fn in range(8):
+            vid_did = qt.pci_cfg_read32(0, dev, fn, 0x00)
+            if vid_did == 0xFFFFFFFF:
+                continue
+            vid = vid_did & 0xFFFF
+            did = (vid_did >> 16) & 0xFFFF
+            if vid == 0x1E60 and did == 0x2864:
+                return (dev, fn)
+    return None
+
+
+def program_bar0(qt, dev, fn, base):
+    """Write `base` into BAR0 + BAR1 (64-bit pair) and enable memory decode."""
+    # BAR0 is a 64-bit BAR; bits 0-3 hold the BAR type flags. Preserve those
+    # for the low half (memory + 64-bit, bits 0=0, 1-2=10, 3=prefetch don't care)
+    # by reading first and OR-ing the address in.
+    qt.pci_cfg_write32(0, dev, fn, 0x10, (base & 0xFFFFFFFF) | 0x04)  # 64-bit memory
+    qt.pci_cfg_write32(0, dev, fn, 0x14, (base >> 32) & 0xFFFFFFFF)
+    # Enable memory-space decode (bit 1 of PCI COMMAND).
+    cmd = qt.pci_cfg_read32(0, dev, fn, 0x04) & 0xFFFF
+    qt.pci_cfg_write32(0, dev, fn, 0x04, cmd | 0x02)
+
+
+# -------------------------------------------------------------------------- #
+# QEMU launcher                                                               #
+# -------------------------------------------------------------------------- #
+
+
+def launch_qemu(corpus_path, qtest_path):
+    """Spawn QEMU in qtest mode, attached to a unix qtest socket."""
+    args = [
+        QEMU,
+        "-nodefaults", "-display", "none", "-no-reboot",
+        "-machine", "q35,accel=qtest",
+        "-m", "256",
+        "-qtest", f"unix:{qtest_path},server=on,wait=off",
+        "-device", f"hailo8,corpus={corpus_path}",
+    ]
+    proc = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # Wait for the qtest socket to appear.
+    deadline = time.monotonic() + 5.0
+    while not os.path.exists(qtest_path):
+        if proc.poll() is not None:
+            out, err = proc.communicate()
+            raise RuntimeError(
+                f"QEMU exited before qtest socket appeared (rc={proc.returncode})\n"
+                f"stdout: {out}\nstderr: {err}"
+            )
+        if time.monotonic() > deadline:
+            proc.kill()
+            raise RuntimeError("timed out waiting for qtest socket")
+        time.sleep(0.05)
+    return proc
+
+
+def connect_qtest(qtest_path):
+    sock = socket.socket(socket.AF_UNIX)
+    sock.connect(qtest_path)
+    qt = QtestSession(sock)
+    # qtest has no connection banner — server stays silent until the
+    # first command. A clock_step 0 is a no-op probe that confirms
+    # the protocol is alive.
+    qt.cmd("clock_step 0")
+    return qt
+
+
+# -------------------------------------------------------------------------- #
+# Scenarios                                                                   #
+# -------------------------------------------------------------------------- #
+
+
+def write_corpus(path, entries):
+    with open(path, "w") as fp:
+        fp.write(json.dumps({
+            "type": "header", "format_version": 1,
+            "hailort_version": "4.23.0", "fw_version": "4.23.0",
+            "capture_host": "qemu-x86_64-smoke",
+            "slmos_base_sha": "0" * 40,
+            "capture_started_at": "2026-05-12T00:00:00Z",
+            "notes": "smoke-test fixture",
+        }) + "\n")
+        for e in entries:
+            fp.write(json.dumps(e) + "\n")
+
+
+def scenario(name, corpus_entries, qtest_ops, expect_exit_nonzero,
+             expect_stdout_contains=None, read_result_check=None):
+    """Run one scenario. Returns (ok, message)."""
+    with tempfile.TemporaryDirectory() as td:
+        corpus = os.path.join(td, "corpus.jsonl")
+        qsock = os.path.join(td, "qtest.sock")
+        write_corpus(corpus, corpus_entries)
+        proc = launch_qemu(corpus, qsock)
+        qt = connect_qtest(qsock)
+        last_read = None
+        try:
+            located = find_hailo8_dev(qt)
+            if located is None:
+                proc.kill()
+                return False, "hailo8 device not found on bus 0"
+            dev, fn = located
+            program_bar0(qt, dev, fn, DEFAULT_BAR0_BASE)
+            for op in qtest_ops:
+                kind = op[0]
+                if kind == "readl":
+                    last_read = qt.readl(DEFAULT_BAR0_BASE + op[1])
+                elif kind == "writel":
+                    qt.writel(DEFAULT_BAR0_BASE + op[1], op[2])
+                else:
+                    raise RuntimeError(f"unknown qtest op {kind!r}")
+        except (RuntimeError, EOFError, ConnectionResetError) as e:
+            # The device may abruptly exit(1) — expected for EXTEND / DIVERGENCE.
+            if not expect_exit_nonzero:
+                proc.kill()
+                stdout, stderr = proc.communicate()
+                return False, f"unexpected qtest error: {e}\nstdout: {stdout}\nstderr: {stderr}"
+        finally:
+            qt.close()
+
+        # If we expect a clean exit, QEMU won't have terminated on its own —
+        # the qtest commands are passive. Send SIGTERM to shut it down.
+        # If we expect non-zero exit, the device's exit(1) should already
+        # have fired; SIGTERM as a fallback is harmless.
+        if not expect_exit_nonzero and proc.poll() is None:
+            proc.terminate()
+
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+
+        rc = proc.returncode
+        if expect_exit_nonzero and rc == 0:
+            return False, f"expected non-zero exit, got 0\nstdout: {stdout}\nstderr: {stderr}"
+        if not expect_exit_nonzero and rc != 0:
+            return False, f"expected zero exit, got {rc}\nstdout: {stdout}\nstderr: {stderr}"
+
+        if expect_stdout_contains:
+            for s in expect_stdout_contains:
+                if s not in stdout:
+                    return False, (f"missing {s!r} in stdout\nstdout: {stdout}\nstderr: {stderr}")
+
+        if read_result_check:
+            ok, msg = read_result_check(last_read)
+            if not ok:
+                return False, f"{msg}\nstdout: {stdout}\nstderr: {stderr}"
+
+    return True, "OK"
+
+
+def scenario_empty_corpus():
+    return scenario(
+        name="empty_corpus_extend",
+        corpus_entries=[],
+        qtest_ops=[("readl", 0x0)],
+        expect_exit_nonzero=True,
+        expect_stdout_contains=[
+            "HAILO_RE_CORPUS_EXTEND",
+            "seq=1",
+            "bar=0",
+            "offset=0",
+            "reason=unknown_read",
+        ],
+    )
+
+
+def scenario_lookup_hit():
+    entry = {
+        "type": "op", "seq": 1, "bar": 0, "offset": 0, "size": 4,
+        "dir": "read", "value": "deadbeef",
+        "source": "slmos_observed",
+        "validated_at_commit": "a" * 40,
+        "validated_at": "2026-05-12T00:00:00Z",
+    }
+    expected = 0xefbeadde
+
+    def check(read):
+        if read != expected:
+            return False, f"expected read=0x{expected:08x}, got 0x{read:08x}"
+        return True, ""
+
+    return scenario(
+        name="lookup_hit",
+        corpus_entries=[entry],
+        qtest_ops=[("readl", 0x0)],
+        expect_exit_nonzero=False,
+        read_result_check=check,
+    )
+
+
+def scenario_write_divergence():
+    # value="01000000" in the corpus is LE-encoded uint32 0x00000001 (matches
+    # the corpus spec's worked example for hex encoding: byte 0 is the LSB).
+    # qtest's `writel 0x03000000` writes integer 0x03000000 — its LE-encoding
+    # is "00000003".
+    entry = {
+        "type": "op", "seq": 1, "bar": 0, "offset": 0, "size": 4,
+        "dir": "write", "value": "01000000",
+        "source": "qemu_capture",
+        "validated_at_commit": None, "validated_at": None,
+    }
+    return scenario(
+        name="write_divergence",
+        corpus_entries=[entry],
+        qtest_ops=[("writel", 0x0, 0x03000000)],
+        expect_exit_nonzero=True,
+        expect_stdout_contains=[
+            "HAILO_RE_CORPUS_DIVERGENCE",
+            "seq=1",
+            "dir=write",
+            "reason=write_value_mismatch",
+            "expected=01000000",
+            "observed=00000003",
+        ],
+    )
+
+
+# -------------------------------------------------------------------------- #
+# Main                                                                        #
+# -------------------------------------------------------------------------- #
+
+
+def main():
+    if not os.path.exists(QEMU):
+        print(f"QEMU binary not found at {QEMU!r} — set QEMU=... to override",
+              file=sys.stderr)
+        return 2
+
+    scenarios = [
+        ("empty_corpus_extend", scenario_empty_corpus),
+        ("lookup_hit",          scenario_lookup_hit),
+        ("write_divergence",    scenario_write_divergence),
+    ]
+
+    failures = 0
+    for name, fn in scenarios:
+        print(f"[smoke] {name:30s} ", end="", flush=True)
+        ok, msg = fn()
+        if ok:
+            print("OK")
+        else:
+            print("FAIL")
+            print(f"    {msg}")
+            failures += 1
+
+    print(f"\n{len(scenarios) - failures} / {len(scenarios)} scenarios passed")
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/host-tools/qemu-hailo8-stub/tests/test_corpus.c
+++ b/host-tools/qemu-hailo8-stub/tests/test_corpus.c
@@ -1,0 +1,332 @@
+/*
+ * Unit tests for the hailo8_corpus module.
+ *
+ * Build + run:
+ *   cd host-tools/qemu-hailo8-stub
+ *   make -C tests
+ */
+
+#include "../src/hailo8_corpus.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int g_fail_count;
+static int g_test_count;
+
+#define TEST(name)  do { g_test_count++; \
+    fprintf(stderr, "[test] %-50s ", #name); \
+    if (name()) { fprintf(stderr, "OK\n"); } \
+    else        { fprintf(stderr, "FAIL\n"); g_fail_count++; } \
+    } while (0)
+
+#define EXPECT(cond) do { if (!(cond)) { \
+    fprintf(stderr, "\n    EXPECT failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+    return 0; } } while (0)
+
+#define EXPECT_EQ(a, b) do { \
+    long long _a = (long long)(a), _b = (long long)(b); \
+    if (_a != _b) { \
+        fprintf(stderr, "\n    EXPECT_EQ failed: %s=%lld vs %s=%lld (%s:%d)\n", \
+                #a, _a, #b, _b, __FILE__, __LINE__); \
+        return 0; } } while (0)
+
+#define EXPECT_STR_EQ(a, b) do { \
+    if (strcmp((a), (b)) != 0) { \
+        fprintf(stderr, "\n    EXPECT_STR_EQ failed: '%s' vs '%s' (%s:%d)\n", \
+                (a), (b), __FILE__, __LINE__); \
+        return 0; } } while (0)
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                     */
+/* -------------------------------------------------------------------------- */
+
+static char tmp_path[256];
+
+static void make_tmp(void)
+{
+    strcpy(tmp_path, "/tmp/hailo8_corpus_test_XXXXXX");
+    int fd = mkstemp(tmp_path);
+    assert(fd >= 0);
+    close(fd);
+}
+
+static void write_file(const char *path, const char *contents)
+{
+    FILE *fp = fopen(path, "w");
+    assert(fp);
+    fputs(contents, fp);
+    fclose(fp);
+}
+
+/* -------------------------------------------------------------------------- */
+/* hex round-trip                                                              */
+/* -------------------------------------------------------------------------- */
+
+static int test_hex_roundtrip_u32(void)
+{
+    char buf[16];
+    EXPECT_EQ(hailo_value_to_hex(0x40130016, 4, buf, sizeof(buf)), 0);
+    EXPECT_STR_EQ(buf, "16001340");
+    uint64_t back = 0;
+    EXPECT_EQ(hailo_value_from_hex(buf, 4, &back), 0);
+    EXPECT_EQ(back, 0x40130016);
+    return 1;
+}
+
+static int test_hex_roundtrip_u8_u16_u64(void)
+{
+    char buf[32];
+    uint64_t back;
+
+    EXPECT_EQ(hailo_value_to_hex(0xAB, 1, buf, sizeof(buf)), 0);
+    EXPECT_STR_EQ(buf, "ab");
+    EXPECT_EQ(hailo_value_from_hex(buf, 1, &back), 0);
+    EXPECT_EQ(back, 0xAB);
+
+    EXPECT_EQ(hailo_value_to_hex(0x1234, 2, buf, sizeof(buf)), 0);
+    EXPECT_STR_EQ(buf, "3412");
+    EXPECT_EQ(hailo_value_from_hex(buf, 2, &back), 0);
+    EXPECT_EQ(back, 0x1234);
+
+    EXPECT_EQ(hailo_value_to_hex(0x0102030405060708ULL, 8, buf, sizeof(buf)), 0);
+    EXPECT_STR_EQ(buf, "0807060504030201");
+    EXPECT_EQ(hailo_value_from_hex(buf, 8, &back), 0);
+    EXPECT_EQ(back, 0x0102030405060708ULL);
+    return 1;
+}
+
+static int test_hex_rejects_bad_size(void)
+{
+    char buf[16];
+    EXPECT_EQ(hailo_value_to_hex(0, 3, buf, sizeof(buf)), -1);
+    uint64_t v;
+    EXPECT_EQ(hailo_value_from_hex("ab", 3, &v), -1);
+    EXPECT_EQ(hailo_value_from_hex("abc", 2, &v), -1);   /* wrong length */
+    EXPECT_EQ(hailo_value_from_hex("xyzz", 2, &v), -1);  /* bad hex */
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Loader                                                                      */
+/* -------------------------------------------------------------------------- */
+
+static int test_load_minimal_corpus(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu-x86_64\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"2026-05-12T00:00:00Z\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":2304,\"size\":4,\"dir\":\"write\",\"value\":\"01000000\",\"source\":\"qemu_capture\",\"validated_at_commit\":null,\"validated_at\":null}\n"
+        "{\"type\":\"op\",\"seq\":2,\"bar\":4,\"offset\":2308,\"size\":4,\"dir\":\"read\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":\"deadbeef\",\"validated_at\":\"2026-05-12T01:00:00Z\"}\n"
+        "{\"type\":\"op\",\"seq\":3,\"bar\":4,\"offset\":2308,\"size\":4,\"dir\":\"read\",\"value\":\"01000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":\"deadbeef\",\"validated_at\":\"2026-05-12T01:00:00Z\"}\n");
+
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    if (!c) {
+        fprintf(stderr, "load failed: %s\n", err);
+        return 0;
+    }
+    EXPECT_EQ(c->n_entries, 3);
+    EXPECT_EQ(c->max_seq, 3);
+    EXPECT_EQ(c->format_version, 1);
+    EXPECT_STR_EQ(c->hailort_version, "4.23.0");
+
+    const hailo_op_entry_t *e1 = hailo_corpus_get(c, 1);
+    EXPECT(e1 != NULL);
+    EXPECT_EQ(e1->bar, 4);
+    EXPECT_EQ(e1->offset, 2304);
+    EXPECT_EQ(e1->is_write, true);
+    EXPECT_EQ(e1->value, 0x00000001);
+
+    const hailo_op_entry_t *e2 = hailo_corpus_get(c, 2);
+    EXPECT(e2 != NULL);
+    EXPECT_EQ(e2->is_write, false);
+    EXPECT_EQ(e2->value, 0x00000000);
+
+    const hailo_op_entry_t *e3 = hailo_corpus_get(c, 3);
+    EXPECT(e3 != NULL);
+    EXPECT_EQ(e3->value, 0x00000001);
+
+    /* Polling-loop semantics: same offset, different values per seq. */
+    EXPECT_EQ(e2->offset, e3->offset);
+    EXPECT(e2->value != e3->value);
+
+    EXPECT(hailo_corpus_get(c, 4) == NULL);
+    EXPECT(hailo_corpus_get(c, 0) == NULL);
+
+    hailo_corpus_free(c);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_rejects_duplicate_seq(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"x\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":4,\"size\":4,\"dir\":\"read\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "duplicate") != NULL);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_rejects_bad_dir(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"x\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"sideways\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_rejects_bad_value_length(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"00\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_tolerates_unknown_keys(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\",\"notes\":\"future fields ok\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null,\"experimental_field\":42}\n"
+        "{\"type\":\"trailer\",\"ended_at\":\"x\",\"last_seq\":1,\"reason\":\"eof\"}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c != NULL);
+    EXPECT_EQ(c->n_entries, 1);
+    hailo_corpus_free(c);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_picks_up_msi_after(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"01000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null,\"msi_after\":2}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c != NULL);
+    const hailo_op_entry_t *e = hailo_corpus_get(c, 1);
+    EXPECT(e != NULL);
+    EXPECT_EQ(e->msi_after_present, true);
+    EXPECT_EQ(e->msi_after_vector, 2);
+    hailo_corpus_free(c);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_tolerates_comments_and_blank_lines(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "# hand-edited fixture\n"
+        "\n"
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n"
+        "\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":0,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"deadbeef\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c != NULL);
+    EXPECT_EQ(c->n_entries, 1);
+    const hailo_op_entry_t *e = hailo_corpus_get(c, 1);
+    EXPECT(e != NULL);
+    EXPECT_EQ(e->value, 0xefbeaddeULL);
+    hailo_corpus_free(c);
+    unlink(tmp_path);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Append + inject                                                             */
+/* -------------------------------------------------------------------------- */
+
+static int test_append_write_persists(void)
+{
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, true, err, sizeof(err));
+    EXPECT(c != NULL);
+    EXPECT_EQ(hailo_corpus_append_write(c, 1, 4, 0x900, 4, 0x12345678, err, sizeof(err)), 0);
+    EXPECT_EQ(c->n_entries, 1);
+    EXPECT_EQ(c->max_seq, 1);
+    const hailo_op_entry_t *e = hailo_corpus_get(c, 1);
+    EXPECT(e != NULL);
+    EXPECT_EQ(e->is_write, true);
+    EXPECT_EQ(e->value, 0x12345678);
+    hailo_corpus_free(c);
+
+    /* Re-load to confirm the file actually grew. */
+    hailo_corpus_t *c2 = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c2 != NULL);
+    EXPECT_EQ(c2->n_entries, 1);
+    const hailo_op_entry_t *e2 = hailo_corpus_get(c2, 1);
+    EXPECT(e2 != NULL);
+    EXPECT_EQ(e2->is_write, true);
+    EXPECT_EQ(e2->value, 0x12345678);
+    EXPECT_STR_EQ(e2->source, "qemu_capture");
+    hailo_corpus_free(c2);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_inject_no_file(void)
+{
+    hailo_corpus_t *c = hailo_corpus_new_memory();
+    EXPECT(c != NULL);
+    hailo_op_entry_t e = {0};
+    e.seq = 7;
+    e.bar = 2;
+    e.offset = 0xdead;
+    e.size = 4;
+    e.is_write = false;
+    e.value = 0xabad1dea;
+    char err[256];
+    EXPECT_EQ(hailo_corpus_inject_entry(c, &e, err, sizeof(err)), 0);
+    const hailo_op_entry_t *got = hailo_corpus_get(c, 7);
+    EXPECT(got != NULL);
+    EXPECT_EQ(got->value, 0xabad1dea);
+    hailo_corpus_free(c);
+    return 1;
+}
+
+int main(void)
+{
+    TEST(test_hex_roundtrip_u32);
+    TEST(test_hex_roundtrip_u8_u16_u64);
+    TEST(test_hex_rejects_bad_size);
+    TEST(test_load_minimal_corpus);
+    TEST(test_load_rejects_duplicate_seq);
+    TEST(test_load_rejects_bad_dir);
+    TEST(test_load_rejects_bad_value_length);
+    TEST(test_load_tolerates_unknown_keys);
+    TEST(test_load_picks_up_msi_after);
+    TEST(test_load_tolerates_comments_and_blank_lines);
+    TEST(test_append_write_persists);
+    TEST(test_inject_no_file);
+    fprintf(stderr, "\n%d / %d tests passed\n", g_test_count - g_fail_count, g_test_count);
+    return g_fail_count == 0 ? 0 : 1;
+}

--- a/host-tools/qemu-hailo8-stub/tests/test_corpus.c
+++ b/host-tools/qemu-hailo8-stub/tests/test_corpus.c
@@ -346,6 +346,21 @@ static int test_load_rejects_int_overflow(void)
     return 1;
 }
 
+static int test_load_rejects_op_before_header(void)
+{
+    /* Spec §File layout requires the header before any op lines. */
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n"
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "before header") != NULL);
+    unlink(tmp_path);
+    return 1;
+}
+
 static int test_load_handles_short_line(void)
 {
     /* line_type_field's boundary check is `p + 6 <= end`; verify we don't
@@ -377,6 +392,7 @@ int main(void)
     TEST(test_load_tolerates_comments_and_blank_lines);
     TEST(test_load_rejects_seq_above_max);
     TEST(test_load_rejects_int_overflow);
+    TEST(test_load_rejects_op_before_header);
     TEST(test_load_handles_short_line);
     TEST(test_append_write_persists);
     TEST(test_inject_no_file);

--- a/host-tools/qemu-hailo8-stub/tests/test_corpus.c
+++ b/host-tools/qemu-hailo8-stub/tests/test_corpus.c
@@ -313,6 +313,56 @@ static int test_inject_no_file(void)
     return 1;
 }
 
+static int test_load_rejects_seq_above_max(void)
+{
+    /* HAILO_CORPUS_MAX_SEQ guards against malicious huge seq values that
+     * would force tens of GB of index allocation. Use one past the cap. */
+    char line[512];
+    snprintf(line, sizeof(line),
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n"
+        "{\"type\":\"op\",\"seq\":%u,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n",
+        (unsigned)HAILO_CORPUS_MAX_SEQ);
+    make_tmp();
+    write_file(tmp_path, line);
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "seq must be in") != NULL);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_rejects_int_overflow(void)
+{
+    /* 20-digit positive literal — overflows int64 if the parser doesn't guard. */
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n"
+        "{\"type\":\"op\",\"seq\":99999999999999999999,\"bar\":4,\"offset\":0,\"size\":4,\"dir\":\"read\",\"value\":\"00000000\",\"source\":\"slmos_observed\",\"validated_at_commit\":null,\"validated_at\":null}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    unlink(tmp_path);
+    return 1;
+}
+
+static int test_load_handles_short_line(void)
+{
+    /* line_type_field's boundary check is `p + 6 <= end`; verify we don't
+     * crash on lines shorter than the "\"type\"" marker. */
+    make_tmp();
+    write_file(tmp_path,
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"x\",\"fw_version\":\"x\",\"capture_host\":\"x\",\"slmos_base_sha\":\"x\",\"capture_started_at\":\"x\"}\n"
+        "{}\n");
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    /* Short non-empty line with no `type` should fail cleanly, not crash. */
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "no 'type' field") != NULL);
+    unlink(tmp_path);
+    return 1;
+}
+
 int main(void)
 {
     TEST(test_hex_roundtrip_u32);
@@ -325,6 +375,9 @@ int main(void)
     TEST(test_load_tolerates_unknown_keys);
     TEST(test_load_picks_up_msi_after);
     TEST(test_load_tolerates_comments_and_blank_lines);
+    TEST(test_load_rejects_seq_above_max);
+    TEST(test_load_rejects_int_overflow);
+    TEST(test_load_handles_short_line);
     TEST(test_append_write_persists);
     TEST(test_inject_no_file);
     fprintf(stderr, "\n%d / %d tests passed\n", g_test_count - g_fail_count, g_test_count);


### PR DESCRIPTION
## Summary
- New QEMU PCIe stub device `hailo8` (vendor `0x1e60`, device `0x2864`) under `host-tools/qemu-hailo8-stub/`. Answers BAR0/BAR2/BAR4 reads from a JSONL corpus per [`docs/hailo-re-corpus-format.md`](../blob/main/docs/hailo-re-corpus-format.md); halts QEMU with `HAILO_RE_CORPUS_EXTEND` on unknown reads so the Task 0.5 driver script can extend the corpus from real hardware. Writes are appended to the corpus in place; value-mismatch writes trigger `HAILO_RE_CORPUS_DIVERGENCE` halts.
- JSONL parser + seq-keyed O(1) lookup is pure C11 so the same code links into both QEMU (via `install.sh`'s symlink-and-patch flow) and a standalone unit-test binary.
- Worktree extension to the corpus protocol (additive, no `format_version` bump): an optional `msi_after: <vector>` field on read entries fires MSI vector V immediately after the read returns. Documented in the stub README; reserved by readers that don't understand it.

Closes nothing; this is Phase 0 Task 0.2 of [#795](https://github.com/SLM-OS/SLM-Operating-System/issues/795). Tasks 0.3 (HailoRT-in-VM), 0.4 (SLM-OS `hailo replay-step`), and 0.5 (driver script) run in parallel.

## Layout
```
host-tools/qemu-hailo8-stub/
├── README.md
├── install.sh                 # symlink + idempotent meson/Kconfig patch
├── src/
│   ├── hailo8.c               # QEMU device model
│   ├── hailo8_corpus.c        # JSONL parser, lookup, append
│   └── hailo8_corpus.h        # corpus API (no QEMU deps)
├── tests/
│   ├── Makefile               # standalone unit-test build
│   ├── test_corpus.c          # 12 unit tests
│   └── smoke.py               # 3 end-to-end qtest scenarios
└── sample/empty.jsonl         # header-only fixture
```

## Test plan
- [x] Unit tests: `make -C host-tools/qemu-hailo8-stub/tests test` — 12/12 pass (hex round-trip, parser strictness, duplicate-seq rejection, append round-trip, msi_after pickup, comment/blank-line tolerance, inject-no-file).
- [x] Smoke tests against QEMU 8.2.10 (`stable-8.2`): `python3 tests/smoke.py` — 3/3 pass.
  - `empty_corpus_extend`: first BAR0 read emits `HAILO_RE_CORPUS_EXTEND seq=1 bar=0 offset=0 size=4 reason=unknown_read` and QEMU exits 1.
  - `lookup_hit`: corpus with one read entry at seq=1 → qtest readl returns the recorded value (`0xdeadbeef`).
  - `write_divergence`: corpus expecting `value=01000000` for seq=1 write → qtest writel 0x03000000 emits `HAILO_RE_CORPUS_DIVERGENCE seq=1 dir=write reason=write_value_mismatch expected=01000000 observed=00000003` and QEMU exits 1.
- [x] Device registration: `qemu-system-x86_64 -device help | grep hailo8` and `qemu-system-x86_64 -device hailo8,help` both report the device with `corpus`, `bar0_size`, `bar2_size`, `bar4_size` properties.
- [ ] Cross-checked against HailoRT-in-VM (Task 0.3). Deferred until that lands; the smoke tests cover the lookup/write/extend mechanics that HailoRT will exercise.

## Out of scope
- DMA buffer capture (HailoRT uploads firmware patches and descriptor lists via DMA; those bytes don't appear in BAR R/W). Capture them separately as opaque blobs keyed by the seq of the descriptor-program write — Phase 4 problem.
- fw timing reproduction (real fw has settle windows; the stub answers instantly). The SLM-OS replay side compensates.
- Pattern-recognition shortcuts (RAM-like windows, ID-register constants) — Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)