### PR TITLE
gpu/ga10b: rebuild GMMU page tree for inherited channel (#788 Stage 2)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -997,6 +997,210 @@ int ga10b_gmmu_free(uint64_t inst_block_phys,
     return 0;
 }
 
+/* ============================================================
+ * #788 Stage 2: rebuild GMMU state for an inherited channel.
+ *
+ * After kexec, Linux's nvgpu has freed the channel's inst block,
+ * page-directory base (PDB), and intermediate page tables —
+ * verified by `nvgpu instdump` (PR #797) showing inst-block
+ * contents as ARM64 kernel code (mid-boot allocations) or random
+ * weight bytes (mid-xload). The Stage 1 reservation in
+ * `pmm_user_reserve_add` (PR #801) keeps SLM-OS from overwriting
+ * the inst-block page itself, but the PDB and page tables stay
+ * gone — they were freed before SLM-OS could see them.
+ *
+ * What survives: the helper's user-allocated dmabufs (USERD,
+ * GPFIFO, pushbuffer, semaphore, SASS pool, cbuf, QMD pool,
+ * weights pool first-page, handoff dmabuf). These are tied to
+ * the helper's open file descriptors, so Linux's reference
+ * counting keeps them alive across kexec. The handoff struct
+ * publishes (phys, gpu_va, size) for each.
+ *
+ * Strategy: build a fresh PDB tree in SLM-OS and re-install PTEs
+ * mapping every preserved dmabuf at its original GPU VA. Write
+ * the inst-block's PDB pointer to point at the new tree. The
+ * GPU's runlist still references the old inst-block physical
+ * address (because that's what nvgpu wrote pre-kexec), but we're
+ * filling THAT physical page with a fresh inst block — so the
+ * runlist's pointer becomes meaningful again. TLB-invalidate
+ * after the rebuild so any cached PDB-walks from before-kexec
+ * are flushed.
+ *
+ * **Scope:** maps fixed-size buffers from the handoff at their
+ * recorded GPU VAs. Skips the weights pool beyond its first
+ * page — the 1.5 GB region is SMMU-stitched from scattered
+ * physical pages, and the handoff only publishes the first
+ * page's phys. A future enhancement (Helper Stage 2.1?) could
+ * enumerate per-page phys via /proc/self/pagemap pre-kexec and
+ * publish a longer reserve list, enabling full weights-pool
+ * mapping. Until then, slm xload's W3 staging will succeed for
+ * the first 4 KB chunk only.
+ * ============================================================ */
+
+#include "ga10b_channel_handoff.h"
+#include "../../include/uart.h"
+
+/* Inst-block PDB-pointer encoding per
+ * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_ram_ga10b.h:62-71`.
+ * Replicates `ga10b_ramin_init_pdb` from the nvgpu source — keeps
+ * the encoding correct without dragging the full HW reg header in. */
+#define GA10B_RAM_IN_PDB_TARGET_SYS_NCOH  0x3u
+#define GA10B_RAM_IN_PDB_VOL_TRUE         0x4u
+#define GA10B_RAM_IN_USE_VER2_PT_FORMAT   0x400u
+#define GA10B_RAM_IN_BIG_PAGE_SIZE_64KB   0x800u
+
+/* Map `n_pages` of contiguous physical memory at the given GPU
+ * VA. Helper for the rebuild path — calls into the existing
+ * `map_one_page` so it benefits from the auto-allocated
+ * intermediate-table code. Returns 0 on success, -1 on PMM
+ * exhaustion or invalid range; on partial failure, the pages
+ * mapped before the failure stay mapped (the caller treats this
+ * as fatal). */
+static int rebuild_map_range(uint64_t pdb_phys, uint64_t gpu_va_base,
+                             uint64_t phys_base, uint32_t n_pages)
+{
+    for (uint32_t i = 0; i < n_pages; i++) {
+        uint64_t va_i   = gpu_va_base + (uint64_t)i * 4096ull;
+        uint64_t phys_i = phys_base   + (uint64_t)i * 4096ull;
+        if (map_one_page(pdb_phys, va_i, phys_i, 0) < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
+                                   const struct ga10b_channel_handoff *h)
+{
+    if (h == NULL) {
+        return -1;
+    }
+    if (!phys_in_dram(inst_block_phys, 4096)) {
+        return -1;
+    }
+
+    /* 1. Allocate a fresh PDB page from SLM-OS PMM. Zero it so
+     *    every PDE3 entry reads as invalid until `map_one_page`
+     *    populates the ones it needs. */
+    void *pdb_page = alloc_zero_table_page();
+    if (pdb_page == NULL) {
+        uart_puts("[rebuild-gmmu] PMM exhausted allocating PDB\n");
+        return -1;
+    }
+    uint64_t pdb_phys = (uint64_t)(uintptr_t)pdb_page;
+    uart_printf("[rebuild-gmmu] fresh PDB at phys=0x%lx\n",
+                (unsigned long)pdb_phys);
+
+    /* 2. Zero the inst block (Stage 1 reservation kept the page
+     *    around but Linux may have left non-zero residue) and
+     *    write the PDB pointer at words 128-129 (byte offsets
+     *    512/516) per `ram_in_page_dir_base_lo_w()`/`_hi_w()`. */
+    volatile uint32_t *inst = (volatile uint32_t *)(uintptr_t)inst_block_phys;
+    for (int i = 0; i < 1024; i++) {
+        inst[i] = 0;
+    }
+
+    /* Encode PDB-lo word: aperture (sys_mem_ncoh on Tegra),
+     * volatile bit, ver2 page-table format, 64 KB big-page size,
+     * and phys[31:12] in bits [31:12] (the bottom 12 bits of phys
+     * are zero by page alignment). */
+    uint32_t pdb_lo_word =
+        GA10B_RAM_IN_PDB_TARGET_SYS_NCOH |
+        GA10B_RAM_IN_PDB_VOL_TRUE |
+        GA10B_RAM_IN_USE_VER2_PT_FORMAT |
+        GA10B_RAM_IN_BIG_PAGE_SIZE_64KB |
+        (uint32_t)(pdb_phys & 0xfffff000u);
+    uint32_t pdb_hi_word = (uint32_t)(pdb_phys >> 32);
+
+    inst[128] = pdb_lo_word;
+    inst[129] = pdb_hi_word;
+    cache_clean_range((void *)(uintptr_t)inst_block_phys, 4096);
+
+    uart_printf("[rebuild-gmmu] inst_block@0x%lx written: "
+                "PDB_lo=0x%08x PDB_hi=0x%08x\n",
+                (unsigned long)inst_block_phys,
+                (unsigned)pdb_lo_word, (unsigned)pdb_hi_word);
+
+    /* 3. Map each preserved buffer at its original GPU VA. The
+     *    handoff publishes (phys, gpu_va, size) for every dmabuf
+     *    the helper allocated; we replay those mappings into the
+     *    fresh PDB tree.
+     *
+     *    USERD and GPFIFO are accessed by PBDMA via physical
+     *    addresses (not GPU VAs), so they don't need GMMU
+     *    mappings — skip them.
+     *
+     *    Buffers that DO need GMMU mappings (Pushbuffer +
+     *    Semaphore + SASS pool + cbuf + QMD pool + weights pool
+     *    first-page) are mapped below. Anything with size=0 or
+     *    gpu_va=0 is skipped — that means the helper didn't
+     *    allocate that buffer for this channel. */
+    struct rebuild_buf {
+        const char *tag;
+        uint64_t phys;
+        uint64_t gpu_va;
+        uint64_t size_bytes;
+    };
+
+    struct rebuild_buf bufs[] = {
+        { "pushbuf", h->pushbuf_phys, h->pushbuf_gpu_va,
+          (uint64_t)h->pushbuf_size },
+        { "sem", h->semaphore_phys, h->semaphore_gpu_va, 4096 },
+        { "shader", h->shader_phys, h->shader_gpu_va,
+          (uint64_t)h->shader_size },
+        { "cbuf", h->cbuf_phys, h->cbuf_gpu_va,
+          (uint64_t)h->cbuf_size },
+        { "qmd_pool", h->qmd_pool_phys, h->qmd_pool_gpu_va,
+          (uint64_t)h->qmd_pool_size_bytes },
+        /* Weights pool: only the first physical page's phys is
+         * known. The 1.5 GB region is SMMU-stitched from
+         * scattered pages so a single (phys, size) reserve
+         * doesn't cover the rest. Map the first page so the
+         * caller can at least chunk-0-test W3 staging; further
+         * pages will MMU-fault and the wedge handler will dump. */
+        { "weights_first", h->weights_pool_phys, h->weights_pool_gpu_va,
+          (h->weights_pool_size_bytes != 0) ? 4096ull : 0ull },
+    };
+
+    int mapped = 0;
+    for (size_t i = 0; i < sizeof(bufs) / sizeof(bufs[0]); i++) {
+        const struct rebuild_buf *b = &bufs[i];
+        if (b->size_bytes == 0 || b->phys == 0 || b->gpu_va == 0) {
+            uart_printf("[rebuild-gmmu]  skip %-14s (not allocated)\n",
+                        b->tag);
+            continue;
+        }
+        uint32_t n_pages = (uint32_t)((b->size_bytes + 4095u) / 4096u);
+        if (rebuild_map_range(pdb_phys, b->gpu_va, b->phys,
+                               n_pages) < 0) {
+            uart_printf("[rebuild-gmmu]  FAIL %-14s gpu_va=0x%lx "
+                        "phys=0x%lx pages=%u\n",
+                        b->tag, (unsigned long)b->gpu_va,
+                        (unsigned long)b->phys, (unsigned)n_pages);
+            return -1;
+        }
+        uart_printf("[rebuild-gmmu]  ok   %-14s gpu_va=0x%lx "
+                    "phys=0x%lx pages=%u\n",
+                    b->tag, (unsigned long)b->gpu_va,
+                    (unsigned long)b->phys, (unsigned)n_pages);
+        mapped++;
+    }
+
+    /* Amortized dsb sy so all PTE writes are visible to the GPU
+     * before TLB invalidate fires (matches the `dsb sy` at the
+     * tail of `ga10b_gmmu_alloc` for the same reason). */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    /* 4. Flush any TLB entries the GPU might have cached against
+     *    the old PDB-tree state. `ga10b_gmmu_tlb_invalidate`
+     *    targets the new PDB phys so the next walk loads fresh
+     *    PTEs from the tree we just built. */
+    int rc = ga10b_gmmu_tlb_invalidate(pdb_phys);
+    uart_printf("[rebuild-gmmu] TLB invalidate rc=%d, %d buffer(s) "
+                "mapped\n", rc, mapped);
+    return (rc == 0) ? 0 : -1;
+}
+
 /* Try to satisfy an allocation of `n_pages` from the free-extent
  * tracker (exact-fit). Returns the freed VA on success, removing
  * its slot; returns 0 on miss (caller falls through to the bump

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -356,6 +356,68 @@ uint64_t ga10b_gmmu_discover_inst_block_phys(void);
  * and does not intersect the OP-TEE carveout. */
 bool ga10b_phys_in_dram(uint64_t phys, size_t bytes);
 
+/* Forward decl — full struct is in `ga10b_channel_handoff.h`,
+ * pulled in by the rebuild path's translation unit. Declaring here
+ * lets callers of `ga10b_gmmu_rebuild_for_handoff` work with an
+ * opaque pointer if they only need the function signature. */
+struct ga10b_channel_handoff;
+
+/* #788 Stage 2 — rebuild a fresh GMMU page-table tree for a kexec'd
+ * channel and write the inst block to point at it.
+ *
+ * Use case: after Linux kexecs, nvgpu's module .shutdown handler
+ * frees the channel's PDB + page tables. The inst-block page
+ * survives via the Stage 1 `pmm_user_reserve_add` reservation, but
+ * its contents (PDB pointer, ramfc state) are gone. The helper's
+ * USER-allocated buffers (pushbuffer, semaphore, SASS pool, etc.)
+ * survive intact because the helper's open file descriptors keep
+ * Linux from reclaiming them.
+ *
+ * This function rebuilds:
+ *
+ *   1. A fresh PDB page allocated from SLM-OS PMM, zeroed so every
+ *      PDE3 entry reads invalid until mapped.
+ *   2. The inst block at `inst_block_phys` — overwritten with a
+ *      valid PDB pointer (sys_mem_ncoh aperture, volatile, ver2
+ *      page-table format, 64 KB big-page size) and zeroed
+ *      elsewhere.
+ *   3. PTEs in the new tree mapping each preserved dmabuf from the
+ *      handoff at its original GPU VA: pushbuf, semaphore, SASS
+ *      pool (shader_*), cbuf, QMD pool, and the first 4 KB of the
+ *      weights pool. USERD and GPFIFO are PBDMA-accessed via phys
+ *      and don't need GMMU entries.
+ *   4. TLB invalidate against the new PDB so the GPU loads fresh
+ *      PTEs on the next walk.
+ *
+ * **Limitations:**
+ *
+ *   - Weights pool beyond its first page is NOT mapped. The 1.5 GB
+ *     IOVMM allocation is SMMU-stitched from physically-scattered
+ *     pages; the handoff publishes only the first page's phys.
+ *     `slm xload qwen`'s W3 staging will succeed for the first 4
+ *     KB chunk only; further chunks MMU-fault. A future helper
+ *     enhancement could enumerate per-page phys via
+ *     /proc/self/pagemap pre-kexec.
+ *
+ *   - GR engine ctxsw save buffer is NOT rebuilt. nvgpu allocates
+ *     this lazily on first GR engagement; if FECS tries to save a
+ *     context during the rebuilt channel's life, the save will
+ *     fault. The MVP doesn't attempt to recreate it; if hardware
+ *     testing shows it's needed, a future revision will allocate a
+ *     save buffer and patch the inst block's engine_wfi fields.
+ *
+ *   - The runlist on the GPU still references the OLD inst-block
+ *     physical address (because that's where nvgpu wrote it
+ *     pre-kexec). The Stage 1 reservation keeps that page intact;
+ *     this function fills it with valid contents so the runlist's
+ *     reference becomes meaningful again. No runlist edit needed.
+ *
+ * Returns 0 on success, -1 on PMM exhaustion / invalid inst_phys /
+ * mapping failure / TLB-invalidate timeout. All UART-logged so the
+ * caller can correlate failures with the boot-time trace. */
+int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
+                                   const struct ga10b_channel_handoff *h);
+
 /* Discover the inherited channel's inst block by walking DRAM and
  * cross-checking each candidate against a known (gpu_va, leaf_phys)
  * pair from the channel handoff. Used as a fallback when

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4576,6 +4576,39 @@ int cmd_nvgpu(int argc, char *argv[])
         ga10b_dump_inst_blocks_atomic("nvgpu-instdump");
         return 0;
     }
+    if (strcmp(argv[1], "rebuild-gmmu") == 0) {
+        /* #788 Stage 2: allocate a fresh PDB tree in SLM-OS,
+         * overwrite the inst block's PDB pointer, and re-install
+         * PTEs mapping every preserved dmabuf at its original GPU
+         * VA. See `ga10b_gmmu_rebuild_for_handoff` in
+         * ga10b_gmmu.c.
+         *
+         * Requires `nvgpu channel` to have run first (so the
+         * handoff is loaded). Reads `inst_block_phys` from
+         * FECS_CURRENT_CTX — the runlist still references that
+         * physical page, so filling it with valid contents is
+         * what makes the channel usable post-kexec.
+         *
+         * Usage:
+         *   nvgpu rebuild-gmmu     — rebuild against the handoff
+         *                            and FECS_CURRENT_CTX */
+        const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+        if (h == NULL || h->magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
+            shell_puts("rebuild-gmmu: handoff not loaded — "
+                       "run `nvgpu channel` first\r\n");
+            return -1;
+        }
+        uint64_t inst_phys = ga10b_gmmu_discover_inst_block_phys();
+        if (inst_phys == 0) {
+            shell_puts("rebuild-gmmu: FECS_CURRENT_CTX returned no "
+                       "current ctx (target=0)\r\n");
+            return -1;
+        }
+        int rc = ga10b_gmmu_rebuild_for_handoff(inst_phys, h);
+        shell_printf("rebuild-gmmu: rc=%d (inst_phys=0x%lx)\r\n",
+                     rc, (unsigned long)inst_phys);
+        return rc;
+    }
     if (strcmp(argv[1], "engine-clear") == 0) {
         return cmd_nvgpu_engine_clear();
     }


### PR DESCRIPTION
**Stacked on #801 (Stage 1).** Review Stage 1 first; this PR's base will auto-update to \`main\` once Stage 1 merges.

## Summary

Adds \`ga10b_gmmu_rebuild_for_handoff()\` — allocates a fresh PDB page in SLM-OS PMM, writes a valid PDB pointer at the inherited inst block's word 128/129 (encoded sys_mem_ncoh + vol + ver2 + 64kb big-page), and replays PTEs for every handoff-published dmabuf at its original GPU VA. Exposed via \`nvgpu rebuild-gmmu\` shell verb.

Builds on the user-reserve infrastructure landed in #801 — the rebuild writes into the inst-block page that Stage 1 reserved.

## Hardware verification on jetson-nano-1 (2026-05-12)

Test sequence: helper → kexec → \`nvgpu inherit / channel / rebuild-gmmu / instdump\`.

\`\`\`
nvgpu rebuild-gmmu
[rebuild-gmmu] fresh PDB at phys=0x1218d6000
[rebuild-gmmu] inst_block@0x1218d5000 written: PDB_lo=0x218d6c07 PDB_hi=0x00000001
[rebuild-gmmu]  ok   pushbuf        gpu_va=0x1ffc000000 phys=0x133e50000 pages=16
[rebuild-gmmu]  ok   sem            gpu_va=0x1ffc010000 phys=0x143f7c000 pages=1
[rebuild-gmmu]  ok   shader         gpu_va=0x1ffc100000 phys=0x133ea0000 pages=256
[rebuild-gmmu]  ok   cbuf           gpu_va=0x1ffc011000 phys=0x13778c000 pages=1
[rebuild-gmmu]  ok   qmd_pool       gpu_va=0x1ffc040000 phys=0x133e60000 pages=64
[rebuild-gmmu]  skip weights_first  (not allocated)
[rebuild-gmmu] TLB invalidate rc=0, 5 buffer(s) mapped
rebuild-gmmu: rc=0 (inst_phys=0x1218d5000)

peek 0x1218d5200 4
[0x1218d5200] 218d6c07 00000001 00000000 00000000
\`\`\`

Inst block now contains a valid PDB pointer (was all-zeros or random garbage before — see #797 \`nvgpu instdump\` captures).

## What this PR fixes

**\`FECS_ERROR_PENDING\` is eliminated.** The original #788 wedge signature (\`gr_intr=0x00080000\` / \`fault_during_ctxsw\` / \`fault_info=0x80110a02\` / \`INVALID_PDE\` at VA 0xc01000) no longer fires. \`nvgpu submit\` post-rebuild reports clean \`gr_intr=0, fecs_host_int=0, ctxsw_mb6=0\` — no FECS error, no MMU fault.

## Known limitation: PBDMA still doesn't pick up submits

Stage 2 only writes the PDB pointer. The other inst-block sections — **RAMFC** (gpfifo base, USERD pointer, signature, pb_header, subdevice, target, acquire, set_channel_info) and **engine_wfi** (engine bindings + VEID) — remain zero from the \`memset(0)\` Stage 2 does before writing the PDB.

\`nvgpu submit\` post-rebuild reports \`GP_GET did not advance\` — PBDMA reads the inst block, sees \`gpfifo_phys=0\`, has nothing to fetch.

**Stage 3 (next PR) will populate the RAMFC fields per nvgpu's \`ga10b_ramfc_setup\`:**
- \`ram_fc_gp_base_w() / _hi_w()\` = encoded gpfifo phys (from handoff)
- \`ram_fc_signature_w()\` = chip-specific signature value (HAL op)
- \`ram_fc_pb_header_w()\` = HAL-defined pb header
- \`ram_fc_subdevice_w()\` = HAL-defined subdevice
- \`ram_fc_target_w()\` = engine-bound aperture
- \`ram_fc_acquire_w()\` = pbdma acquire timeout encoded
- \`ram_fc_set_channel_info_w()\` = chid + veid (from handoff)
- \`ram_in_engine_wfi_veid_w()\` = VEID for engine WFI

Each needs the bit encoding from L4T \`hw_ram_ga10b.h\` plus the HAL-defined opaque values. The GMMU rebuild infrastructure (PDB alloc + PTE install + TLB invalidate) landing here is reusable scaffolding for Stage 3.

## Why land Stage 2 now without Stage 3

1. **Strict improvement.** One fault class (FECS_ERROR_PENDING / INVALID_PDE) eliminated. The diagnostic signature is now cleaner — \`gr_intr=0\` instead of a noisy FECS error — which makes the remaining failure tractable.
2. **Reusable scaffolding.** Stage 3 only needs to add RAMFC writes to the same code path; it doesn't have to re-derive PDB encoding, page-table installation, or TLB-invalidate flow.
3. **Independent review surface.** PDB tree construction and RAMFC encoding are different reverse-engineering tasks; reviewing them separately is cleaner than one mega-PR.

## Test plan

- [x] \`make test\` passes (QEMU ARM64; the rebuild path itself can't be exercised in QEMU because there's no inherited channel, but the existing GMMU walker / page-table-allocator tests cover the primitives the rebuild uses)
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` builds clean
- [x] \`make kernel PLATFORM=RASPI5\` builds clean (the rebuild function is in \`ga10b_gmmu.c\` which is Jetson-only per CMakeLists)
- [x] Hardware test on jetson-nano-1: \`nvgpu rebuild-gmmu\` reports success, inst block contains valid PDB pointer, \`nvgpu submit\` no longer triggers the FECS_ERROR_PENDING wedge

🤖 Generated with [Claude Code](https://claude.com/claude-code)