### PR TITLE
host-tools(hailo-re): HailoRT-in-VM capture environment — #795 Phase 0 Task 0.3

### DIFF
--- a/host-tools/hailort-vm/README.md
+++ b/host-tools/hailort-vm/README.md
@@ -94,7 +94,7 @@ The determinism check is the load-bearing deliverable of Task 0.3 — see [§ De
 │  │  │   - built hailo_pci.ko via DKMS                        │  │   │
 │  │  │   - disabled ASLR, NTP, irqbalance, ...                │  │   │
 │  │  │                                                        │  │   │
-│  │  │  20-capture-run.sh runs at first boot:                 │  │   │
+│  │  │  20-capture-run.sh runs once per capture boot:         │  │   │
 │  │  │   1. modprobe hailo_pci  (auto-binds to Hailo IDs)     │  │   │
 │  │  │   2. taskset -c 0 hailortcli fw-control identify       │  │   │
 │  │  │   3. shutdown -h now                                   │  │   │
@@ -129,7 +129,7 @@ Mitigations applied (all enforced via `cloud-init/user-data` + `guest-scripts/00
 | Telemetry / hailo-monitor | Not installed in the .deb chain we use; `systemctl mask hailo-monitor.service` defensively |
 | HailoRT internal async paths | TBD: `HAILORT_LOGGER_PATH` + `HAILORT_CONSOLE_LOGGER_LEVEL=trace` to inspect post-capture; if async pre-fetch is observed, set `HAILO_DISABLE_ASYNC=1` (or whatever the v4.23 env knob is — discover during capture) |
 | QEMU CPU-mode jitter | `-cpu host,migratable=no` under KVM; `-smp 1` for the capture VM |
-| Wall-clock dependent code paths | Boot the guest with `clocksource=hpet` and a fixed RTC base (`-rtc base=2026-05-12T00:00:00,clock=vm`) |
+| Wall-clock dependent code paths | Fixed RTC base via `-rtc base=2026-05-12T00:00:00,clock=vm` (guest's `time()` returns a deterministic starting point each boot) |
 
 `verify-determinism.sh` runs two captures back-to-back from the same cold qcow2 snapshot and diffs the trace files. Expected result: byte-for-byte match. Any divergence is documented in this README under [§ Observed determinism](#observed-determinism) below.
 

--- a/host-tools/hailort-vm/README.md
+++ b/host-tools/hailort-vm/README.md
@@ -1,0 +1,169 @@
+# HailoRT-in-VM capture environment
+
+Task 0.3 of [#795](https://github.com/SLM-OS/SLM-Operating-System/issues/795). Stands up a reproducible QEMU/KVM VM that runs Hailo's proprietary HailoRT userspace runtime (`libhailort.so` + `hailortcli`) against an emulated PCIe device, so every BAR R/W operation HailoRT issues during device probe / IDENTIFY / Configure() / Activate() can be recorded into the corpus format defined in [`docs/hailo-re-corpus-format.md`](../../docs/hailo-re-corpus-format.md).
+
+This directory contains environment + automation. No SLM-OS or HailoRT source lives here; the HailoRT `.deb` packages must be obtained separately from Hailo's developer portal — see [§ Obtaining HailoRT](#obtaining-hailort).
+
+## Status
+
+Phase 0 scaffolding. Pre-integration with [Task 0.2 (QEMU stub device)](https://github.com/SLM-OS/SLM-Operating-System/issues/795).
+
+Until Task 0.2 lands a corpus-driven Hailo stub, this environment uses a **stub-stub**: a ~150-line QEMU device patch (`qemu-patch/hw/misc/hailo-stub-stub.c`) that advertises Hailo-8 PCI IDs (0x1e60:0x2864) and three BARs (4 KB / 16 KB / 1 MB) where every read returns 0 and writes are discarded. That's enough for the upstream `hailo_pci` driver to probe successfully and for HailoRT to begin issuing MMIO. Trace capture goes through QEMU's `--trace memory_region_ops_*` channel and is post-processed into the corpus format.
+
+Why a separate stub-stub instead of just using the QEMU `edu` device: `edu` exposes only BAR0. The Hailo driver hard-requires BAR0 + BAR2 + BAR4 to be present and non-zero-size — it fails probe with `Invalid PCIe BAR 2` against any device with fewer BARs. Hence the minimal patch.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `README.md` | This file |
+| `build-qemu.sh` | Fetches QEMU 8.2 source, applies the hailo-stub-stub patch, builds a custom `qemu-system-x86_64` binary. Output: `~/slmos-ref/derivatives/hailort-vm-qemu/qemu-system-x86_64` |
+| `build-vm-image.sh` | Builds a customized Ubuntu 24.04 qcow2 via cloud-init seed ISO. Output: `~/slmos-ref/derivatives/hailort-vm-images/`, **not in this repo** |
+| `launch-capture.sh` | Boots the qcow2 with the custom QEMU + `-device hailo-stub-stub`, captures MMIO trace, emits a corpus JSONL |
+| `verify-determinism.sh` | Runs `launch-capture.sh` twice from a cold snapshot, diffs the traces, reports match / first divergence |
+| `qemu-patch/hw/misc/hailo-stub-stub.c` | Minimal QEMU PCI device with Hailo-8 IDs (0x1e60:0x2864) and three BARs (4 KB / 16 KB / 1 MB). Reads return 0; writes are discarded. Throwaway placeholder for Task 0.2's real stub |
+| `qemu-patch/apply.sh` | Copies hailo-stub-stub.c into a QEMU source tree and registers it in `hw/misc/meson.build` |
+| `cloud-init/user-data` | First-boot cloud-init config: user account, package install, dpkg of the HailoRT `.deb`s, determinism tweaks |
+| `cloud-init/meta-data` | cloud-init NoCloud meta-data (instance-id, hostname) |
+| `guest-scripts/00-determinism.sh` | Disables ASLR, NTP, telemetry, irqbalance, tuned, etc. Inside the guest |
+| `guest-scripts/10-bind-stub.sh` | Loads `hailo_pci`; the kernel auto-probes the hailo-stub-stub device via its Hailo IDs (`new_id` only needed in the edu-fallback path) |
+| `guest-scripts/20-capture-run.sh` | Runs `taskset -c 0 hailortcli fw-control identify` (and exits cleanly so QEMU snapshot ends) |
+| `tools/qemu-trace-to-corpus.py` | Parses QEMU `--trace memory_region_ops_read,memory_region_ops_write` output into the corpus JSONL format |
+
+## Prerequisites (host)
+
+- Ubuntu 22.04+ / Debian 12+ host with `qemu-system-x86_64` ≥ 8.0, `qemu-img`, `genisoimage` (or `xorriso`), `curl`, `python3` ≥ 3.10.
+- KVM enabled and `/dev/kvm` accessible by the invoking user. Verify with `qemu-system-x86_64 -accel help | grep kvm`. The build runs in TCG if KVM is unavailable but is ~10× slower.
+- For building the custom QEMU: `build-essential`, `ninja-build`, `pkg-config`, `meson`, `libglib2.0-dev`, `libpixman-1-dev`, `libslirp-dev`, `python3-pip`.
+- ~6 GB free in `~/slmos-ref/derivatives/hailort-vm-images/` (Ubuntu cloud image + working qcow2).
+- ~3 GB free in `/var/tmp/qemu-stub-build/` for the QEMU build tree (override with `QEMU_BUILD_ROOT`; must be a path **without spaces** — QEMU's configure script can't handle them).
+
+## Obtaining HailoRT
+
+The HailoRT `.deb` packages are not freely redistributable. Download them from Hailo's developer portal (login required) and place them at:
+
+```
+~/Downloads/hailort_4.23.0_amd64.deb            # libhailort + hailortcli (userspace)
+~/Downloads/hailort-pcie-driver_4.23.0_all.deb  # DKMS source for hailo_pci.ko
+```
+
+Or set `HAILORT_DEB_DIR=<path>` to override the location. `build-vm-image.sh` will sha256-check these and fail loudly if they don't match the pinned values.
+
+**Pinned versions (HailoRT v4.23.0, 2026-05-12):**
+
+| File | sha256 | Notes |
+|---|---|---|
+| `hailort_4.23.0_amd64.deb` | _TBD on first build — script will print observed sha and persist it_ | Must match the version running on pi-5-1 — see CLAUDE.md / memory `hailo_fw_v4_23_struct_sizes.md` |
+| `hailort-pcie-driver_4.23.0_all.deb` | `36e308eb492808db9db7c64046e3fdfb3e4e02fdfd67550db678f068869c1fbf` | Arch-independent DKMS package — same file used on pi-5-1 |
+
+The arm64 build (`hailort_4.23.0_arm64.deb`, sha256 `344c7432e8240b666f7817226e5bdface02902380904432caa639fdb09e67417`) is what pi-5-1 has installed. The amd64 build of the **same upstream release** is what we need for the x86_64 VM; Hailo distributes both side-by-side on their portal.
+
+## Quick start
+
+```bash
+# One-time: build the custom QEMU with the 3-BAR stub-stub device (~10-20 min).
+./build-qemu.sh
+
+# One-time: build the VM image (~5 minutes on first run, cached afterwards).
+./build-vm-image.sh
+
+# Run a single capture.
+./launch-capture.sh ~/slmos-ref/derivatives/hailo-re-corpora/test.jsonl
+
+# Run the determinism check (two captures + byte-for-byte diff).
+./verify-determinism.sh
+```
+
+The determinism check is the load-bearing deliverable of Task 0.3 — see [§ Determinism](#determinism).
+
+## How capture works
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ host (this machine)                                                 │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │ qemu-system-x86_64 (custom build with hailo-stub-stub)       │   │
+│  │  --trace memory_region_ops_{read,write}                      │   │
+│  │  -device hailo-stub-stub     ← Hailo IDs, BAR0/2/4, reads=0  │   │
+│  │  -serial file:...            ← guest-side trace markers      │   │
+│  │                                                              │   │
+│  │  ┌──────────────────── guest (Ubuntu 24.04) ──────────────┐  │   │
+│  │  │  cloud-init has already:                               │  │   │
+│  │  │   - installed HailoRT v4.23 (.deb)                     │  │   │
+│  │  │   - built hailo_pci.ko via DKMS                        │  │   │
+│  │  │   - disabled ASLR, NTP, irqbalance, ...                │  │   │
+│  │  │                                                        │  │   │
+│  │  │  20-capture-run.sh runs at first boot:                 │  │   │
+│  │  │   1. modprobe hailo_pci  (auto-binds to Hailo IDs)     │  │   │
+│  │  │   2. taskset -c 0 hailortcli fw-control identify       │  │   │
+│  │  │   3. shutdown -h now                                   │  │   │
+│  │  └────────────────────────────────────────────────────────┘  │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                          │                                          │
+│                          ▼                                          │
+│                  qemu-trace.log                                     │
+│                          │                                          │
+│            tools/qemu-trace-to-corpus.py                            │
+│                          │                                          │
+│                          ▼                                          │
+│   ~/slmos-ref/derivatives/hailo-re-corpora/...jsonl                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+`memory_region_ops_read` and `memory_region_ops_write` fire on **every** MMIO trap regardless of accelerator (KVM dispatches MMIO faults to QEMU, where the device's `MemoryRegionOps` callbacks run and the trace points fire). The captured stream is complete for the stub-stub device. Once Task 0.2 lands a corpus-driven stub, this same trace machinery applies to its BAR0/2/4 regions — `qemu-trace-to-corpus.py`'s `BAR_NAME_MAP` already accepts both names.
+
+## Determinism
+
+The single most important question Task 0.3 answers: **is HailoRT's BAR write sequence deterministic across runs?** If not, the entire RE plan in #795 is unviable (capture would record a different protocol every iteration).
+
+Mitigations applied (all enforced via `cloud-init/user-data` + `guest-scripts/00-determinism.sh`):
+
+| Source of non-determinism | Mitigation |
+|---|---|
+| Address-space layout randomization | `echo 0 > /proc/sys/kernel/randomize_va_space` |
+| Scheduler placement across cores | `taskset -c 0 hailortcli ...` |
+| Background daemons issuing parallel I/O | Mask `systemd-timesyncd`, `unattended-upgrades`, `irqbalance`, `tuned`, `snapd`, `cron`, `apt-daily*.timer` |
+| Network/DNS lookups during HailoRT init | Guest has no NIC except hostfwd; no resolvers reachable |
+| Kernel-side IRQ ordering | Pin all IRQs to CPU 0 (`/proc/irq/default_smp_affinity = 1`) |
+| Telemetry / hailo-monitor | Not installed in the .deb chain we use; `systemctl mask hailo-monitor.service` defensively |
+| HailoRT internal async paths | TBD: `HAILORT_LOGGER_PATH` + `HAILORT_CONSOLE_LOGGER_LEVEL=trace` to inspect post-capture; if async pre-fetch is observed, set `HAILO_DISABLE_ASYNC=1` (or whatever the v4.23 env knob is — discover during capture) |
+| QEMU CPU-mode jitter | `-cpu host,migratable=no` under KVM; `-smp 1` for the capture VM |
+| Wall-clock dependent code paths | Boot the guest with `clocksource=hpet` and a fixed RTC base (`-rtc base=2026-05-12T00:00:00,clock=vm`) |
+
+`verify-determinism.sh` runs two captures back-to-back from the same cold qcow2 snapshot and diffs the trace files. Expected result: byte-for-byte match. Any divergence is documented in this README under [§ Observed determinism](#observed-determinism) below.
+
+### Observed determinism
+
+| Date | HailoRT version | Run-A vs Run-B | First divergence (seq, offset) | Notes |
+|---|---|---|---|---|
+| 2026-05-12 | 4.23.0 | **MATCH** — 19/19 op entries identical byte-for-byte | none | First end-to-end run. `hailortcli fw-control identify` against the hailo-stub-stub device. All 19 ops on BAR0; mix of reads (probe + vendor/fw-loaded magic) + writes (driver init + FW_CONTROL ioctl). Driver eventually returns `Failed writing fw control to pcie` because the stub doesn't fake any of the fw_control request/response handshake — but the **write sequence up to that failure point reproduces exactly**. That is the capture invariant the rest of #795 needs. |
+
+**Implication for #795**: the strict single-step + corpus discipline in [`docs/hailo-re-corpus-format.md`](../../docs/hailo-re-corpus-format.md) is viable. Task 0.2 can build its corpus-driven stub knowing that re-running HailoRT against the same stub responses will produce the same write sequence — no race-driven non-determinism observed at this stage. Re-validate once Task 0.2's stub lands (the MMIO surface will be larger; this run only covers the first 19 ops).
+
+## Hand-off to Task 0.2
+
+The stub-stub QEMU patch is throwaway. Once Task 0.2 lands a corpus-driven Hailo stub:
+
+1. Replace `-device hailo-stub-stub` in `launch-capture.sh` with `-device hailo-stub,corpus=<path>` (or whichever invocation Task 0.2 ships).
+2. `qemu-patch/hw/misc/hailo-stub-stub.c` becomes redundant — Task 0.2's device replaces it. Delete `build-qemu.sh` and the patch tree.
+3. `guest-scripts/10-bind-stub.sh`'s fallback branch (for the edu device) becomes dead code; keep it or trim.
+4. Either keep `tools/qemu-trace-to-corpus.py` as the trace post-processor or switch to Task 0.2's direct-emit path (the stub writes corpus entries itself, no post-processing needed).
+
+The VM image, cloud-init, and determinism harness all stay the same. Integration cost is ~30 minutes once 0.2 has a working stub.
+
+## Workflow rules
+
+- **No HailoRT source in this repo.** The local reference cache at `~/slmos-ref/hailo/v4.23.0/` is read-only. Don't copy contents into this directory.
+- **HailoRT `.deb` packages stay out of git.** The README directs the user to obtain them manually; the build script verifies sha256s.
+- **VM disk images stay out of git.** They land in `~/slmos-ref/derivatives/hailort-vm-images/`.
+- **Corpora stay out of git.** They land in `~/slmos-ref/derivatives/hailo-re-corpora/`.
+- Per top-level `CLAUDE.md`: no emoji; branch + PR; ask before commit; second-person avoided.
+
+## References
+
+- Issue #795 — full RE plan, parallelization layout, Phase 0 task table.
+- `docs/hailo-re-corpus-format.md` — the on-disk schema this environment feeds.
+- `docs/hailo-protocol-architecture.md` — context: what HailoRT does on a real MNIST load (84,003 inferences, 27 fw_control calls, all IDENTIFY).
+- Memory pointers: `hailo_re_plan_qemu_capture.md`, `hailort_protocol_architecture.md`.
+- HailoRT v4.23 reference cache: `~/slmos-ref/hailo/v4.23.0/` (kernel-side driver only — no userspace source).

--- a/host-tools/hailort-vm/build-qemu.sh
+++ b/host-tools/hailort-vm/build-qemu.sh
@@ -108,7 +108,12 @@ fi
 "${PATCH_DIR}/apply.sh" "${SRC_DIR}"
 
 # ---------------------------------------------------------------------------
-# Configure (minimal — just x86_64-softmmu, KVM, slirp, no GUI)
+# Configure (minimal — just x86_64-softmmu, KVM, slirp, no GUI).
+#
+# We wipe the build dir unconditionally because QEMU's meson-based configure
+# is sensitive to leftover state from prior `configure` runs (especially when
+# the apply.sh patch is iterated). Incremental rebuilds are not worth the
+# debugging cost; full rebuild is ~3-4 min on a modern host.
 # ---------------------------------------------------------------------------
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"

--- a/host-tools/hailort-vm/build-qemu.sh
+++ b/host-tools/hailort-vm/build-qemu.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Fetch upstream QEMU source, apply the hailo-stub-stub patch, and build a
+# host-local qemu-system-x86_64 binary. Caches the source tarball and the
+# built tree so re-runs are fast.
+#
+# Output: ~/slmos-ref/derivatives/hailort-vm-qemu/qemu-system-x86_64
+#
+# launch-capture.sh prefers this binary if present.
+#
+# This is throwaway: Task 0.2 ships a corpus-driven stub that this script's
+# binary will be retired in favour of.
+
+set -euo pipefail
+
+QEMU_VERSION="${QEMU_VERSION:-8.2.10}"
+QEMU_URL="${QEMU_URL:-https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz}"
+# Final binary destination — can be anywhere (including paths with spaces).
+QEMU_OUT_DIR="${QEMU_OUT_DIR:-$HOME/slmos-ref/derivatives/hailort-vm-qemu}"
+# Working directory MUST live on a path without spaces. QEMU's configure script
+# splits $python on whitespace at line ~955, which breaks when the source/build
+# tree resolves through a path containing spaces (e.g. our ~/slmos-ref symlink
+# targets "/home/dropbox/Dropbox/Projects/SLM-OS Reference Library/").
+QEMU_BUILD_ROOT="${QEMU_BUILD_ROOT:-/var/tmp/qemu-stub-build}"
+JOBS="${JOBS:-$(nproc)}"
+FORCE_REBUILD=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force) FORCE_REBUILD=1; shift;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# //; s/^#//'
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 2;;
+    esac
+done
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PATCH_DIR="${HERE}/qemu-patch"
+
+mkdir -p "${QEMU_OUT_DIR}" "${QEMU_BUILD_ROOT}"
+
+WORK_DIR="${QEMU_BUILD_ROOT}"
+SRC_DIR="${WORK_DIR}/qemu-${QEMU_VERSION}"
+TARBALL="${WORK_DIR}/qemu-${QEMU_VERSION}.tar.xz"
+BUILD_DIR="${WORK_DIR}/build"
+OUT_BIN="${QEMU_OUT_DIR}/qemu-system-x86_64"
+
+# Refuse to build through a path containing spaces.
+if [[ "${WORK_DIR}" == *" "* ]]; then
+    echo "ERROR: build root ${WORK_DIR} contains spaces; QEMU configure cannot handle this." >&2
+    echo "       Set QEMU_BUILD_ROOT to a space-free path." >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Short-circuit if binary exists
+# ---------------------------------------------------------------------------
+if [[ -x "${OUT_BIN}" && "${FORCE_REBUILD}" -eq 0 ]]; then
+    echo "Custom QEMU already built: ${OUT_BIN}"
+    "${OUT_BIN}" --version | head -1
+    if "${OUT_BIN}" -device help 2>&1 | grep -q hailo-stub-stub; then
+        echo "Confirmed: -device hailo-stub-stub is registered."
+        exit 0
+    else
+        echo "Binary exists but hailo-stub-stub not registered. Rebuilding." >&2
+        FORCE_REBUILD=1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Build dependencies (system packages — required for QEMU configure step)
+# ---------------------------------------------------------------------------
+need_pkg() {
+    dpkg -l "$1" 2>/dev/null | grep -q '^ii' && return 0
+    echo "Missing apt package: $1 (sudo apt install $1)" >&2
+    return 1
+}
+MISSING=0
+for p in ninja-build python3-pip pkg-config libglib2.0-dev libpixman-1-dev libslirp-dev meson; do
+    need_pkg "$p" || MISSING=$((MISSING+1))
+done
+if [[ ${MISSING} -gt 0 ]]; then
+    echo "Install the packages above and re-run." >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch tarball
+# ---------------------------------------------------------------------------
+if [[ ! -f "${TARBALL}" ]]; then
+    echo "Downloading ${QEMU_URL}..."
+    curl -fL --output "${TARBALL}.partial" "${QEMU_URL}"
+    mv "${TARBALL}.partial" "${TARBALL}"
+fi
+
+# ---------------------------------------------------------------------------
+# Extract (idempotent)
+# ---------------------------------------------------------------------------
+if [[ ! -d "${SRC_DIR}" ]]; then
+    echo "Extracting ${TARBALL}..."
+    tar -xJf "${TARBALL}" -C "${WORK_DIR}"
+fi
+
+# ---------------------------------------------------------------------------
+# Apply patch
+# ---------------------------------------------------------------------------
+"${PATCH_DIR}/apply.sh" "${SRC_DIR}"
+
+# ---------------------------------------------------------------------------
+# Configure (minimal — just x86_64-softmmu, KVM, slirp, no GUI)
+# ---------------------------------------------------------------------------
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+"${SRC_DIR}/configure" \
+    --target-list=x86_64-softmmu \
+    --disable-werror \
+    --disable-docs \
+    --disable-tools \
+    --disable-guest-agent \
+    --disable-vnc \
+    --disable-gtk \
+    --disable-sdl \
+    --disable-spice \
+    --disable-cocoa \
+    --disable-curses \
+    --disable-libusb \
+    --disable-libdaxctl \
+    --disable-snappy \
+    --disable-bzip2 \
+    --disable-lzfse \
+    --disable-rbd \
+    --disable-cap-ng \
+    --disable-curl \
+    --enable-slirp \
+    --enable-kvm \
+    --enable-trace-backends=log
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+ninja -j "${JOBS}" qemu-system-x86_64
+
+# ---------------------------------------------------------------------------
+# Install: copy the binary AND its data files (pc-bios, etc.) so the binary
+# can be invoked without -L pointing at the build tree. QEMU looks for data
+# in $(dirname $0)/../share/qemu by default if compiled with --datadir; we
+# bypass that by always passing -L explicitly in launch-capture.sh.
+# ---------------------------------------------------------------------------
+cp -f "${BUILD_DIR}/qemu-system-x86_64" "${OUT_BIN}"
+
+PC_BIOS_OUT="${QEMU_OUT_DIR}/pc-bios"
+rm -rf "${PC_BIOS_OUT}"
+cp -a "${SRC_DIR}/pc-bios" "${PC_BIOS_OUT}"
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+"${OUT_BIN}" --version | head -1
+if ! "${OUT_BIN}" -device help 2>&1 | grep -q hailo-stub-stub; then
+    echo "ERROR: built QEMU does not register hailo-stub-stub" >&2
+    exit 4
+fi
+if [[ ! -f "${PC_BIOS_OUT}/bios-256k.bin" ]]; then
+    echo "ERROR: pc-bios/bios-256k.bin not copied to ${PC_BIOS_OUT}" >&2
+    exit 4
+fi
+echo "OK: ${OUT_BIN} ready (hailo-stub-stub registered)."
+echo "    pc-bios at ${PC_BIOS_OUT}"

--- a/host-tools/hailort-vm/build-vm-image.sh
+++ b/host-tools/hailort-vm/build-vm-image.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+# Build a reproducible HailoRT capture VM image.
+#
+# 1. Downloads the Ubuntu 24.04 (noble) cloud image if not cached.
+# 2. Verifies the HailoRT .deb packages live where expected (manual pre-stage
+#    per README — Hailo does not allow redistribution).
+# 3. Builds a cloud-init NoCloud seed ISO bundling user-data + meta-data + .debs
+#    + guest scripts.
+# 4. Resizes a copy of the cloud image to 8 GB.
+# 5. Boots it once under QEMU with the seed ISO attached. cloud-init installs
+#    everything, applies determinism, then powers off.
+# 6. The customized qcow2 is saved to $VM_IMG_DIR.
+#
+# Idempotent: re-running with the same inputs returns the cached image unless
+# --force is passed. Outputs land in ~/slmos-ref/derivatives/hailort-vm-images/
+# so the VM disk stays out of git.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (override via env)
+# ---------------------------------------------------------------------------
+HAILORT_VERSION="${HAILORT_VERSION:-4.23.0}"
+UBUNTU_RELEASE="${UBUNTU_RELEASE:-noble}"
+UBUNTU_IMG_URL="${UBUNTU_IMG_URL:-https://cloud-images.ubuntu.com/${UBUNTU_RELEASE}/current/${UBUNTU_RELEASE}-server-cloudimg-amd64.img}"
+HAILORT_DEB_DIR="${HAILORT_DEB_DIR:-$HOME/Downloads}"
+VM_IMG_DIR="${VM_IMG_DIR:-$HOME/slmos-ref/derivatives/hailort-vm-images}"
+VM_IMG_NAME="${VM_IMG_NAME:-hailort-vm-${HAILORT_VERSION}-ubuntu-${UBUNTU_RELEASE}.qcow2}"
+VM_DISK_SIZE="${VM_DISK_SIZE:-8G}"
+BUILD_TIMEOUT="${BUILD_TIMEOUT:-1800}"  # 30 minutes — cloud-init runs apt-update + installs ~50 packages + DKMS-builds hailo_pci; under TCG this is the floor
+FORCE_REBUILD=0
+
+# Hailo-side pinned sha256 (driver .deb is arch-independent and stable).
+HAILORT_DRIVER_DEB_SHA256="36e308eb492808db9db7c64046e3fdfb3e4e02fdfd67550db678f068869c1fbf"
+
+# The amd64 userspace sha is recorded into a stamp file on first successful
+# build and then required to match on subsequent builds. There is no upstream
+# canonical sha published for this artifact.
+HAILORT_AMD64_SHA_STAMP="${VM_IMG_DIR}/hailort_${HAILORT_VERSION}_amd64.sha256"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force) FORCE_REBUILD=1; shift;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# //; s/^#//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CLOUD_INIT_DIR="${HERE}/cloud-init"
+GUEST_SCRIPTS_DIR="${HERE}/guest-scripts"
+WORK_DIR="${VM_IMG_DIR}/.work"
+SEED_ISO="${WORK_DIR}/seed.iso"
+BASE_IMG="${VM_IMG_DIR}/ubuntu-${UBUNTU_RELEASE}-cloudimg-amd64.qcow2"
+VM_IMG="${VM_IMG_DIR}/${VM_IMG_NAME}"
+
+mkdir -p "${VM_IMG_DIR}" "${WORK_DIR}"
+
+# ---------------------------------------------------------------------------
+# Step 1: tools
+# ---------------------------------------------------------------------------
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing tool: $1" >&2; exit 2; }; }
+need qemu-system-x86_64
+need qemu-img
+need curl
+need sha256sum
+if command -v xorriso >/dev/null 2>&1; then
+    MKISO="xorriso -as mkisofs"
+elif command -v genisoimage >/dev/null 2>&1; then
+    MKISO="genisoimage"
+else
+    echo "neither xorriso nor genisoimage installed" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: verify HailoRT .debs (manual pre-stage)
+# ---------------------------------------------------------------------------
+USERSPACE_DEB="${HAILORT_DEB_DIR}/hailort_${HAILORT_VERSION}_amd64.deb"
+DRIVER_DEB="${HAILORT_DEB_DIR}/hailort-pcie-driver_${HAILORT_VERSION}_all.deb"
+
+if [[ ! -f "${USERSPACE_DEB}" ]]; then
+    cat >&2 <<EOF
+HailoRT amd64 userspace .deb not found at:
+  ${USERSPACE_DEB}
+
+Download it manually from Hailo's developer portal (login required) and place
+it at the path above, or set HAILORT_DEB_DIR=<path>. The file is not
+redistributable; do not commit it.
+
+The driver .deb is architecture-independent and the same file used on pi-5-1
+(sha256 ${HAILORT_DRIVER_DEB_SHA256}).
+EOF
+    exit 3
+fi
+
+if [[ ! -f "${DRIVER_DEB}" ]]; then
+    echo "HailoRT PCIe driver .deb not found at: ${DRIVER_DEB}" >&2
+    exit 3
+fi
+
+OBSERVED_DRIVER_SHA="$(sha256sum "${DRIVER_DEB}" | awk '{print $1}')"
+if [[ "${OBSERVED_DRIVER_SHA}" != "${HAILORT_DRIVER_DEB_SHA256}" ]]; then
+    echo "Driver .deb sha256 mismatch:"  >&2
+    echo "  expected: ${HAILORT_DRIVER_DEB_SHA256}" >&2
+    echo "  observed: ${OBSERVED_DRIVER_SHA}"      >&2
+    exit 4
+fi
+
+OBSERVED_USERSPACE_SHA="$(sha256sum "${USERSPACE_DEB}" | awk '{print $1}')"
+if [[ -f "${HAILORT_AMD64_SHA_STAMP}" ]]; then
+    EXPECTED_USERSPACE_SHA="$(cat "${HAILORT_AMD64_SHA_STAMP}")"
+    if [[ "${OBSERVED_USERSPACE_SHA}" != "${EXPECTED_USERSPACE_SHA}" ]]; then
+        echo "Userspace .deb sha256 changed since last build:" >&2
+        echo "  recorded: ${EXPECTED_USERSPACE_SHA}" >&2
+        echo "  observed: ${OBSERVED_USERSPACE_SHA}" >&2
+        echo "If this is intentional, rm ${HAILORT_AMD64_SHA_STAMP} and rebuild." >&2
+        exit 4
+    fi
+else
+    echo "Recording first-seen userspace .deb sha256: ${OBSERVED_USERSPACE_SHA}"
+    echo "${OBSERVED_USERSPACE_SHA}" > "${HAILORT_AMD64_SHA_STAMP}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: short-circuit if already built
+# ---------------------------------------------------------------------------
+if [[ -f "${VM_IMG}" && "${FORCE_REBUILD}" -eq 0 ]]; then
+    echo "VM image already built: ${VM_IMG}"
+    echo "Pass --force to rebuild."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: download Ubuntu cloud image
+# ---------------------------------------------------------------------------
+if [[ ! -f "${BASE_IMG}" ]]; then
+    echo "Downloading Ubuntu ${UBUNTU_RELEASE} cloud image..."
+    curl -fL --output "${BASE_IMG}.tmp" "${UBUNTU_IMG_URL}"
+    mv "${BASE_IMG}.tmp" "${BASE_IMG}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: build cloud-init seed ISO
+# ---------------------------------------------------------------------------
+SEED_STAGING="${WORK_DIR}/seed-staging"
+rm -rf "${SEED_STAGING}"
+mkdir -p "${SEED_STAGING}/stage"
+
+cp "${CLOUD_INIT_DIR}/user-data" "${SEED_STAGING}/user-data"
+cp "${CLOUD_INIT_DIR}/meta-data" "${SEED_STAGING}/meta-data"
+cp "${USERSPACE_DEB}" "${SEED_STAGING}/stage/hailort_${HAILORT_VERSION}_amd64.deb"
+cp "${DRIVER_DEB}"    "${SEED_STAGING}/stage/hailort-pcie-driver_${HAILORT_VERSION}_all.deb"
+cp "${GUEST_SCRIPTS_DIR}"/*.sh "${SEED_STAGING}/stage/"
+
+rm -f "${SEED_ISO}"
+${MKISO} -output "${SEED_ISO}" \
+    -volid CIDATA -joliet -rock -quiet \
+    "${SEED_STAGING}"
+
+# ---------------------------------------------------------------------------
+# Step 6: prepare working qcow2 (copy + resize)
+# ---------------------------------------------------------------------------
+echo "Preparing working qcow2..."
+qemu-img convert -O qcow2 "${BASE_IMG}" "${VM_IMG}.work"
+qemu-img resize "${VM_IMG}.work" "${VM_DISK_SIZE}"
+
+# ---------------------------------------------------------------------------
+# Step 7: run cloud-init build boot
+# ---------------------------------------------------------------------------
+echo "Running cloud-init build boot (timeout ${BUILD_TIMEOUT}s)..."
+
+ACCEL_ARGS=(-accel tcg,thread=single)
+if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+    ACCEL_ARGS=(-accel kvm -cpu host)
+else
+    echo "WARNING: /dev/kvm not accessible; falling back to TCG (slow). Add the invoking user to the 'kvm' group to speed this up." >&2
+fi
+
+BUILD_LOG="${WORK_DIR}/build-boot.log"
+set +e
+timeout "${BUILD_TIMEOUT}" qemu-system-x86_64 \
+    "${ACCEL_ARGS[@]}" \
+    -smp 2 \
+    -m 2G \
+    -drive "file=${VM_IMG}.work,format=qcow2,if=virtio" \
+    -drive "file=${SEED_ISO},format=raw,if=virtio,readonly=on" \
+    -nic user \
+    -nographic \
+    -serial "file:${BUILD_LOG}" \
+    -monitor none \
+    -no-reboot
+QEMU_STATUS=$?
+set -e
+
+if [[ ${QEMU_STATUS} -eq 124 ]]; then
+    echo "Build boot timed out after ${BUILD_TIMEOUT}s. cloud-init never reached poweroff. Tail of build log:" >&2
+    tail -50 "${BUILD_LOG}" >&2 || true
+    rm -f "${VM_IMG}.work"
+    exit 5
+fi
+if [[ ${QEMU_STATUS} -ne 0 ]]; then
+    echo "QEMU exited with status ${QEMU_STATUS}. Tail of build log:" >&2
+    tail -50 "${BUILD_LOG}" >&2 || true
+    rm -f "${VM_IMG}.work"
+    exit 5
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8: verify build success
+# ---------------------------------------------------------------------------
+# cloud-init shutdown is the success signal; the guest writes
+# /opt/hailort-stage/build-complete.stamp before calling shutdown -h.
+# If the Power-Off target was reached, treat the build as successful.
+# The stamp itself is verified at first capture (lives inside the qcow2).
+if ! grep -qE 'reboot: Power down|Reached target .*Power-Off|systemd-poweroff.service' "${BUILD_LOG}"; then
+    echo "cloud-init did not reach Power-Off cleanly. Last 80 lines of build log:" >&2
+    tail -80 "${BUILD_LOG}" >&2 || true
+    rm -f "${VM_IMG}.work"
+    exit 5
+fi
+
+mv "${VM_IMG}.work" "${VM_IMG}"
+echo
+echo "VM image built: ${VM_IMG}"
+echo "Build log:      ${BUILD_LOG}"

--- a/host-tools/hailort-vm/build-vm-image.sh
+++ b/host-tools/hailort-vm/build-vm-image.sh
@@ -77,9 +77,9 @@ need qemu-img
 need curl
 need sha256sum
 if command -v xorriso >/dev/null 2>&1; then
-    MKISO="xorriso -as mkisofs"
+    MKISO=(xorriso -as mkisofs)
 elif command -v genisoimage >/dev/null 2>&1; then
-    MKISO="genisoimage"
+    MKISO=(genisoimage)
 else
     echo "neither xorriso nor genisoimage installed" >&2
     exit 2
@@ -166,7 +166,7 @@ cp "${DRIVER_DEB}"    "${SEED_STAGING}/stage/hailort-pcie-driver_${HAILORT_VERSI
 cp "${GUEST_SCRIPTS_DIR}"/*.sh "${SEED_STAGING}/stage/"
 
 rm -f "${SEED_ISO}"
-${MKISO} -output "${SEED_ISO}" \
+"${MKISO[@]}" -output "${SEED_ISO}" \
     -volid CIDATA -joliet -rock -quiet \
     "${SEED_STAGING}"
 
@@ -189,7 +189,11 @@ else
     echo "WARNING: /dev/kvm not accessible; falling back to TCG (slow). Add the invoking user to the 'kvm' group to speed this up." >&2
 fi
 
-BUILD_LOG="${WORK_DIR}/build-boot.log"
+# Per-invocation log path so re-runs don't overwrite forensic evidence.
+# A `latest` symlink always points at the most recent run for convenience.
+BUILD_LOG_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BUILD_LOG="${WORK_DIR}/build-boot-${BUILD_LOG_STAMP}.log"
+ln -sfn "$(basename "${BUILD_LOG}")" "${WORK_DIR}/build-boot.log"
 set +e
 timeout "${BUILD_TIMEOUT}" qemu-system-x86_64 \
     "${ACCEL_ARGS[@]}" \

--- a/host-tools/hailort-vm/cloud-init/meta-data
+++ b/host-tools/hailort-vm/cloud-init/meta-data
@@ -1,0 +1,2 @@
+instance-id: hailort-capture-vm
+local-hostname: hailort-capture

--- a/host-tools/hailort-vm/cloud-init/user-data
+++ b/host-tools/hailort-vm/cloud-init/user-data
@@ -12,13 +12,13 @@ users:
   - name: slmos
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
-    lock_passwd: false
-    plain_text_passwd: slmos
+    # Account is sudo-able but its password is locked. The capture pipeline
+    # never logs in interactively — hailort-capture.service runs at boot and
+    # shuts down. For debugging, mount the qcow2 via qemu-nbd and chroot,
+    # or boot with `init=/bin/bash` on the kernel cmdline.
+    lock_passwd: true
 
-chpasswd:
-  expire: false
-
-ssh_pwauth: true
+ssh_pwauth: false
 
 # No network-time, no DNS, no apt-daily timers. Determinism > convenience.
 write_files:
@@ -121,9 +121,3 @@ runcmd:
   - touch /opt/hailort-stage/build-complete.stamp
   - sync
   - shutdown -h now
-
-# Disable cloud-init on subsequent boots — capture runs are not first-boot scenarios.
-power_state:
-  mode: poweroff
-  timeout: 60
-  condition: true

--- a/host-tools/hailort-vm/cloud-init/user-data
+++ b/host-tools/hailort-vm/cloud-init/user-data
@@ -1,0 +1,129 @@
+#cloud-config
+# First-boot configuration for the HailoRT capture VM.
+# Runs once during build-vm-image.sh; installs HailoRT, builds hailo_pci via DKMS,
+# applies determinism tweaks, then powers off. The customized qcow2 is preserved
+# and reused for every capture run.
+
+hostname: hailort-capture
+manage_etc_hosts: true
+
+users:
+  - default
+  - name: slmos
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    lock_passwd: false
+    plain_text_passwd: slmos
+
+chpasswd:
+  expire: false
+
+ssh_pwauth: true
+
+# No network-time, no DNS, no apt-daily timers. Determinism > convenience.
+write_files:
+  - path: /etc/systemd/system/hailort-capture.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=HailoRT MMIO capture run
+      After=multi-user.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/hailort-stage/20-capture-run.sh
+      StandardOutput=journal+console
+      StandardError=journal+console
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /etc/sysctl.d/99-hailort-determinism.conf
+    permissions: "0644"
+    content: |
+      kernel.randomize_va_space = 0
+      kernel.perf_event_paranoid = 3
+      kernel.kptr_restrict = 2
+
+  - path: /etc/modprobe.d/hailo_pci.conf
+    permissions: "0644"
+    content: |
+      # The placeholder QEMU stub-stub device only fakes the absolute minimum
+      # magic to satisfy hailo_pci's probe (vendor ID + firmware-loaded flag).
+      # `support_soft_reset=0` lets load_nnc_firmware early-return on the
+      # firmware-loaded check instead of trying to soft-reset (which would
+      # require a much larger magic-register surface).
+      # Applies to the kernel's PCI-auto-probe at boot, not just modprobe.
+      #
+      # no_power_mode=1 disables `pci_set_power_state(PCI_D3hot)` after the
+      # board is activated. The stub-stub doesn't expose a PCI Power
+      # Management capability, so that call fails with -EIO and probe
+      # propagates the error.
+      options hailo_pci support_soft_reset=0 no_power_mode=1
+
+package_update: true
+package_upgrade: false
+packages:
+  - pciutils
+  - kmod
+
+runcmd:
+  # Install build deps + headers for the CURRENTLY RUNNING kernel only.
+  # We intentionally avoid `linux-headers-generic` because the meta package
+  # pulls in a newer linux-image (e.g. -111 when the base image runs -106),
+  # which causes DKMS to build for the running kernel (-106) while grub picks
+  # the newer one (-111) on next boot — modprobe then fails because hailo_pci
+  # was never built for the boot kernel. `linux-headers-$(uname -r)` keeps
+  # the running kernel and the DKMS target identical.
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential dkms "linux-headers-$(uname -r)"
+
+  # Stage payload: copy bundled scripts + .debs off the cloud-init seed ISO.
+  # The seed ISO is built with `genisoimage -volid CIDATA`, which writes the
+  # label uppercase on iso9660. Older docs say lowercase `cidata` — using blkid
+  # to look up the device by label is case-correct either way.
+  - mkdir -p /opt/hailort-stage
+  - 'SEED_DEV=$(blkid -L CIDATA || blkid -L cidata); echo "seed device: $SEED_DEV"'
+  - 'SEED_DEV=$(blkid -L CIDATA || blkid -L cidata); mount "$SEED_DEV" /mnt'
+  - cp -v /mnt/stage/*.deb /opt/hailort-stage/
+  - cp -v /mnt/stage/*.sh  /opt/hailort-stage/
+  - chmod +x /opt/hailort-stage/*.sh
+  - umount /mnt
+
+  # Mask everything that issues background activity. Order matters: mask before enable,
+  # so the capture service does not race with apt-daily, snapd, etc.
+  - bash /opt/hailort-stage/00-determinism.sh
+
+  # Install Hailo PCIe driver DKMS package first, then HailoRT userspace.
+  # Hailo's postinst scripts have hardcoded interactive prompts (`read -t 10`)
+  # that bail under non-interactive dpkg: when stdin is closed they return
+  # exit 1 (not >128), the `|| (($? > 128))` guard evaluates false, and
+  # `set -e` kills the postinst. `yes Y` feeds a continuous stream so every
+  # prompt is answered Y. Side effects:
+  #   - hailort-pcie-driver: Y -> compile_and_install_pcie_driver_with_dkms
+  #   - hailort:             Y -> start_hailort_service  (we re-mask it below)
+  - 'yes Y | DEBIAN_FRONTEND=noninteractive dpkg -i /opt/hailort-stage/hailort-pcie-driver_4.23.0_all.deb || (apt-get -fy install && yes Y | dpkg -i /opt/hailort-stage/hailort-pcie-driver_4.23.0_all.deb)'
+  - 'yes Y | DEBIAN_FRONTEND=noninteractive dpkg -i /opt/hailort-stage/hailort_4.23.0_amd64.deb           || (apt-get -fy install && yes Y | dpkg -i /opt/hailort-stage/hailort_4.23.0_amd64.deb)'
+
+  # Mask hailort service (started by its postinst's Y answer) — capture runs
+  # bring up the device themselves; an auto-started daemon would race them.
+  - systemctl mask hailort.service || true
+
+  # Confirm DKMS built the module.
+  - bash -c 'modinfo hailo_pci > /opt/hailort-stage/modinfo.txt 2>&1 || echo "hailo_pci modinfo FAILED" > /opt/hailort-stage/modinfo.txt'
+
+  # Enable the capture service for next boot.
+  - systemctl enable hailort-capture.service
+
+  # Reload sysctls without rebooting.
+  - sysctl --system
+
+  # Mark completion and power off so the qcow2 is reusable as a snapshot.
+  - touch /opt/hailort-stage/build-complete.stamp
+  - sync
+  - shutdown -h now
+
+# Disable cloud-init on subsequent boots — capture runs are not first-boot scenarios.
+power_state:
+  mode: poweroff
+  timeout: 60
+  condition: true

--- a/host-tools/hailort-vm/guest-scripts/00-determinism.sh
+++ b/host-tools/hailort-vm/guest-scripts/00-determinism.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Disable every background activity inside the guest that could perturb HailoRT's
+# MMIO write order between capture runs. Applied at first boot (build time); the
+# changes persist into the captured qcow2 snapshot.
+#
+# Anything added here must have a stated reason in the comment above the line —
+# masked units accumulate fast and the rationale rots without inline notes.
+
+set -euo pipefail
+
+# Apt-daily and unattended-upgrades touch the disk at random intervals and run
+# postinst hooks that may load modules out-of-order.
+systemctl mask apt-daily.service             || true
+systemctl mask apt-daily.timer               || true
+systemctl mask apt-daily-upgrade.service     || true
+systemctl mask apt-daily-upgrade.timer       || true
+systemctl mask unattended-upgrades.service   || true
+
+# NTP / time sync: any clock step can cause HailoRT internal timers to jitter.
+systemctl mask systemd-timesyncd.service     || true
+
+# Snapd refreshes itself on a schedule and starts background processes.
+systemctl mask snapd.service                 || true
+systemctl mask snapd.socket                  || true
+systemctl mask snapd.seeded.service          || true
+
+# IRQ rebalancing across CPUs is an explicit source of cross-run nondeterminism.
+systemctl mask irqbalance.service            || true
+
+# tuned applies per-profile scheduler / kernel tweaks asynchronously after login.
+systemctl mask tuned.service                 || true
+
+# cron timers run user jobs we can't predict.
+systemctl mask cron.service                  || true
+
+# Telemetry channels.
+systemctl mask motd-news.service             || true
+systemctl mask motd-news.timer               || true
+systemctl mask ua-timer.service              || true
+systemctl mask ua-timer.timer                || true
+
+# Hailo's own monitor daemon, if it appears in a future .deb. Defensive — does
+# nothing if the unit is absent.
+systemctl mask hailo-monitor.service         || true
+
+# Pin every default IRQ to CPU 0. New IRQs created post-boot also inherit this.
+echo 1 > /proc/irq/default_smp_affinity || true
+
+# ASLR off — already in /etc/sysctl.d/99-hailort-determinism.conf, but enforce now
+# so the first boot's hailortcli invocation also sees it.
+echo 0 > /proc/sys/kernel/randomize_va_space || true
+
+# Touch a stamp so the rest of the build can confirm this script ran.
+touch /opt/hailort-stage/determinism-applied.stamp

--- a/host-tools/hailort-vm/guest-scripts/10-bind-stub.sh
+++ b/host-tools/hailort-vm/guest-scripts/10-bind-stub.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Force-bind hailo_pci to the QEMU `edu` test device.
+#
+# The `edu` device has PCI vendor:device 0x1234:0x11e8 — not Hailo's
+# 0x1e60:0x2864. hailo_pci's id_table only matches Hailo IDs, so without help it
+# never probes. The kernel's `new_id` sysfs entry lets us register an extra
+# (vendor, device) pair against the driver at runtime and trigger probe.
+#
+# This is the Task 0.3 placeholder strategy: the edu device's BAR0 R/W returns
+# zero for unwritten offsets, which is the "stub-stub" behavior #795's plan calls
+# for. The corpus produced under this binding is not a useful protocol artifact —
+# its only purpose is to validate that the capture pipeline produces a
+# deterministic MMIO stream end-to-end. Replaced by Task 0.2's real stub on
+# integration.
+
+set -euo pipefail
+
+HAILO_VENDOR=1e60
+HAILO_DEVICE=2864
+EDU_VENDOR=1234
+EDU_DEVICE=11e8
+
+# The Hailo PCIe driver ships as kernel module `hailo_pci` (modinfo / dkms name)
+# but registers itself as PCI driver `hailo` in sysfs (per `DRIVER_NAME` in
+# hailo's common/pcie_common.h). The module and driver names differ; this
+# script uses the sysfs name.
+DRIVER_SYSFS=/sys/bus/pci/drivers/hailo
+
+# 1. Load hailo_pci. With the custom QEMU `hailo-stub-stub` device advertising
+#    the Hailo IDs (0x1e60:0x2864), the kernel's PCI subsystem auto-probes via
+#    hailo_pci's id_table — no /sys/bus/pci/drivers/hailo/new_id trick needed.
+#
+#    support_soft_reset=0 makes load_nnc_firmware early-return when the stub's
+#    is_firmware_loaded magic register reports loaded. With the default
+#    (support_soft_reset=1), the driver would try to soft-reset the device
+#    instead, which requires far more magic in the stub.
+modprobe hailo_pci support_soft_reset=0 || {
+    echo "hailo_pci modprobe failed; dmesg tail:" >&2
+    dmesg | tail -30 >&2
+    exit 1
+}
+
+# Diagnostics, always-on for now.
+echo "lsmod | grep hailo:"
+lsmod | grep -i hailo || true
+echo "PCI devices with Hailo IDs:"
+lspci -d "${HAILO_VENDOR}:${HAILO_DEVICE}" || true
+
+if [[ ! -d "${DRIVER_SYSFS}" ]]; then
+    echo "Expected PCI driver sysfs path ${DRIVER_SYSFS} not present after modprobe hailo_pci." >&2
+    echo "Available PCI drivers:" >&2
+    ls /sys/bus/pci/drivers/ >&2
+    echo "dmesg tail:" >&2
+    dmesg | tail -30 >&2
+    exit 1
+fi
+
+# 2. Fallback (placeholder-of-placeholder): if the QEMU device exposes the edu
+#    IDs instead of Hailo IDs (because the custom QEMU wasn't built), force-bind
+#    via new_id. Auto-detect by checking lspci.
+if ! lspci -d "${HAILO_VENDOR}:${HAILO_DEVICE}" | grep -q .; then
+    echo "No Hailo-IDed device on PCI bus. Falling back to edu force-bind." >&2
+    if lspci -d "${EDU_VENDOR}:${EDU_DEVICE}" | grep -q .; then
+        echo "${EDU_VENDOR} ${EDU_DEVICE}" > "${DRIVER_SYSFS}/new_id"
+    else
+        echo "No edu device either. Capture cannot proceed." >&2
+        lspci -nn >&2
+        exit 1
+    fi
+fi
+
+# 3. Wait briefly for /dev/hailo0 to appear. udev creates it from the cdev the
+#    driver publishes on probe.
+for _ in $(seq 1 50); do
+    if [[ -e /dev/hailo0 ]]; then
+        ls -l /dev/hailo0
+        echo "Bound devices under driver:"
+        ls -l "${DRIVER_SYSFS}/" | grep '^l' || true
+        exit 0
+    fi
+    sleep 0.1
+done
+
+echo "Probe completed but /dev/hailo0 never appeared. State dump:" >&2
+echo "  driver sysfs:" >&2
+ls -la "${DRIVER_SYSFS}/" >&2
+echo "  dmesg tail:" >&2
+dmesg | tail -50 >&2
+exit 1

--- a/host-tools/hailort-vm/guest-scripts/10-bind-stub.sh
+++ b/host-tools/hailort-vm/guest-scripts/10-bind-stub.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
-# Force-bind hailo_pci to the QEMU `edu` test device.
+# Bring up the hailo_pci driver against the QEMU placeholder device.
 #
-# The `edu` device has PCI vendor:device 0x1234:0x11e8 — not Hailo's
-# 0x1e60:0x2864. hailo_pci's id_table only matches Hailo IDs, so without help it
-# never probes. The kernel's `new_id` sysfs entry lets us register an extra
-# (vendor, device) pair against the driver at runtime and trigger probe.
+# Primary path: the custom QEMU's `hailo-stub-stub` device advertises Hailo's
+# vendor/device IDs (0x1e60:0x2864), so hailo_pci's id_table matches and the
+# kernel auto-probes at module load.
 #
-# This is the Task 0.3 placeholder strategy: the edu device's BAR0 R/W returns
-# zero for unwritten offsets, which is the "stub-stub" behavior #795's plan calls
-# for. The corpus produced under this binding is not a useful protocol artifact —
-# its only purpose is to validate that the capture pipeline produces a
-# deterministic MMIO stream end-to-end. Replaced by Task 0.2's real stub on
-# integration.
+# Fallback path: if the custom QEMU isn't built and we're running against
+# stock QEMU + `-device edu` (0x1234:0x11e8), the kernel won't auto-probe;
+# we force-bind via `/sys/bus/pci/drivers/hailo/new_id`. Corpora captured
+# under the edu fallback are NOT protocol-valid (BAR2/BAR4 missing) — that
+# path exists only as a smoke test for the load-module pipeline. Replaced
+# by Task 0.2's real stub on integration.
 
 set -euo pipefail
 

--- a/host-tools/hailort-vm/guest-scripts/20-capture-run.sh
+++ b/host-tools/hailort-vm/guest-scripts/20-capture-run.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Capture-time entry point. Invoked once per VM boot by hailort-capture.service.
+#
+# Sequence:
+#   1. Apply runtime determinism knobs that don't survive snapshot/reboot.
+#   2. Force-bind hailo_pci to the placeholder `edu` device.
+#   3. Run `hailortcli fw-control identify` pinned to CPU 0.
+#   4. Emit a single boundary marker on the serial console so the host knows
+#      capture is complete and QEMU can be shut down.
+#   5. Power off.
+#
+# All stdout/stderr from steps 1-3 lands in /var/log/hailort-capture.log AND
+# the serial console. The host's launch-capture.sh greps the console for the
+# boundary marker — do not change the marker string without also updating the
+# host script.
+
+set -uo pipefail
+exec > >(tee -a /var/log/hailort-capture.log) 2>&1
+
+echo "===== HAILORT_CAPTURE_BEGIN $(date -u +%FT%TZ) ====="
+
+# Runtime determinism.
+echo 0 > /proc/sys/kernel/randomize_va_space || true
+echo 1 > /proc/irq/default_smp_affinity      || true
+
+# Force-bind. Failures here are fatal.
+if ! /opt/hailort-stage/10-bind-stub.sh; then
+    echo "===== HAILORT_CAPTURE_FAILED bind-stub ====="
+    sync
+    shutdown -h now
+    exit 1
+fi
+
+# Sanity-check HailoRT presence.
+if ! command -v hailortcli >/dev/null 2>&1; then
+    echo "===== HAILORT_CAPTURE_FAILED hailortcli-missing ====="
+    sync
+    shutdown -h now
+    exit 1
+fi
+hailortcli --version || true
+
+# The real capture: a single IDENTIFY round-trip pinned to CPU 0.
+# Exit status is captured but we don't fail the run on non-zero — the trace is
+# the deliverable, not the exit code. (Identify is expected to fail against the
+# placeholder edu device; what matters is that HailoRT got far enough to issue
+# the first BAR read, which is the capture point.)
+set +e
+taskset -c 0 hailortcli fw-control identify
+echo "IDENTIFY_EXIT=$?"
+set -e
+
+echo "===== HAILORT_CAPTURE_DONE $(date -u +%FT%TZ) ====="
+sync
+shutdown -h now

--- a/host-tools/hailort-vm/guest-scripts/20-capture-run.sh
+++ b/host-tools/hailort-vm/guest-scripts/20-capture-run.sh
@@ -3,7 +3,8 @@
 #
 # Sequence:
 #   1. Apply runtime determinism knobs that don't survive snapshot/reboot.
-#   2. Force-bind hailo_pci to the placeholder `edu` device.
+#   2. Bring up hailo_pci against the QEMU placeholder via 10-bind-stub.sh
+#      (auto-probe on the hailo-stub-stub device; new_id fallback on edu).
 #   3. Run `hailortcli fw-control identify` pinned to CPU 0.
 #   4. Emit a single boundary marker on the serial console so the host knows
 #      capture is complete and QEMU can be shut down.

--- a/host-tools/hailort-vm/launch-capture.sh
+++ b/host-tools/hailort-vm/launch-capture.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Run one HailoRT capture session.
+#
+# Usage: ./launch-capture.sh <corpus-output.jsonl> [--variant <name>]
+#
+# Boots a clone of the customized qcow2 (so each run starts from the same cold
+# state), runs `hailortcli fw-control identify` inside the guest pinned to CPU
+# 0, captures every MMIO trap via QEMU's memory_region_ops_{read,write} trace
+# events, and converts the trace into the corpus JSONL format defined in
+# docs/hailo-re-corpus-format.md.
+#
+# The disk is always a fresh clone — capture runs are non-destructive.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <corpus-output.jsonl> [--variant <name>]" >&2
+    exit 2
+fi
+
+CORPUS_OUT="$1"; shift
+VARIANT="default"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --variant) VARIANT="$2"; shift 2;;
+        *) echo "Unknown argument: $1" >&2; exit 2;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+HAILORT_VERSION="${HAILORT_VERSION:-4.23.0}"
+UBUNTU_RELEASE="${UBUNTU_RELEASE:-noble}"
+VM_IMG_DIR="${VM_IMG_DIR:-$HOME/slmos-ref/derivatives/hailort-vm-images}"
+VM_IMG_NAME="${VM_IMG_NAME:-hailort-vm-${HAILORT_VERSION}-ubuntu-${UBUNTU_RELEASE}.qcow2}"
+VM_IMG="${VM_IMG_DIR}/${VM_IMG_NAME}"
+QEMU_CUSTOM="${QEMU_CUSTOM:-$HOME/slmos-ref/derivatives/hailort-vm-qemu/qemu-system-x86_64}"
+CAPTURE_TIMEOUT="${CAPTURE_TIMEOUT:-180}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TRACE_PARSER="${HERE}/tools/qemu-trace-to-corpus.py"
+
+# Prefer the custom QEMU with the hailo-stub-stub device; fall back to system
+# QEMU only with -device edu (placeholder of a placeholder).
+QEMU_DATA_ARGS=()
+if [[ -x "${QEMU_CUSTOM}" ]] && "${QEMU_CUSTOM}" -device help 2>&1 | grep -q hailo-stub-stub; then
+    QEMU_BIN="${QEMU_CUSTOM}"
+    STUB_DEVICE="hailo-stub-stub"
+    # The custom QEMU is invoked from $QEMU_OUT_DIR; point -L at the
+    # pc-bios sibling so BIOS / vgabios / option ROMs are findable.
+    QEMU_DATA_ARGS=(-L "$(dirname "${QEMU_CUSTOM}")/pc-bios")
+else
+    QEMU_BIN="qemu-system-x86_64"
+    STUB_DEVICE="edu"
+    echo "WARNING: custom QEMU not found; falling back to system QEMU + edu device." >&2
+    echo "         hailo_pci will fail to probe (no BAR2/BAR4). Build custom QEMU with" >&2
+    echo "         ./build-qemu.sh to fix this." >&2
+fi
+
+if [[ ! -f "${VM_IMG}" ]]; then
+    echo "VM image missing: ${VM_IMG}" >&2
+    echo "Run ./build-vm-image.sh first." >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Working directory per run — fresh disk clone, fresh trace log.
+# ---------------------------------------------------------------------------
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-${VARIANT}"
+RUN_DIR="${VM_IMG_DIR}/.runs/${RUN_ID}"
+mkdir -p "${RUN_DIR}"
+
+DISK_CLONE="${RUN_DIR}/disk.qcow2"
+SERIAL_LOG="${RUN_DIR}/serial.log"
+TRACE_LOG="${RUN_DIR}/qemu-trace.log"
+
+# Clone disk as overlay so the base image is never mutated.
+qemu-img create -f qcow2 -b "${VM_IMG}" -F qcow2 "${DISK_CLONE}" >/dev/null
+
+# ---------------------------------------------------------------------------
+# QEMU invocation.
+#
+# Key flags for determinism + capture:
+#   -cpu host,migratable=no    pin to host CPU features
+#   -smp 1                     single vCPU; HailoRT runs under taskset -c 0 anyway
+#   -rtc base=2026-05-12T...   fixed wall-clock so timer code paths repeat
+#   -device edu                placeholder PCI device (BAR0 returns 0 on
+#                              unwritten offsets, matches stub-stub spec)
+#   -trace memory_region_ops_* capture every MMIO trap
+#   -no-reboot                 if the guest reboots, exit (we always shutdown -h)
+# ---------------------------------------------------------------------------
+ACCEL_ARGS=(-accel tcg,thread=single)
+if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+    ACCEL_ARGS=(-accel kvm -cpu host,migratable=no)
+fi
+
+# QEMU's -trace flag glob captures both _read and _write events in one filter.
+# Caveat: this is event-name filtering, not per-region — the trace log will
+# include rtc/apic/port92/serial MMIO from boot too (~2.6 MB/sec). The Python
+# parser drops anything not in BAR_NAME_MAP, so the corpus stays clean.
+# Use an array so the literal '*' is passed to QEMU without bash glob expansion.
+TRACE_ARGS=(-trace "memory_region_ops_*,file=${TRACE_LOG}")
+
+set +e
+timeout "${CAPTURE_TIMEOUT}" "${QEMU_BIN}" \
+    "${QEMU_DATA_ARGS[@]}" \
+    "${ACCEL_ARGS[@]}" \
+    -smp 1 \
+    -m 1G \
+    -rtc base=2026-05-12T00:00:00,clock=vm \
+    -drive "file=${DISK_CLONE},format=qcow2,if=virtio" \
+    -nic user,model=virtio-net-pci \
+    -device "${STUB_DEVICE}" \
+    -nographic \
+    -serial "file:${SERIAL_LOG}" \
+    -monitor none \
+    -no-reboot \
+    "${TRACE_ARGS[@]}"
+QEMU_STATUS=$?
+set -e
+
+if [[ ${QEMU_STATUS} -ne 0 && ${QEMU_STATUS} -ne 124 ]]; then
+    echo "QEMU exit ${QEMU_STATUS}. Tail of serial log:" >&2
+    tail -50 "${SERIAL_LOG}" >&2 || true
+    exit 5
+fi
+
+# ---------------------------------------------------------------------------
+# Verify capture markers landed.
+# ---------------------------------------------------------------------------
+if ! grep -q HAILORT_CAPTURE_BEGIN "${SERIAL_LOG}"; then
+    echo "Capture begin marker missing in serial log:" >&2
+    tail -80 "${SERIAL_LOG}" >&2
+    exit 6
+fi
+if ! grep -q HAILORT_CAPTURE_DONE "${SERIAL_LOG}"; then
+    echo "Capture done marker missing — capture may have hung. Serial tail:" >&2
+    tail -80 "${SERIAL_LOG}" >&2
+    exit 6
+fi
+
+# ---------------------------------------------------------------------------
+# Convert trace -> corpus.
+# ---------------------------------------------------------------------------
+mkdir -p "$(dirname "${CORPUS_OUT}")"
+python3 "${TRACE_PARSER}" \
+    --trace "${TRACE_LOG}" \
+    --serial "${SERIAL_LOG}" \
+    --hailort-version "${HAILORT_VERSION}" \
+    --capture-host "qemu-x86_64-ubuntu-${UBUNTU_RELEASE}-${STUB_DEVICE}" \
+    --slmos-base-sha "$(git -C "${HERE}" rev-parse HEAD 2>/dev/null || echo unknown)" \
+    --output "${CORPUS_OUT}"
+
+echo "Capture complete: ${CORPUS_OUT}"
+echo "Serial log:       ${SERIAL_LOG}"
+echo "Trace log:        ${TRACE_LOG}"

--- a/host-tools/hailort-vm/qemu-patch/apply.sh
+++ b/host-tools/hailort-vm/qemu-patch/apply.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Apply the hailo-stub-stub patch to a freshly extracted QEMU source tree.
+#
+# Usage: ./apply.sh <qemu-source-dir>
+#
+# Idempotent: re-running on an already-patched tree is a no-op.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <qemu-source-dir>" >&2
+    exit 2
+fi
+
+QEMU_SRC="$1"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ ! -f "${QEMU_SRC}/hw/misc/edu.c" ]]; then
+    echo "ERROR: ${QEMU_SRC}/hw/misc/edu.c not found — does not look like a QEMU source tree." >&2
+    exit 3
+fi
+
+# 1. Copy the device source into hw/misc/.
+cp -v "${HERE}/hw/misc/hailo-stub-stub.c" "${QEMU_SRC}/hw/misc/hailo-stub-stub.c"
+
+# 2. Hook it into the build system. hw/misc/meson.build registers device
+#    sources against a CONFIG_PCI condition that's true for x86_64-softmmu —
+#    add ours next to edu.c the same way.
+MESON="${QEMU_SRC}/hw/misc/meson.build"
+if grep -q "hailo-stub-stub.c" "${MESON}"; then
+    echo "meson.build already references hailo-stub-stub.c — skipping injection."
+else
+    # Find the line that adds edu.c and add hailo-stub-stub.c right after.
+    if grep -q "edu.c" "${MESON}"; then
+        sed -i "/files('edu.c')/a system_ss.add(when: 'CONFIG_PCI', if_true: files('hailo-stub-stub.c'))" "${MESON}"
+    else
+        echo "system_ss.add(when: 'CONFIG_PCI', if_true: files('hailo-stub-stub.c'))" >> "${MESON}"
+    fi
+    echo "Injected hailo-stub-stub.c entry into ${MESON}"
+fi
+
+echo "Patch applied to ${QEMU_SRC}"

--- a/host-tools/hailort-vm/qemu-patch/hw/misc/hailo-stub-stub.c
+++ b/host-tools/hailort-vm/qemu-patch/hw/misc/hailo-stub-stub.c
@@ -1,0 +1,192 @@
+/*
+ * Hailo stub-stub QEMU PCI device.
+ *
+ * Placeholder for Task 0.3 of the Hailo BAR4 RE plan (issue #795). Exposes
+ * the Hailo-8 PCI IDs (0x1e60:0x2864) and three BARs (0/2/4) so the upstream
+ * `hailo_pci` kernel driver can probe the device. All reads return 0; all
+ * writes are discarded. The point is solely to let HailoRT inside the VM
+ * complete device-open and begin issuing MMIO, which QEMU's
+ * memory_region_ops_{read,write} trace events capture.
+ *
+ * NOT a faithful Hailo-8 emulation. Throwaway — Task 0.2 (`hailo-re/0.2-qemu-stub`)
+ * replaces this with a real-protocol stub backed by the corpus file.
+ *
+ * BAR layout chosen to match the Linux driver's expectations
+ * (see ~/slmos-ref/hailo/v4.23.0/common/pcie_common.h):
+ *   BAR0 — config window           (4 KB)
+ *   BAR2 — VDMA registers          (16 KB)
+ *   BAR4 — firmware-access window  (1 MB)
+ *
+ * BAR sizes are conservative lower bounds — enough that pci_resource_len()
+ * returns non-zero. Real Hailo-8 BARs are larger; the placeholder returns
+ * zero outside any meaningful range anyway.
+ */
+
+#include "qemu/osdep.h"
+#include "hw/pci/pci_device.h"
+#include "hw/pci/msi.h"
+#include "qemu/module.h"
+#include "qom/object.h"
+#include "trace.h"
+
+#define TYPE_HAILO_STUB_STUB "hailo-stub-stub"
+typedef struct HailoStubStubState HailoStubStubState;
+DECLARE_INSTANCE_CHECKER(HailoStubStubState, HAILO_STUB_STUB, TYPE_HAILO_STUB_STUB)
+
+#define HAILO_VENDOR_ID  0x1e60
+#define HAILO_DEVICE_ID  0x2864
+#define HAILO_BAR0_SIZE  (4   * 1024)
+#define HAILO_BAR2_SIZE  (16  * 1024)
+#define HAILO_BAR4_SIZE  (1   * 1024 * 1024)
+
+struct HailoStubStubState {
+    PCIDevice parent_obj;
+    MemoryRegion bar0;
+    MemoryRegion bar2;
+    MemoryRegion bar4;
+};
+
+/*
+ * Probe-time magic register whitelist on BAR0. Two reads must succeed for
+ * `hailo_pci`'s probe to reach the `device_create_with_groups` call that
+ * creates /dev/hailo0:
+ *
+ * 1. hailo_pcie_is_device_connected() reads BAR0 + 0x0098 (16-bit)
+ *    and expects PCI_VENDOR_ID_HAILO (0x1e60).
+ *    (~/slmos-ref/hailo/v4.23.0/common/pcie_common.c:51, 884)
+ *
+ * 2. hailo_pcie_is_firmware_loaded(), for the Hailo-8 board path, reads
+ *    BAR0 + ATR_PCIE_BRIDGE_OFFSET(0) + offsetof(atr_trsl_addr_1) (32-bit)
+ *    = 0x700 + 8 = 0x708, and expects PCIE_CONTROL_SECTION_ADDRESS_H8
+ *    (0x60000000) so it can short-circuit firmware loading.
+ *    (~/slmos-ref/hailo/v4.23.0/common/pcie_common.c:817-821)
+ *
+ *    The short-circuit only triggers when the module is loaded with
+ *    `support_soft_reset=0`. 10-bind-stub.sh sets that.
+ *
+ * Without these, probe bails with "Failed reading device BARs, device may
+ * be disconnected" (1) or hangs on a 5-second firmware-load timeout (2).
+ * The corpus produced past these reads is HailoRT's actual MMIO sequence
+ * once it opens /dev/hailo0 — the DoD's "first BAR read" target.
+ *
+ * Resist extending this whitelist beyond what probe demands. Anything more
+ * is Task 0.2's surface.
+ */
+#define PCIE_CONFIG_VENDOR_OFFSET           0x0098
+#define PCI_VENDOR_ID_HAILO                 0x1e60
+#define HAILO_BAR0_FW_LOADED_OFFSET         0x0708
+#define PCIE_CONTROL_SECTION_ADDRESS_H8     0x60000000
+
+static uint64_t hailo_stub_bar0_read(void *opaque, hwaddr addr, unsigned size)
+{
+    /*
+     * The Hailo driver's `hailo_resource_read16` macro expands to a 32-bit
+     * MMIO read on x86 (the kernel masks the high 16 bits). So observed
+     * `size` here is 4 for the "_read16" case. Match both 2 and 4 for the
+     * vendor magic; the high 16 bits of a 32-bit response are always 0.
+     */
+    if (addr == PCIE_CONFIG_VENDOR_OFFSET && (size == 2 || size == 4)) {
+        return PCI_VENDOR_ID_HAILO;
+    }
+    if (addr == HAILO_BAR0_FW_LOADED_OFFSET && size == 4) {
+        return PCIE_CONTROL_SECTION_ADDRESS_H8;
+    }
+    return 0;
+}
+
+static uint64_t hailo_stub_read(void *opaque, hwaddr addr, unsigned size)
+{
+    return 0;
+}
+
+static void hailo_stub_write(void *opaque, hwaddr addr, uint64_t val,
+                             unsigned size)
+{
+    /* Writes are discarded. The interesting work happens in QEMU's
+     * memory_region_ops_write trace event, which fires before this callback. */
+}
+
+static const MemoryRegionOps hailo_stub_bar0_ops = {
+    .read       = hailo_stub_bar0_read,
+    .write      = hailo_stub_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .valid      = { .min_access_size = 1, .max_access_size = 8 },
+    .impl       = { .min_access_size = 1, .max_access_size = 8 },
+};
+
+static const MemoryRegionOps hailo_stub_ops = {
+    .read       = hailo_stub_read,
+    .write      = hailo_stub_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .valid      = { .min_access_size = 1, .max_access_size = 8 },
+    .impl       = { .min_access_size = 1, .max_access_size = 8 },
+};
+
+static void hailo_stub_realize(PCIDevice *pdev, Error **errp)
+{
+    HailoStubStubState *s = HAILO_STUB_STUB(pdev);
+    uint8_t *pci_conf = pdev->config;
+
+    /* Enable bus-master so the guest driver doesn't bail on PCI setup. */
+    pci_conf[PCI_INTERRUPT_PIN] = 1;
+
+    memory_region_init_io(&s->bar0, OBJECT(s), &hailo_stub_bar0_ops, s,
+                          "hailo-stub-bar0", HAILO_BAR0_SIZE);
+    memory_region_init_io(&s->bar2, OBJECT(s), &hailo_stub_ops, s,
+                          "hailo-stub-bar2", HAILO_BAR2_SIZE);
+    memory_region_init_io(&s->bar4, OBJECT(s), &hailo_stub_ops, s,
+                          "hailo-stub-bar4", HAILO_BAR4_SIZE);
+
+    pci_register_bar(pdev, 0,
+                     PCI_BASE_ADDRESS_SPACE_MEMORY |
+                     PCI_BASE_ADDRESS_MEM_TYPE_64,
+                     &s->bar0);
+    pci_register_bar(pdev, 2,
+                     PCI_BASE_ADDRESS_SPACE_MEMORY |
+                     PCI_BASE_ADDRESS_MEM_TYPE_64,
+                     &s->bar2);
+    pci_register_bar(pdev, 4,
+                     PCI_BASE_ADDRESS_SPACE_MEMORY |
+                     PCI_BASE_ADDRESS_MEM_TYPE_64,
+                     &s->bar4);
+
+    /* Single MSI vector so the guest driver can register an IRQ handler.
+     * The stub never raises MSIs; Task 0.2 will. */
+    if (msi_init(pdev, 0, 1, true, false, errp) < 0) {
+        /* Non-fatal — the kernel driver tolerates absence of MSI. */
+        *errp = NULL;
+    }
+}
+
+static void hailo_stub_class_init(ObjectClass *class, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(class);
+    PCIDeviceClass *k = PCI_DEVICE_CLASS(class);
+
+    k->realize     = hailo_stub_realize;
+    k->vendor_id   = HAILO_VENDOR_ID;
+    k->device_id   = HAILO_DEVICE_ID;
+    k->revision    = 0;
+    k->class_id    = PCI_CLASS_PROCESSOR_CO;
+
+    set_bit(DEVICE_CATEGORY_MISC, dc->categories);
+    dc->desc = "Hailo-8 stub-stub for RE capture";
+}
+
+static const TypeInfo hailo_stub_info = {
+    .name          = TYPE_HAILO_STUB_STUB,
+    .parent        = TYPE_PCI_DEVICE,
+    .instance_size = sizeof(HailoStubStubState),
+    .class_init    = hailo_stub_class_init,
+    .interfaces    = (InterfaceInfo[]) {
+        { INTERFACE_CONVENTIONAL_PCI_DEVICE },
+        { },
+    },
+};
+
+static void hailo_stub_register_types(void)
+{
+    type_register_static(&hailo_stub_info);
+}
+
+type_init(hailo_stub_register_types)

--- a/host-tools/hailort-vm/qemu-patch/hw/misc/hailo-stub-stub.c
+++ b/host-tools/hailort-vm/qemu-patch/hw/misc/hailo-stub-stub.c
@@ -23,11 +23,11 @@
  */
 
 #include "qemu/osdep.h"
+#include "qapi/error.h"
 #include "hw/pci/pci_device.h"
 #include "hw/pci/msi.h"
 #include "qemu/module.h"
 #include "qom/object.h"
-#include "trace.h"
 
 #define TYPE_HAILO_STUB_STUB "hailo-stub-stub"
 typedef struct HailoStubStubState HailoStubStubState;
@@ -126,8 +126,10 @@ static void hailo_stub_realize(PCIDevice *pdev, Error **errp)
 {
     HailoStubStubState *s = HAILO_STUB_STUB(pdev);
     uint8_t *pci_conf = pdev->config;
+    Error *local_err = NULL;
 
-    /* Enable bus-master so the guest driver doesn't bail on PCI setup. */
+    /* Advertise INTA so the kernel's PCI subsystem won't reject the device
+     * even when it falls back from MSI; the stub never asserts the line. */
     pci_conf[PCI_INTERRUPT_PIN] = 1;
 
     memory_region_init_io(&s->bar0, OBJECT(s), &hailo_stub_bar0_ops, s,
@@ -151,10 +153,11 @@ static void hailo_stub_realize(PCIDevice *pdev, Error **errp)
                      &s->bar4);
 
     /* Single MSI vector so the guest driver can register an IRQ handler.
-     * The stub never raises MSIs; Task 0.2 will. */
-    if (msi_init(pdev, 0, 1, true, false, errp) < 0) {
-        /* Non-fatal — the kernel driver tolerates absence of MSI. */
-        *errp = NULL;
+     * The stub never raises MSIs; Task 0.2 will. msi_init failure is
+     * non-fatal (the kernel driver tolerates absence of MSI), so discard
+     * the Error via local_err rather than leaking it through *errp. */
+    if (msi_init(pdev, 0, 1, true, false, &local_err) < 0) {
+        error_free(local_err);
     }
 }
 

--- a/host-tools/hailort-vm/tools/qemu-trace-to-corpus.py
+++ b/host-tools/hailort-vm/tools/qemu-trace-to-corpus.py
@@ -57,28 +57,23 @@ BAR_SIZE_BY_NAME = {
 }
 
 
-def parse_capture_window(serial_log: Path) -> tuple[int | None, int | None]:
+def check_capture_markers(serial_log: Path) -> bool:
     """
-    Return (begin_byte, end_byte) offsets bracketing the HAILORT_CAPTURE_BEGIN /
-    HAILORT_CAPTURE_DONE markers in the serial log. Used only for human-friendly
-    reporting — the QEMU trace itself has no synchronized timestamps with the
-    serial log, so we capture *everything* the trace emitted during the boot
-    and rely on the placeholder device having no other MMIO consumers.
+    Confirm the guest emitted both HAILORT_CAPTURE_BEGIN and HAILORT_CAPTURE_DONE
+    on the serial console. Returns True if both markers are present. Trace lines
+    are not filtered by capture window because QEMU's trace timestamps don't
+    cross-correlate with serial output — instead, the parser drops MMIO from
+    any MR not in BAR_NAME_MAP, which keeps the corpus scoped to the stub device.
     """
-    begin, end = None, None
     text = serial_log.read_text(errors="replace")
-    if "HAILORT_CAPTURE_BEGIN" in text:
-        begin = text.index("HAILORT_CAPTURE_BEGIN")
-    if "HAILORT_CAPTURE_DONE" in text:
-        end = text.index("HAILORT_CAPTURE_DONE")
-    return begin, end
+    return "HAILORT_CAPTURE_BEGIN" in text and "HAILORT_CAPTURE_DONE" in text
 
 
 def hex_value_to_le_bytes(value_hex: str, size: int) -> str:
     """
-    Corpus spec § operation entries: value is hex-encoded, little-endian, no 0x
-    prefix, lowercase, exactly size*2 characters. QEMU prints values as
-    big-endian integers (host byte order in hex), so we convert.
+    Convert an integer (parsed from QEMU's `value 0x...` trace field) into a
+    `size`-byte little-endian hex string. The corpus spec requires LE byte
+    order, lowercase hex, no 0x prefix, exactly `size * 2` characters.
     """
     v = int(value_hex, 16)
     return v.to_bytes(size, "little").hex()
@@ -97,16 +92,15 @@ def main() -> int:
     ap.add_argument("--output", required=True, type=Path)
     args = ap.parse_args()
 
-    begin, end = parse_capture_window(args.serial)
-    if begin is None or end is None:
-        print("warn: serial log missing CAPTURE_BEGIN/DONE markers; including all trace lines",
+    if not check_capture_markers(args.serial):
+        print("warn: serial log missing CAPTURE_BEGIN/DONE markers; capture may be incomplete",
               file=sys.stderr)
 
     seq = 0
     entries: list[dict] = []
     unknown_names: set[str] = set()
     dropped = 0
-    total_trace_lines = 0
+    matched_trace_lines = 0
 
     with args.trace.open(errors="replace") as fh:
         for line in fh:
@@ -116,7 +110,7 @@ def main() -> int:
             m = TRACE_LINE.match(line)
             if not m:
                 continue
-            total_trace_lines += 1
+            matched_trace_lines += 1
             name = m.group("name") or ""
 
             if name not in BAR_NAME_MAP:
@@ -177,7 +171,7 @@ def main() -> int:
 
     print(f"corpus: {args.output}", file=sys.stderr)
     print(f"  ops: {len(entries)}", file=sys.stderr)
-    print(f"  trace lines parsed: {total_trace_lines}", file=sys.stderr)
+    print(f"  matched trace lines: {matched_trace_lines}", file=sys.stderr)
     print(f"  dropped (unknown MR): {dropped}", file=sys.stderr)
     if unknown_names:
         print(f"  unknown MR names seen: {sorted(unknown_names)}", file=sys.stderr)

--- a/host-tools/hailort-vm/tools/qemu-trace-to-corpus.py
+++ b/host-tools/hailort-vm/tools/qemu-trace-to-corpus.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Convert a QEMU --trace memory_region_ops_{read,write} log into the corpus JSONL
+# format defined in docs/hailo-re-corpus-format.md.
+#
+# QEMU 8.x emits memory_region_ops_read/write trace events in this shape:
+#
+#   memory_region_ops_read cpu 0 mr 0x55a... addr 0x10 value 0x0 size 4 name 'edu-mmio'
+#   memory_region_ops_write cpu 0 mr 0x55a... addr 0x14 value 0x42 size 4 name 'edu-mmio'
+#
+# (The exact bytes-per-line vary by QEMU version. The parser is permissive —
+# it pulls addr / value / size / name / direction via regex and ignores the rest.)
+#
+# This parser is intentionally minimal and scoped to the Task 0.3 placeholder.
+# Once Task 0.2 lands a real Hailo stub that emits corpus entries directly,
+# this script becomes redundant.
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+TRACE_LINE = re.compile(
+    r"^memory_region_ops_(?P<dir>read|write)\s+"
+    r"cpu\s+\d+\s+"
+    r"mr\s+0x[0-9a-fA-F]+\s+"
+    r"addr\s+0x(?P<addr>[0-9a-fA-F]+)\s+"
+    r"value\s+0x(?P<value>[0-9a-fA-F]+)\s+"
+    r"size\s+(?P<size>\d+)"
+    r"(?:\s+name\s+'(?P<name>[^']*)')?"
+)
+
+
+# MemoryRegion names of interest. The Task 0.3 stub-stub device exposes three
+# BARs named hailo-stub-bar0/2/4 (matching the corpus spec). The edu-mmio
+# entry is a fallback for environments where the custom QEMU isn't built —
+# corpora from edu are not useful protocol artifacts.
+BAR_NAME_MAP = {
+    "hailo-stub-bar0": 0,
+    "hailo-stub-bar2": 2,
+    "hailo-stub-bar4": 4,
+    "edu-mmio": 0,    # fallback only
+}
+
+# Each BAR's size, used to convert the absolute guest-physical addresses in
+# QEMU 8.2's memory_region_ops_* trace events back to BAR-relative offsets.
+# Match hailo-stub-stub.c's HAILO_BAR*_SIZE constants.
+BAR_SIZE_BY_NAME = {
+    "hailo-stub-bar0": 4 * 1024,
+    "hailo-stub-bar2": 16 * 1024,
+    "hailo-stub-bar4": 1 * 1024 * 1024,
+    "edu-mmio":        1 * 1024 * 1024,
+}
+
+
+def parse_capture_window(serial_log: Path) -> tuple[int | None, int | None]:
+    """
+    Return (begin_byte, end_byte) offsets bracketing the HAILORT_CAPTURE_BEGIN /
+    HAILORT_CAPTURE_DONE markers in the serial log. Used only for human-friendly
+    reporting — the QEMU trace itself has no synchronized timestamps with the
+    serial log, so we capture *everything* the trace emitted during the boot
+    and rely on the placeholder device having no other MMIO consumers.
+    """
+    begin, end = None, None
+    text = serial_log.read_text(errors="replace")
+    if "HAILORT_CAPTURE_BEGIN" in text:
+        begin = text.index("HAILORT_CAPTURE_BEGIN")
+    if "HAILORT_CAPTURE_DONE" in text:
+        end = text.index("HAILORT_CAPTURE_DONE")
+    return begin, end
+
+
+def hex_value_to_le_bytes(value_hex: str, size: int) -> str:
+    """
+    Corpus spec § operation entries: value is hex-encoded, little-endian, no 0x
+    prefix, lowercase, exactly size*2 characters. QEMU prints values as
+    big-endian integers (host byte order in hex), so we convert.
+    """
+    v = int(value_hex, 16)
+    return v.to_bytes(size, "little").hex()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--trace", required=True, type=Path,
+                    help="QEMU trace log (from -trace ...,file=...)")
+    ap.add_argument("--serial", required=True, type=Path,
+                    help="Guest serial log (for capture markers)")
+    ap.add_argument("--hailort-version", required=True)
+    ap.add_argument("--capture-host", required=True)
+    ap.add_argument("--slmos-base-sha", required=True)
+    ap.add_argument("--fw-version", default="4.23.0")
+    ap.add_argument("--output", required=True, type=Path)
+    args = ap.parse_args()
+
+    begin, end = parse_capture_window(args.serial)
+    if begin is None or end is None:
+        print("warn: serial log missing CAPTURE_BEGIN/DONE markers; including all trace lines",
+              file=sys.stderr)
+
+    seq = 0
+    entries: list[dict] = []
+    unknown_names: set[str] = set()
+    dropped = 0
+    total_trace_lines = 0
+
+    with args.trace.open(errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            m = TRACE_LINE.match(line)
+            if not m:
+                continue
+            total_trace_lines += 1
+            name = m.group("name") or ""
+
+            if name not in BAR_NAME_MAP:
+                if name:
+                    unknown_names.add(name)
+                # Drop trace lines for memory regions we don't recognize (e.g.
+                # serial UART MMIO, PCI config space). The placeholder edu
+                # device is what we care about; ignore the rest.
+                dropped += 1
+                continue
+
+            size = int(m.group("size"))
+            value_hex = hex_value_to_le_bytes(m.group("value"), size)
+            # QEMU 8.x's memory_region_ops_{read,write} trace emits the
+            # *absolute* guest-physical address. BARs are size-aligned, so
+            # offset-within-BAR = abs_addr & (bar_size - 1).
+            abs_addr = int(m.group("addr"), 16)
+            bar_size = BAR_SIZE_BY_NAME.get(name, 1 << 20)
+            offset = abs_addr & (bar_size - 1)
+            seq += 1
+            entries.append({
+                "type": "op",
+                "seq": seq,
+                "bar": BAR_NAME_MAP[name],
+                "offset": offset,
+                "size": size,
+                "dir": m.group("dir"),
+                "value": value_hex,
+                "source": "qemu_capture",
+                "validated_at_commit": None,
+                "validated_at": None,
+                "note": f"placeholder/{name}",
+            })
+
+    header = {
+        "type": "header",
+        "format_version": 1,
+        "hailort_version": args.hailort_version,
+        "fw_version": args.fw_version,
+        "capture_host": args.capture_host,
+        "slmos_base_sha": args.slmos_base_sha,
+        "capture_started_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "notes": "Task 0.3 placeholder capture against hailo-stub-stub QEMU device. BAR0 reads return 0 except for vendor magic (0x98) and firmware-loaded magic (0x708); all BAR2/BAR4 reads return 0. Captured MMIO is HailoRT's deterministic write sequence under that stub — not a real Hailo protocol artifact, but a faithful capture-invariant proof.",
+    }
+    trailer = {
+        "type": "trailer",
+        "ended_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "last_seq": seq,
+        "reason": "capture_run_complete",
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w") as out:
+        out.write(json.dumps(header) + "\n")
+        for e in entries:
+            out.write(json.dumps(e) + "\n")
+        out.write(json.dumps(trailer) + "\n")
+
+    print(f"corpus: {args.output}", file=sys.stderr)
+    print(f"  ops: {len(entries)}", file=sys.stderr)
+    print(f"  trace lines parsed: {total_trace_lines}", file=sys.stderr)
+    print(f"  dropped (unknown MR): {dropped}", file=sys.stderr)
+    if unknown_names:
+        print(f"  unknown MR names seen: {sorted(unknown_names)}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/host-tools/hailort-vm/verify-determinism.sh
+++ b/host-tools/hailort-vm/verify-determinism.sh
@@ -76,7 +76,7 @@ echo
 echo "RESULT: NON-DETERMINISTIC — runs A and B diverge."
 echo "Diff:                ${DIFF_OUT}"
 echo "First mismatch (op): "
-diff -u "${OPS_A}" "${OPS_B}" | grep -E '^[-+]' | grep -v '^[-+]{3}' | head -20
+diff -u "${OPS_A}" "${OPS_B}" | grep -E '^[-+]' | grep -vE '^(---|\+\+\+) ' | head -20
 
 FIRST_A_DIVERGE="$(diff "${OPS_A}" "${OPS_B}" | grep -m1 -E '^< ' | sed 's/^< //')"
 FIRST_B_DIVERGE="$(diff "${OPS_A}" "${OPS_B}" | grep -m1 -E '^> ' | sed 's/^> //')"

--- a/host-tools/hailort-vm/verify-determinism.sh
+++ b/host-tools/hailort-vm/verify-determinism.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Run two captures back-to-back and diff them.
+#
+# The load-bearing deliverable of Task 0.3. If the two runs match byte-for-byte
+# (after stripping known-volatile fields), HailoRT's BAR write sequence is
+# deterministic and the corpus-based RE plan in #795 is viable. Any divergence
+# is reported with first-mismatch context and the verify exits non-zero.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CORPORA_DIR="${CORPORA_DIR:-$HOME/slmos-ref/derivatives/hailo-re-corpora}"
+mkdir -p "${CORPORA_DIR}"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_A="${CORPORA_DIR}/verify-${STAMP}-A.jsonl"
+RUN_B="${CORPORA_DIR}/verify-${STAMP}-B.jsonl"
+DIFF_OUT="${CORPORA_DIR}/verify-${STAMP}.diff"
+
+echo "=== Run A (${RUN_A}) ==="
+"${HERE}/launch-capture.sh" "${RUN_A}" --variant A
+echo
+echo "=== Run B (${RUN_B}) ==="
+"${HERE}/launch-capture.sh" "${RUN_B}" --variant B
+
+# ---------------------------------------------------------------------------
+# Diff strategy:
+#  - Strip the header (line 1) — capture_started_at and slmos_base_sha may match
+#    but timestamps differ.
+#  - Strip wall-clock-derived fields entirely.
+#  - Compare ops line-by-line.
+#
+# A pass means every `op` entry — same seq, bar, offset, size, dir, value —
+# matches across both runs. The host_clock/cpu_index trace fields are NOT in
+# the corpus so are not compared.
+# ---------------------------------------------------------------------------
+
+extract_ops() {
+    # Drop header / trailer; keep op lines only. Python's json.dumps inserts
+    # spaces after colons by default, so the literal needs to match either form.
+    grep -E '^\{"type": *"op"' "$1" || true
+}
+
+OPS_A="$(mktemp)"
+OPS_B="$(mktemp)"
+trap 'rm -f "${OPS_A}" "${OPS_B}"' EXIT
+
+extract_ops "${RUN_A}" > "${OPS_A}"
+extract_ops "${RUN_B}" > "${OPS_B}"
+
+A_COUNT=$(wc -l < "${OPS_A}")
+B_COUNT=$(wc -l < "${OPS_B}")
+echo
+echo "Run A: ${A_COUNT} op entries"
+echo "Run B: ${B_COUNT} op entries"
+
+if [[ "${A_COUNT}" -eq 0 || "${B_COUNT}" -eq 0 ]]; then
+    echo "ERROR: at least one run captured zero MMIO operations." >&2
+    echo "Check serial logs under ~/slmos-ref/derivatives/hailort-vm-images/.runs/" >&2
+    exit 6
+fi
+
+if diff -u "${OPS_A}" "${OPS_B}" > "${DIFF_OUT}"; then
+    echo
+    echo "RESULT: DETERMINISTIC — runs A and B match byte-for-byte across ${A_COUNT} op entries."
+    echo "Corpus A: ${RUN_A}"
+    echo "Corpus B: ${RUN_B}"
+    rm -f "${DIFF_OUT}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Non-deterministic: emit context.
+# ---------------------------------------------------------------------------
+echo
+echo "RESULT: NON-DETERMINISTIC — runs A and B diverge."
+echo "Diff:                ${DIFF_OUT}"
+echo "First mismatch (op): "
+diff -u "${OPS_A}" "${OPS_B}" | grep -E '^[-+]' | grep -v '^[-+]{3}' | head -20
+
+FIRST_A_DIVERGE="$(diff "${OPS_A}" "${OPS_B}" | grep -m1 -E '^< ' | sed 's/^< //')"
+FIRST_B_DIVERGE="$(diff "${OPS_A}" "${OPS_B}" | grep -m1 -E '^> ' | sed 's/^> //')"
+echo
+echo "Run A first divergent line:"
+echo "  ${FIRST_A_DIVERGE}"
+echo "Run B first divergent line:"
+echo "  ${FIRST_B_DIVERGE}"
+
+echo
+echo "Investigate determinism mitigations in host-tools/hailort-vm/README.md § Determinism."
+exit 7


### PR DESCRIPTION
## Summary

- Phase 0 Task 0.3 of [#795](https://github.com/SLM-OS/SLM-Operating-System/issues/795). Adds `host-tools/hailort-vm/` — a reproducible QEMU/KVM environment that runs Hailo's proprietary HailoRT v4.23 inside an Ubuntu 24.04 guest and records every BAR R/W operation HailoRT issues, in the corpus JSONL format defined by Task 0.1 (`docs/hailo-re-corpus-format.md`).
- Determinism answer (the load-bearing #795 deliverable): **yes, HailoRT's MMIO sequence is deterministic across runs** — 19/19 op entries byte-identical across two independent captures of `hailortcli fw-control identify` against the placeholder stub. The strict single-step + corpus discipline in the RE plan is viable.
- Placeholder QEMU device (`-device hailo-stub-stub`, ~190 lines C in `qemu-patch/`) advertises Hailo-8 IDs and three BARs sized 4 KB / 16 KB / 1 MB. Reads return 0 except for two probe-time magic registers (vendor at BAR0+0x98, firmware-loaded flag at BAR0+0x708). Throwaway — Task 0.2 (`hailo-re/0.2-qemu-stub`) replaces it with a corpus-driven stub; integration plan documented in the README's *Hand-off to Task 0.2* section.

## What's in the PR

- `README.md` — full procedure, determinism strategy, observed result, hand-off plan, list of host prerequisites
- `build-qemu.sh` + `qemu-patch/` — fetch QEMU 8.2 source, apply the stub-stub patch, build a custom `qemu-system-x86_64`
- `build-vm-image.sh` + `cloud-init/` + `guest-scripts/` — Ubuntu 24.04 first-boot install of HailoRT `.deb`s + hailo_pci DKMS, with 14 determinism mitigations baked in
- `launch-capture.sh` + `verify-determinism.sh` + `tools/qemu-trace-to-corpus.py` — capture orchestration + JSONL post-processor + two-run differential validator

Out of repo (in `~/slmos-ref/derivatives/`): VM disk images, custom QEMU binary, captured corpora, HailoRT `.deb` packages.

## Quirks worth a reviewer's attention

Sources of mid-iteration failure I worked through; all documented inline:

- Hailo `.deb` postinst scripts use `read -s -p ... -t 10` with no fallback for closed stdin → install bails under non-interactive dpkg → fixed via `yes Y | dpkg -i ...`
- `linux-headers-generic` pulls a newer `linux-image` than the cloud image's running kernel → DKMS targets the wrong kernel → `modprobe hailo_pci` fails at next boot. Fixed by pinning to `linux-headers-$(uname -r)`.
- The `hailo_pci` module registers as PCI driver name `hailo` (not `hailo_pci`) in `/sys/bus/pci/drivers/`. Source: `~/slmos-ref/hailo/v4.23.0/common/pcie_common.h:DRIVER_NAME`.
- `~/slmos-ref` symlinks through a Dropbox path containing spaces, which breaks QEMU's `configure` (line ~955, `python="$python -B"` whitespace-splits). Build root forced to `/var/tmp/qemu-stub-build/`.
- The driver does a **32-bit** read for `hailo_resource_read16` (high bits ignored); my stub matches both `size==2` and `size==4` for the vendor magic.
- QEMU 8.2 changed `memory_region_ops_*` trace events to emit the absolute guest-physical address instead of MR-relative offset; the parser converts back via `abs_addr & (bar_size - 1)`.
- Module params `support_soft_reset=0 no_power_mode=1` skip two post-probe paths the stub-stub doesn't fake (`hailo_pcie_soft_reset` and `pci_set_power_state(PCI_D3hot)`).

## Test plan

- [x] `./build-qemu.sh` builds a `qemu-system-x86_64` that registers `-device hailo-stub-stub`.
- [x] `./build-vm-image.sh` produces a reproducible qcow2 from upstream Ubuntu 24.04 cloud image + cloud-init.
- [x] `./launch-capture.sh` boots the qcow2, `hailo_pci` auto-probes the stub-stub, `/dev/hailo0` is created, `hailortcli fw-control identify` reaches its first BAR read.
- [x] `./verify-determinism.sh` runs two captures back-to-back; both produce identical 19-op corpora.
- [ ] (Reviewer can re-run) Once Task 0.2 lands a corpus-driven stub, swap `-device hailo-stub-stub` → `-device hailo-stub,corpus=…`, retire the patch + build-qemu.sh, re-run determinism on the larger MMIO surface.

Refs: #795 (parent), #682 (target of the RE plan), [`docs/hailo-re-corpus-format.md`](docs/hailo-re-corpus-format.md), [`docs/hailo-protocol-architecture.md`](docs/hailo-protocol-architecture.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)