### PR TITLE
gpu/ga10b: populate RAMFC + engine_wfi in rebuilt inst block (#788 Stage 3)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1049,6 +1049,88 @@ int ga10b_gmmu_free(uint64_t inst_block_phys,
 #define GA10B_RAM_IN_USE_VER2_PT_FORMAT   0x400u
 #define GA10B_RAM_IN_BIG_PAGE_SIZE_64KB   0x800u
 
+/* RAMFC field word offsets per
+ * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_ram_ga10b.h:118-140`.
+ * RAMFC starts at word 0 of the inst block and ends at word 127;
+ * PDB lives at words 128/129. All offsets here are word indices
+ * (multiply by 4 for the byte offset into the inst block). */
+#define GA10B_RAMFC_W_SIGNATURE            4u
+#define GA10B_RAMFC_W_ACQUIRE              12u
+#define GA10B_RAMFC_W_GP_BASE              18u
+#define GA10B_RAMFC_W_GP_BASE_HI           19u
+#define GA10B_RAMFC_W_PB_HEADER            33u
+#define GA10B_RAMFC_W_SUBDEVICE            37u
+#define GA10B_RAMFC_W_TARGET               43u
+#define GA10B_RAMFC_W_CONFIG               61u
+#define GA10B_RAMFC_W_INTR_NOTIFY          62u
+#define GA10B_RAMFC_W_SET_CHANNEL_INFO     63u
+/* engine_wfi block (post-PDB), word 134 for the VEID field. */
+#define GA10B_RAMIN_W_ENGINE_WFI_VEID      134u
+
+/* PBDMA-encoded field values for a default Tegra GA10B channel
+ * (chid=0, subctx=1 ASYNC veid, engine=GR rleng_id=0, intr_vec=0,
+ * privileged-config=no, long acquire timeout saturated). Derived
+ * by mechanically following the L4T r36.4.4 nvgpu HAL ops chain:
+ *
+ *   .signature   = gp10b_pbdma_get_signature
+ *                  → litter(GPFIFO_CLASS) = AMPERE_CHANNEL_GPFIFO_B
+ *   .pb_header   = gv11b_pbdma_get_fc_pb_header
+ *                  → method_zero | subch_zero | level_main |
+ *                    first_true | type_inc
+ *   .subdevice   = gm20b_pbdma_get_fc_subdevice
+ *                  → subdevice_id(1) | status_active | channel_dma_enable
+ *   .target      = ga10b_pbdma_get_fc_target
+ *                  → engine_f(rleng=0) | eng_ctx_valid_true | ce_ctx_valid_true
+ *   .acquire     = gm20b_pbdma_acquire_val (2 s scaled saturates)
+ *                  → retry_man_2 | retry_exp_2 |
+ *                    timeout_man_max | timeout_exp_max | timeout_en_enable
+ *   .intr_notify = ga10b_pbdma_set_intr_notify(0)
+ *                  → vector_f(0) | ctrl_cpu_enable | ctrl_gsp_disable
+ *   .config      = gv11b_pbdma_config_userd_writeback_enable(0)
+ *                  → userd_writeback_enable bit (12)
+ *
+ * Documented offsets keyed back to the L4T header so a future
+ * investigator can re-derive these from the nvgpu source if the
+ * Tegra HAL chain ever changes. */
+#define GA10B_RAMFC_VAL_SIGNATURE          0x0000C76Fu  /* AMPERE_CHANNEL_GPFIFO_B */
+#define GA10B_RAMFC_VAL_PB_HEADER          0x20400000u  /* first | type_inc */
+#define GA10B_RAMFC_VAL_SUBDEVICE          0x30000001u  /* id=1 | active | dma_enable */
+#define GA10B_RAMFC_VAL_TARGET_GR          0x00030000u  /* rleng=0 | eng+ce_ctx_valid */
+#define GA10B_RAMFC_VAL_ACQUIRE_LONG       0xFFFF7902u  /* saturated 2 s acquire */
+#define GA10B_RAMFC_VAL_INTR_NOTIFY        0x80000000u  /* vec=0 | cpu_enable */
+#define GA10B_RAMFC_VAL_CONFIG_USERD_WB    0x00001000u  /* userd_writeback bit */
+
+/* `set_channel_info` is read-modify-write on a 32-bit value with
+ * `chid` at bits[27:16] and `veid` at bits[13:8]. We start from 0
+ * (the inst block was just zeroed) and OR in the encoded fields. */
+#define GA10B_RAMFC_SET_CHANNEL_INFO(chid, veid) \
+    ((((uint32_t)(chid) & 0xfffu) << 16) | (((uint32_t)(veid) & 0x3fu) << 8))
+
+/* The helper's CREATE_SUBCONTEXT call publishes subctx_id=1 (ASYNC
+ * veid=1). The handoff doesn't carry this explicitly today
+ * (channel_id and tsg_id are u32 fields but veid is implicit);
+ * hardcoded here matching the helper's invariant. If a future
+ * helper revision uses a different subctx_id, both this constant
+ * AND the helper need updating in lock-step — fortunately the
+ * runlist + USERD config flow through SLM-OS only handles single-
+ * subctx channels today, so the hardcode is the simplest safe
+ * choice. Document in `ga10b_channel_handoff.h` if a veid field
+ * is ever added to the handoff struct. */
+#define GA10B_HELPER_SUBCTX_ID             1u
+
+/* Compute log2 of `n` for n that's a non-zero power of two. Used
+ * for the gpfifo `limit2` field in gp_base_hi which encodes
+ * log2(num_entries). Returns 0 for n=0 (defensive — caller should
+ * have validated). The handoff always carries
+ * GPU_LAUNCH_GPFIFO_ENTRIES (currently 512 → log2 = 9), but the
+ * computation generalises so a future helper change doesn't bake
+ * the magic 9 in. */
+static inline uint32_t log2_pow2(uint32_t n)
+{
+    if (n == 0) return 0;
+    return (uint32_t)__builtin_ctz(n);
+}
+
 /* Map `n_pages` of contiguous physical memory at the given GPU
  * VA. Helper for the rebuild path — calls into the existing
  * `map_one_page` so it benefits from the auto-allocated
@@ -1114,12 +1196,76 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
 
     inst[128] = pdb_lo_word;
     inst[129] = pdb_hi_word;
+
+    /* 2b. Populate RAMFC fields PBDMA reads when fetching submits
+     *    for this channel. Without these, PBDMA finds gpfifo_phys
+     *    = 0 in the inst block and silently does nothing — the
+     *    Stage 2 PR's known limitation. Mirrors
+     *    `ga10b_ramfc_setup` from
+     *    `~/slmos-ref/nvidia/nvgpu-hal-fifo-ramfc_ga10b_fusa.c`,
+     *    with the PBDMA-HAL-computed values inlined as constants
+     *    above (the HAL chain dispatches through 4 chip-version
+     *    HAL ops to produce them on Linux; we replicate the
+     *    Tegra GA10B output values directly). */
+
+    /* `gp_base_offset_f` shifts the gpfifo phys's bits[31:3] into
+     * word bits[31:3]. We just need to mask off the bottom 3 bits;
+     * gpfifo phys is page-aligned (4 KB) so the bottom 12 bits are
+     * already zero, but the mask keeps the encoding explicit. */
+    uint32_t gp_base_lo_val =
+        (uint32_t)(h->gpfifo_phys & 0xfffffff8u);
+    /* `gp_base_hi` carries phys bits[39:32] in bits[7:0], and the
+     * gpfifo size in entries-log2 at bits[20:16]. Tegra GA10B
+     * gpfifo phys is 40-bit so the high byte is at most 0xFF. */
+    uint32_t gp_base_hi_val =
+        ((uint32_t)(h->gpfifo_phys >> 32) & 0xffu) |
+        (log2_pow2(h->gpfifo_entries) << 16);
+
+    inst[GA10B_RAMFC_W_GP_BASE]       = gp_base_lo_val;
+    inst[GA10B_RAMFC_W_GP_BASE_HI]    = gp_base_hi_val;
+    inst[GA10B_RAMFC_W_SIGNATURE]     = GA10B_RAMFC_VAL_SIGNATURE;
+    inst[GA10B_RAMFC_W_PB_HEADER]     = GA10B_RAMFC_VAL_PB_HEADER;
+    inst[GA10B_RAMFC_W_SUBDEVICE]     = GA10B_RAMFC_VAL_SUBDEVICE;
+    inst[GA10B_RAMFC_W_TARGET]        = GA10B_RAMFC_VAL_TARGET_GR;
+    inst[GA10B_RAMFC_W_ACQUIRE]       = GA10B_RAMFC_VAL_ACQUIRE_LONG;
+    inst[GA10B_RAMFC_W_INTR_NOTIFY]   = GA10B_RAMFC_VAL_INTR_NOTIFY;
+    inst[GA10B_RAMFC_W_CONFIG]        = GA10B_RAMFC_VAL_CONFIG_USERD_WB;
+    inst[GA10B_RAMFC_W_SET_CHANNEL_INFO] =
+        GA10B_RAMFC_SET_CHANNEL_INFO(h->channel_id,
+                                      GA10B_HELPER_SUBCTX_ID);
+
+    /* engine_wfi block (post-RAMFC, pre-PDB region for the
+     * engine-wait-for-idle save pointer). Only the VEID is written
+     * by `ga10b_ramfc_setup`; ptr_lo/ptr_hi/target stay zero in
+     * the inherited channel because the helper doesn't allocate a
+     * GR ctxsw save buffer (Tegra's nvgpu lazy-allocates it on
+     * first GR engagement, and the helper never engages GR — only
+     * does host-family sema releases on subch 0). */
+    inst[GA10B_RAMIN_W_ENGINE_WFI_VEID] = GA10B_HELPER_SUBCTX_ID;
+
     cache_clean_range((void *)(uintptr_t)inst_block_phys, 4096);
 
-    uart_printf("[rebuild-gmmu] inst_block@0x%lx written: "
-                "PDB_lo=0x%08x PDB_hi=0x%08x\n",
-                (unsigned long)inst_block_phys,
+    uart_printf("[rebuild-gmmu] inst_block@0x%lx written:\n",
+                (unsigned long)inst_block_phys);
+    uart_printf("[rebuild-gmmu]   PDB_lo=0x%08x PDB_hi=0x%08x\n",
                 (unsigned)pdb_lo_word, (unsigned)pdb_hi_word);
+    uart_printf("[rebuild-gmmu]   gp_base=0x%08x gp_base_hi=0x%08x "
+                "(entries=%u → log2=%u)\n",
+                (unsigned)gp_base_lo_val, (unsigned)gp_base_hi_val,
+                (unsigned)h->gpfifo_entries,
+                (unsigned)log2_pow2(h->gpfifo_entries));
+    uart_printf("[rebuild-gmmu]   signature=0x%08x pb_header=0x%08x "
+                "subdevice=0x%08x target=0x%08x\n",
+                GA10B_RAMFC_VAL_SIGNATURE, GA10B_RAMFC_VAL_PB_HEADER,
+                GA10B_RAMFC_VAL_SUBDEVICE, GA10B_RAMFC_VAL_TARGET_GR);
+    uart_printf("[rebuild-gmmu]   acquire=0x%08x intr_notify=0x%08x "
+                "config=0x%08x set_channel_info=0x%08x veid=%u\n",
+                GA10B_RAMFC_VAL_ACQUIRE_LONG,
+                GA10B_RAMFC_VAL_INTR_NOTIFY,
+                GA10B_RAMFC_VAL_CONFIG_USERD_WB,
+                GA10B_RAMFC_SET_CHANNEL_INFO(h->channel_id,
+                                              GA10B_HELPER_SUBCTX_ID),
+                (unsigned)GA10B_HELPER_SUBCTX_ID);
 
     /* 3. Map each preserved buffer at its original GPU VA. The
      *    handoff publishes (phys, gpu_va, size) for every dmabuf


### PR DESCRIPTION
**Stacked on #803 (Stage 2).** Review #801 (Stage 1) and #803 (Stage 2) first; this PR's base will auto-update to whichever lands first.

## Summary

Builds on #803's GMMU rebuild. Stage 2 wrote only the PDB pointer in the inst block, leaving PBDMA to read \`gpfifo_phys=0\` and silently fetch nothing. Stage 3 populates the rest of the RAMFC fields PBDMA needs (\`gp_base\`, \`signature\`, \`pb_header\`, \`subdevice\`, \`target\`, \`acquire\`, \`config\`, \`intr_notify\`, \`set_channel_info\`) plus the \`engine_wfi_veid\` field, mirroring nvgpu's \`ga10b_ramfc_setup\` from \`~/slmos-ref/nvidia/nvgpu-hal-fifo-ramfc_ga10b_fusa.c\`.

Encoded values derived by mechanically following the L4T r36.4.4 HAL chain (gm20b → gp10b → gv11b → ga10b PBDMA ops) and inlining the chip-version outputs as named constants. Each constant carries a comment naming the source HAL op so a future investigator can re-derive it from nvgpu.

## Fields written

| word | byte off | field | value |
|------|----------|-------|-------|
| 4    | +0x010 | signature        | \`0x0000C76F\` (AMPERE_CHANNEL_GPFIFO_B) |
| 12   | +0x030 | acquire          | \`0xFFFF7902\` (saturated 2 s timeout) |
| 18   | +0x048 | gp_base          | \`gpfifo_phys[31:3]\` (encoded) |
| 19   | +0x04C | gp_base_hi       | \`gpfifo_phys[39:32]\` | \`(log2(entries)<<16)\` |
| 33   | +0x084 | pb_header        | \`0x20400000\` (type_inc | first_true) |
| 37   | +0x094 | subdevice        | \`0x30000001\` (id=1 | active | dma_enable) |
| 43   | +0x0AC | target           | \`0x00030000\` (rleng=0 GR | eng+ce_ctx_valid) |
| 61   | +0x0F4 | config           | \`0x00001000\` (userd_writeback_enable) |
| 62   | +0x0F8 | intr_notify      | \`0x80000000\` (vec=0 | cpu_enable) |
| 63   | +0x0FC | set_channel_info | \`(chid<<16) | (veid<<8)\` |
| 134  | +0x218 | engine_wfi_veid  | \`veid\` (subctx_id) |

## Hardware verification on jetson-nano-1 (2026-05-12)

Test sequence: helper → kexec → \`nvgpu inherit / channel / rebuild-gmmu\`, then progressively-harder smoke tests:

\`\`\`
nvgpu submit         → rc=0, state=7   (host-family SEMAPHORE_RELEASE fires sema)
nvgpu submit-compute → rc=0, state=7   (AMPERE_COMPUTE_B SEMAPHORE_RELEASE fires)
slm xload smollm     → 100 MB GGUF streams + W3 staging + register (clean)
slm xload qwen       → 1778 chunks (~109 MB) staged before a different wedge
\`\`\`

**The original #788 fault signature does not fire at any point.** \`gr_intr=0x00080000\` / \`fault_during_ctxsw\` / \`INVALID_PDE\` at VA \`0xc01000\` — the triple that defined #788 — is gone. The rebuilt channel functions as a real PBDMA-decoded submission target for both host-family and compute-class methods.

## Progression across stages

| Test | Before #788 fix | Stage 1 (#801) | Stage 2 (#803) | **Stage 3 (this)** |
|---|---|---|---|---|
| inst block contents | garbage | all-zero | PDB only | PDB + RAMFC |
| FECS_ERROR_PENDING wedge | fires | fires | gone | gone |
| \`nvgpu submit\` | wedges | wedges | GP_GET stuck | **rc=0** |
| \`slm xload smollm\` | wedges chunk 0 | wedges chunk 0 | wedges chunk 0 | **loads cleanly** |
| \`slm xload qwen\` | wedges chunk 0 | wedges chunk 0 | wedges chunk 0 | wedges chunk 1778 |

Stage 3 is the first stage where SLM-OS can actually submit work through the inherited channel.

## Remaining limitation: 1.5 GB weights-pool partially mapped

The handoff publishes only the FIRST physical page's phys for the 1.5 GB IOVMM weights pool — the rest is SMMU-stitched from physically-scattered pages, and the helper does \`virt_to_phys\` on only the first page. Stage 2 / Stage 3 map only that one 4 KB page in the rebuilt GMMU; CE memcpy writes past page 1 land in unmapped VAs.

On Tegra GA10B, those out-of-bounds CE writes apparently succeed silently for many chunks before tripping a deferred-fault threshold around chunk 1778 (~109 MB into 191 MB of Qwen weights). SmolLM at ~100 MB stays under the threshold and completes cleanly.

**This is a SEPARATE bug** from the original #788 wedge — it's about the helper not publishing per-page phys for SMMU-stitched allocations, not about kernel-internal nvgpu allocations being freed. Fix path: extend the helper to walk \`/proc/self/pagemap\` over the weights-pool dmabuf and publish a list of \`(phys, page_count)\` extents in the handoff, then map each extent in the rebuild path. Tracked separately.

## Hard-coded assumption: subctx_id

\`set_channel_info\`'s veid and \`engine_wfi_veid\` use a compile-time \`GA10B_HELPER_SUBCTX_ID = 1\` matching the helper's \`CREATE_SUBCONTEXT(type=ASYNC, veid=1)\` call. The handoff struct doesn't publish veid today; if a future helper revision uses a different veid, both this constant AND the helper need updating in lock-step. If a future handoff struct grows a veid field, replace the constant with \`h->subctx_id\`. Currently only single-subctx channels are supported through SLM-OS's runlist + USERD flow, so the hard-code is the simplest safe choice.

## Test plan

- [x] \`make test\` passes (QEMU ARM64; no new unit tests — the RAMFC encoding is field-shift arithmetic and the integration is hardware-only)
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` builds clean
- [x] \`make kernel PLATFORM=RASPI5\` builds clean (the rebuild function is in Jetson-only \`ga10b_gmmu.c\`)
- [x] Hardware on jetson-nano-1: original #788 fault eliminated, \`nvgpu submit\` / \`submit-compute\` both rc=0, SmolLM xload clean, Qwen progresses 1778 chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)