### PR TITLE
[WIP] gpu/ga10b: weights-pool per-page extents handoff + GMMU mapping (#788 Stage 4)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1250,12 +1250,18 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
      *      accept the W1 handoff; oplib_pool consumers still
      *      check `version >= 8u` before reading the trailing
      *      weights_pool_* fields.
-     * Phase 6 inherit accepts all seven; launch_kernel version-gates
+     * v9: + weights-pool per-page extents (weights_extents_phys +
+     *      weights_n_extents). Lets SLM-OS map the full 1.5 GB
+     *      IOVMM-stitched weights pool post-kexec instead of just
+     *      the first 4 KB. Helpers that don't allocate a weights
+     *      pool leave these at zero; SLM-OS rebuild path falls
+     *      back to the Stage 3 single-page mapping. #788 Stage 4.
+     * Phase 6 inherit accepts all eight; launch_kernel version-gates
      * at dispatch time (v3 minimum for single-shot, v5 for pipelines,
      * v7 for the QMD-pool path, v8 for the weights pool). */
     if (h->version != 2 && h->version != 3 &&
         h->version != 4 && h->version != 5 && h->version != 6 &&
-        h->version != 7 && h->version != 8) return -1;
+        h->version != 7 && h->version != 8 && h->version != 9) return -1;
     if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
         h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
     if (h->work_submit_token == 0) return -1;
@@ -1443,6 +1449,14 @@ int ga10b_bringup_channel_kind(struct ga10b_bringup *b, uint32_t wanted_kind)
     g_handoff.weights_pool_phys       = hoff->weights_pool_phys;
     g_handoff.weights_pool_gpu_va     = hoff->weights_pool_gpu_va;
     g_handoff.weights_pool_size_bytes = hoff->weights_pool_size_bytes;
+
+    /* v9 extension: weights-pool per-page extents. Same
+     * "unconditional read is safe" argument as v7/v8 — the
+     * `_Static_assert` pins the offsets so a v8 helper leaves
+     * these as zero and SLM-OS's rebuild path falls back to the
+     * single-page mapping. #788 Stage 4. */
+    g_handoff.weights_extents_phys = hoff->weights_extents_phys;
+    g_handoff.weights_n_extents    = hoff->weights_n_extents;
 
     /* Validate the handoff block (pure-logic, host-testable). */
     if (ga10b_validate_handoff((const struct ga10b_channel_handoff *)

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -273,7 +273,80 @@ struct ga10b_channel_handoff {
     uint64_t weights_pool_phys;
     uint64_t weights_pool_gpu_va;
     uint64_t weights_pool_size_bytes;
+
+    /* --- v9 extension: weights-pool per-page physical layout. ---
+     * Zero on v2..v8. Populated by the helper when it walks the
+     * weights pool's pages via /proc/self/pagemap and coalesces
+     * consecutive physical pages into extents.
+     *
+     * The 1.5 GB IOVMM weights pool is SMMU-stitched from
+     * physically-scattered pages — `weights_pool_phys` records
+     * only the FIRST page's CPU phys (the rest can't be derived
+     * by `phys + offset` arithmetic). For SLM-OS to install GMMU
+     * PTEs covering the entire pool post-kexec (#788 Stage 4),
+     * the helper publishes a list of `(phys, n_pages)` extents
+     * describing the contiguous physical runs that make up the
+     * IO-virtually-contiguous 1.5 GB region.
+     *
+     * `weights_extents_phys` is the CPU physical address of a
+     * separate dmabuf containing an array of
+     * `struct ga10b_phys_extent` entries. The dmabuf is
+     * page-aligned (4 KB) and sized to hold at most
+     * GA10B_WEIGHTS_EXTENTS_MAX entries (see below). The phys
+     * is in DRAM and identity-mapped, so SLM-OS can read it
+     * directly without re-walking GMMU.
+     *
+     * `weights_n_extents` is the actual count of valid entries.
+     * If the helper finds more physical runs than the dmabuf
+     * can hold, it warns and truncates — SLM-OS only maps the
+     * extents that fit; the tail of the weights pool will
+     * trigger MMU faults if a CE memcpy writes there. The
+     * helper's warning gives a fix-by-resizing path.
+     *
+     * SLM-OS PMM also reserves every extent's pages via the
+     * `pmm_user_reserve_add` API (PR #801), so the kernel
+     * doesn't allocate from physical pages that the GPU is
+     * about to receive weight data into.
+     *
+     * Backward compatible: a v8-or-earlier helper writes zero
+     * here; SLM-OS sees `weights_n_extents == 0` and falls back
+     * to mapping the single first-page run from
+     * `weights_pool_phys` (the Stage 3 behaviour).
+     *
+     * Note: this field only applies when `weights_pool_size_bytes`
+     * is non-zero. A helper that didn't allocate a weights pool
+     * leaves both at zero. */
+    uint64_t weights_extents_phys;
+    uint32_t weights_n_extents;
+    uint32_t _pad_v9;
 };
+
+/* One entry in the v9 weights-pool extents array. Represents a
+ * contiguous run of physical pages within the IOVMM-stitched
+ * weights pool. Walking the entries in order from GPU-VA
+ * `weights_pool_gpu_va`, each extent covers `n_pages * 4 KB` of
+ * virtual address space starting at the cursor (which advances
+ * by `n_pages * 4 KB` after each extent).
+ *
+ * Wire-format-locked to 16 bytes — pinned by static_assert
+ * below. */
+struct ga10b_phys_extent {
+    uint64_t phys;        /* run's base physical address (4 KB aligned) */
+    uint32_t n_pages;     /* number of consecutive 4 KB pages */
+    uint32_t reserved;    /* zero; reserved for future flags */
+};
+
+/* Cap on extents the helper publishes. With 1.5 GB at 4 KB pages
+ * = 393,216 pages, the worst case is one extent per page (most
+ * scattered allocation) → too many to inline. In practice nvmap's
+ * IOVMM allocator returns sequences of contiguous runs (often
+ * dozens to low thousands of extents for a 1.5 GB CMA-backed
+ * region on Tegra), so 8192 caps the dmabuf at 128 KB (8192 × 16
+ * bytes) — generous for empirically-observed L4T behaviour, leaves
+ * headroom for fragmentation as the system ages. If a future
+ * helper logs `extents truncated`, bump this cap on both sides
+ * in lock-step and re-publish the handoff. */
+#define GA10B_WEIGHTS_EXTENTS_MAX 8192u
 
 /* Pipeline-kind discriminator values stored in
  * `struct ga10b_channel_handoff::pipeline_kind`. Numbered to keep
@@ -364,12 +437,17 @@ struct ga10b_pipeline_op_v7 {
  * (qmd_pool_phys + qmd_pool_gpu_va + qmd_pool_size_bytes +
  * qmd_pool_n_slots) → 232 + 24 = 256. v8 grows it by another 24
  * (weights_pool_phys + weights_pool_gpu_va +
- * weights_pool_size_bytes) → 256 + 24 = 280. */
-_Static_assert(sizeof(struct ga10b_channel_handoff) == 280,
+ * weights_pool_size_bytes) → 256 + 24 = 280. v9 grows it by 16
+ * (weights_extents_phys + weights_n_extents + _pad_v9) → 280 + 16
+ * = 296. */
+_Static_assert(sizeof(struct ga10b_channel_handoff) == 296,
                "ga10b_channel_handoff layout changed — update Linux "
                "helper (scripts/gpu-channel-helper.c, "
                "scripts/gpu-kernel-launch.c, scripts/gpu-launch-common.c) "
                "and bump version");
+_Static_assert(sizeof(struct ga10b_phys_extent) == 16,
+               "ga10b_phys_extent layout changed — Linux helper and "
+               "SLM-OS must agree on the v9 extents-array entry size");
 _Static_assert(sizeof(struct ga10b_pipeline_op) == 24,
                "ga10b_pipeline_op layout changed — Linux + SLM-OS "
                "must agree on the per-op size");
@@ -440,6 +518,15 @@ _Static_assert(offsetof(struct ga10b_channel_handoff, weights_pool_gpu_va) == 26
                "v8 weights_pool_gpu_va offset drifted");
 _Static_assert(offsetof(struct ga10b_channel_handoff, weights_pool_size_bytes) == 272,
                "v8 weights_pool_size_bytes offset drifted");
+
+/* v9 extents descriptor — appended after weights_pool_size_bytes.
+ * `weights_n_extents == 0` lets a v9-aware reader detect a v8-
+ * built handoff (where these bytes are zero) and fall back to
+ * mapping just `weights_pool_phys` as a single 4 KB run. */
+_Static_assert(offsetof(struct ga10b_channel_handoff, weights_extents_phys) == 280,
+               "v9 weights_extents_phys offset drifted");
+_Static_assert(offsetof(struct ga10b_channel_handoff, weights_n_extents) == 288,
+               "v9 weights_n_extents offset drifted");
 
 _Static_assert(offsetof(struct ga10b_pipeline_op, qmd_gpu_va) == 0,
                "pipeline_op.qmd_gpu_va must be at offset 0");

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1298,12 +1298,17 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
           (uint64_t)h->cbuf_size },
         { "qmd_pool", h->qmd_pool_phys, h->qmd_pool_gpu_va,
           (uint64_t)h->qmd_pool_size_bytes },
-        /* Weights pool: only the first physical page's phys is
-         * known. The 1.5 GB region is SMMU-stitched from
-         * scattered pages so a single (phys, size) reserve
-         * doesn't cover the rest. Map the first page so the
-         * caller can at least chunk-0-test W3 staging; further
-         * pages will MMU-fault and the wedge handler will dump. */
+        /* Weights pool: when the helper publishes a v9 extents
+         * list, we walk it below (after this fixed-list loop)
+         * and map every extent. The single-page first-run entry
+         * stays here as a fallback for v8 helpers — SLM-OS sees
+         * `weights_n_extents == 0` and maps only this 4 KB run,
+         * mirroring the Stage 3 behaviour. v9 helpers leave
+         * `weights_pool_phys` populated (matches the first
+         * extent's phys) so the entry is harmlessly redundant
+         * with extent[0] — the GMMU's PTE write is idempotent
+         * since both writes encode the same `phys → gpu_va`
+         * mapping for the first page. */
         { "weights_first", h->weights_pool_phys, h->weights_pool_gpu_va,
           (h->weights_pool_size_bytes != 0) ? 4096ull : 0ull },
     };
@@ -1330,6 +1335,70 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
                     b->tag, (unsigned long)b->gpu_va,
                     (unsigned long)b->phys, (unsigned)n_pages);
         mapped++;
+    }
+
+    /* v9 weights-pool extents — the helper walks
+     * /proc/self/pagemap over the 1.5 GB IOVMM-stitched pool
+     * pre-kexec and publishes a list of (phys, n_pages) extents
+     * in a separate dmabuf. Walk them and install PTEs covering
+     * the entire pool. Without this, only the first 4 KB above
+     * is mapped and CE memcpy writes past that fault.
+     *
+     * The cursor advances by `n_pages * 4 KB` per extent because
+     * the pool is IO-virtually contiguous at `weights_pool_gpu_va`
+     * — the SMMU stitches scattered phys into one IOVA range —
+     * but the underlying physical pages aren't contiguous. Each
+     * extent maps a contiguous physical run to its corresponding
+     * stretch of GPU VA. */
+    if (h->version >= 9u && h->weights_n_extents > 0u &&
+        h->weights_extents_phys != 0u &&
+        h->weights_pool_gpu_va != 0u) {
+        if (!phys_in_dram(h->weights_extents_phys,
+                          (size_t)h->weights_n_extents *
+                          sizeof(struct ga10b_phys_extent))) {
+            uart_printf("[rebuild-gmmu] weights_extents_phys=0x%lx "
+                        "(n=%u) outside DRAM — skipping extent map\n",
+                        (unsigned long)h->weights_extents_phys,
+                        (unsigned)h->weights_n_extents);
+        } else {
+            const struct ga10b_phys_extent *exts =
+                (const struct ga10b_phys_extent *)
+                (uintptr_t)h->weights_extents_phys;
+            uint64_t cursor_va = h->weights_pool_gpu_va;
+            uint32_t total_pages_mapped = 0;
+            uint32_t failed_at = 0;
+            bool extent_fail = false;
+            for (uint32_t i = 0; i < h->weights_n_extents; i++) {
+                if (exts[i].n_pages == 0u) {
+                    continue;
+                }
+                if (rebuild_map_range(pdb_phys, cursor_va,
+                                       exts[i].phys,
+                                       exts[i].n_pages) < 0) {
+                    failed_at = i;
+                    extent_fail = true;
+                    break;
+                }
+                cursor_va += (uint64_t)exts[i].n_pages * 4096ull;
+                total_pages_mapped += exts[i].n_pages;
+            }
+            if (extent_fail) {
+                uart_printf("[rebuild-gmmu] weights extents FAIL at "
+                            "index %u of %u (mapped %u pages before "
+                            "failure)\n",
+                            (unsigned)failed_at,
+                            (unsigned)h->weights_n_extents,
+                            (unsigned)total_pages_mapped);
+                return -1;
+            }
+            uart_printf("[rebuild-gmmu]  ok   weights_extents  "
+                        "n=%u total_pages=%u (~%u MB) end_va=0x%lx\n",
+                        (unsigned)h->weights_n_extents,
+                        (unsigned)total_pages_mapped,
+                        (unsigned)(total_pages_mapped / 256u),
+                        (unsigned long)cursor_va);
+            mapped++;
+        }
     }
 
     /* Amortized dsb sy so all PTE writes are visible to the GPU

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -47,7 +47,9 @@
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 
+#include "ga10b_channel_handoff.h"
 #include "ga10b_gmmu.h"
+#include "../../include/dtb.h"
 #include "../../include/pmm.h"
 #include "../../include/uart.h"
 
@@ -144,6 +146,193 @@ void ga10b_kexec_handoff_register_reserves(void)
                 (unsigned long)inst_phys,
                 (unsigned)GA10B_INST_BLOCK_BYTES,
                 (unsigned)reg, (unsigned)target);
+
+    /* #788 Stage 4 — scan DRAM for the handoff and reserve every
+     * weights-pool extent it lists. The IOVMM-stitched 1.5 GB
+     * weights pool is physically scattered across hundreds-to-
+     * thousands of contiguous runs; without reserving each run's
+     * pages, SLM-OS PMM allocates from those pages and the CE
+     * memcpy writes during W3 staging clobber whatever kernel
+     * data SLM-OS put there.
+     *
+     * The handoff itself lives somewhere in the 4-8 GB DRAM
+     * range (the helper's nvmap allocation lands wherever the
+     * IOVMM heap has room). Scanning at 4 KB stride is ~50 ms
+     * one-time-only at boot; acceptable cost for the protection.
+     *
+     * If the scan fails (no handoff found) we still finished the
+     * inst-block reservation above — a fresh-boot or no-helper
+     * test path that doesn't have a kexec'd channel works
+     * normally without the extents protection. */
+    uart_puts("[ga10b-reserve] scanning DRAM for handoff magic + "
+              "weights-pool extents...\n");
+    uint64_t handoff_phys =
+        ga10b_find_handoff_in_range(0x100000000ull, 0x200000000ull,
+                                     4096ull);
+    if (handoff_phys == 0) {
+        uart_puts("[ga10b-reserve]   handoff not found — skipping "
+                  "weights-pool extent reservation\n");
+        return;
+    }
+
+    /* Reserve the handoff dmabuf page itself first (cheap + small). */
+    if (pmm_user_reserve_add(handoff_phys & ~4095ull, 4096ull) != 0) {
+        uart_printf("[ga10b-reserve]   pmm_user_reserve_add for "
+                    "handoff page @0x%lx failed (table full?)\n",
+                    (unsigned long)handoff_phys);
+    } else {
+        uart_printf("[ga10b-reserve]   reserved handoff dmabuf "
+                    "@0x%lx (4 KB)\n",
+                    (unsigned long)(handoff_phys & ~4095ull));
+    }
+    const volatile struct ga10b_channel_handoff *h =
+        (const volatile struct ga10b_channel_handoff *)
+        (uintptr_t)handoff_phys;
+    uint32_t version = h->version;
+    uint32_t n_extents = h->weights_n_extents;
+    uint64_t extents_phys = h->weights_extents_phys;
+
+    /* Reserve every helper-allocated buffer the channel needs
+     * (USERD, GPFIFO, pushbuf, sem, SASS pool, cbuf, QMD pool).
+     * Without these, SLM-OS PMM can hand them out to its own
+     * allocations (e.g. the GMMU rebuild's page-table pages —
+     * Stage 4 maps a 1.5 GB weights pool which requires ~3 MB of
+     * PTE tables, way more PMM activity than the Stage 3
+     * single-page case), and the channel state gets clobbered.
+     * Stage 3 worked without these because the PTE-table footprint
+     * was tiny (a few pages); Stage 4's larger PTE footprint
+     * surfaced the latent collision.
+     *
+     * Each buffer is small + finite (max ~1 MB for SASS pool);
+     * collectively well under the PMM user-reserve table cap.
+     * Read the (volatile) handoff fields into locals first so the
+     * struct-initializer fits a static helper table cleanly. */
+    {
+        uint64_t userd_p   = h->userd_phys;
+        uint64_t gpfifo_p  = h->gpfifo_phys;
+        uint32_t gpfifo_e  = h->gpfifo_entries;
+        uint32_t gpfifo_es = h->gpfifo_entry_size;
+        uint64_t pushbuf_p = h->pushbuf_phys;
+        uint32_t pushbuf_s = h->pushbuf_size;
+        uint64_t sem_p     = h->semaphore_phys;
+        uint64_t shader_p  = h->shader_phys;
+        uint32_t shader_s  = h->shader_size;
+        uint64_t cbuf_p    = h->cbuf_phys;
+        uint32_t cbuf_s    = h->cbuf_size;
+        uint64_t qmd_p     = h->qmd_pool_phys;
+        uint32_t qmd_s     = h->qmd_pool_size_bytes;
+
+        struct {
+            const char *tag;
+            uint64_t phys;
+            uint64_t size;
+        } refs[] = {
+            { "userd",    userd_p,   4096 },
+            { "gpfifo",   gpfifo_p,  (uint64_t)gpfifo_e * (uint64_t)gpfifo_es },
+            { "pushbuf",  pushbuf_p, (uint64_t)pushbuf_s },
+            { "sem",      sem_p,     4096 },
+            { "shader",   shader_p,  (uint64_t)shader_s },
+            { "cbuf",     cbuf_p,    (uint64_t)cbuf_s },
+            { "qmd_pool", qmd_p,     (uint64_t)qmd_s },
+        };
+        for (size_t i = 0; i < sizeof(refs) / sizeof(refs[0]); i++) {
+            if (refs[i].phys == 0 || refs[i].size == 0) {
+                continue;
+            }
+            uint64_t base = refs[i].phys & ~4095ull;
+            uint64_t end  = (refs[i].phys + refs[i].size + 4095ull) &
+                            ~4095ull;
+            uint64_t sz   = end - base;
+            if (pmm_user_reserve_add(base, sz) != 0) {
+                uart_printf("[ga10b-reserve]   pmm_user_reserve_add "
+                            "for %s @0x%lx failed (table full?)\n",
+                            refs[i].tag, (unsigned long)base);
+            } else {
+                uart_printf("[ga10b-reserve]   reserved %s @0x%lx "
+                            "(%llu B)\n",
+                            refs[i].tag, (unsigned long)base,
+                            (unsigned long long)sz);
+            }
+        }
+    }
+    if (version < 9u || n_extents == 0u || extents_phys == 0u) {
+        uart_printf("[ga10b-reserve]   handoff@0x%lx v=%u no v9 "
+                    "extents (n=%u extents_phys=0x%lx) — skipping\n",
+                    (unsigned long)handoff_phys, (unsigned)version,
+                    (unsigned)n_extents, (unsigned long)extents_phys);
+        return;
+    }
+    uint64_t extents_bytes =
+        (uint64_t)n_extents * sizeof(struct ga10b_phys_extent);
+    if (!ga10b_phys_in_dram(extents_phys, (size_t)extents_bytes)) {
+        uart_printf("[ga10b-reserve]   extents_phys=0x%lx (n=%u) "
+                    "outside DRAM — skipping\n",
+                    (unsigned long)extents_phys, (unsigned)n_extents);
+        return;
+    }
+
+    /* Reserve the extents dmabuf itself so PMM doesn't allocate
+     * from it before the rebuild path reads it. The dmabuf can
+     * be 100s of KB for a fragmented IOVMM allocation (1033
+     * extents × 16 B = 16 KB; capped at GA10B_WEIGHTS_EXTENTS_MAX
+     * × 16 B = 128 KB), much larger than the inst-block page or
+     * handoff dmabuf — without explicit reservation, SLM-OS PMM
+     * easily hands those pages to ramdisk allocations or model
+     * preload buffers, and by rebuild-time the extents array
+     * reads as random bytes. */
+    {
+        uint64_t extents_page_base = extents_phys & ~4095ull;
+        uint64_t extents_page_end =
+            (extents_phys + extents_bytes + 4095ull) & ~4095ull;
+        uint64_t extents_reserve_bytes =
+            extents_page_end - extents_page_base;
+        if (pmm_user_reserve_add(extents_page_base,
+                                  extents_reserve_bytes) != 0) {
+            uart_printf("[ga10b-reserve]   pmm_user_reserve_add for "
+                        "extents dmabuf failed — array will be at "
+                        "risk of clobber between boot and rebuild\n");
+        } else {
+            uart_printf("[ga10b-reserve]   reserved extents dmabuf "
+                        "@0x%lx (%llu B)\n",
+                        (unsigned long)extents_page_base,
+                        (unsigned long long)extents_reserve_bytes);
+        }
+    }
+
+    const struct ga10b_phys_extent *exts =
+        (const struct ga10b_phys_extent *)(uintptr_t)extents_phys;
+    int reserved_count = 0;
+    int skipped_count = 0;
+    uint64_t total_pages = 0;
+    for (uint32_t i = 0; i < n_extents; i++) {
+        uint64_t ph = exts[i].phys;
+        uint32_t np = exts[i].n_pages;
+        if (np == 0u) {
+            continue;
+        }
+        uint64_t sz = (uint64_t)np * 4096ull;
+        if (!ga10b_phys_in_dram(ph, sz)) {
+            skipped_count++;
+            continue;
+        }
+        if (pmm_user_reserve_add(ph, sz) != 0) {
+            uart_printf("[ga10b-reserve]   pmm_user_reserve_add "
+                        "failed at extent %u/%u — table full, "
+                        "tail unprotected\n",
+                        (unsigned)i, (unsigned)n_extents);
+            break;
+        }
+        reserved_count++;
+        total_pages += np;
+    }
+    uart_printf("[ga10b-reserve]   weights extents: %u reserved "
+                "(%llu pages, ~%llu MB), %u skipped (outside DRAM), "
+                "from handoff@0x%lx\n",
+                (unsigned)reserved_count,
+                (unsigned long long)total_pages,
+                (unsigned long long)(total_pages / 256ull),
+                (unsigned)skipped_count,
+                (unsigned long)handoff_phys);
 }
 
 #else  /* !PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/include/pmm.h
+++ b/kernel/include/pmm.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "dtb.h"  /* dtb_memreserve_t for pmm_user_reserve_add_array */
 
 /* Page sizes */
 #define PAGE_SIZE           4096            /* 4 KB standard page */
@@ -101,6 +102,27 @@ void pmm_init(void);
  * in single-CPU context before scheduler bring-up, so callers don't
  * need to synchronize. */
 int pmm_user_reserve_add(uint64_t phys, uint64_t size);
+
+/*
+ * Bulk wrapper around `pmm_user_reserve_add` for callers that have
+ * a contiguous array of (phys, size) pairs to register — the
+ * canonical case being #788 Stage 4's weights-pool extent list,
+ * where the helper publishes potentially thousands of extents
+ * describing the physically-scattered IOVMM allocation. Calling
+ * `pmm_user_reserve_add` per-entry would still work but spreads
+ * the loop into the caller; this helper keeps the loop centralized
+ * with the rest of the user-reserve API.
+ *
+ * `extents[i].addr` and `extents[i].size` are passed through to
+ * `pmm_user_reserve_add` unchanged. Returns the number of
+ * successfully-added entries; stops early on the first failure
+ * (table full or zero-size entry), which lets the caller see
+ * how many made it before truncation.
+ *
+ * Same pre-`pmm_init` ordering constraint as the single-entry
+ * variant. */
+int pmm_user_reserve_add_array(const dtb_memreserve_t *extents,
+                                size_t n_extents);
 
 /*
  * Test-only accessor: read back the number of user reserves currently

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -467,17 +467,34 @@ int pmm_carve_reserves(uintptr_t start, uintptr_t end,
 /* User-supplied reserve slots. PMM init feeds these into the same
  * `pmm_carve_reserves` pipeline as the firmware /memreserve/ entries,
  * so runtime-discovered protected ranges (the canonical case: nvgpu
- * inst block + GMMU page tables that survived kexec but live in
- * physical pages SLM-OS would otherwise allocate from) get carved
- * out before any page is published to the buddy. See
- * `pmm_user_reserve_add` in pmm.h.
+ * inst block + GMMU page tables + IOVMM-stitched weights-pool
+ * extents that survived kexec but live in physical pages SLM-OS
+ * would otherwise allocate from) get carved out before any page is
+ * published to the buddy. See `pmm_user_reserve_add` in pmm.h.
  *
- * Capacity sized for the Jetson kexec-handoff caller, which adds at
- * most a handful of regions per boot. Sized to PMM_MAX_USER_RESERVES
- * = 16 — generous for the current use case, leaves room for
- * follow-on work (PDB-tree-walk-style enumeration) without revisiting
- * the cap. */
-#define PMM_MAX_USER_RESERVES 16
+ * Capacity bumped from 16 → 2048 in #788 Stage 4 to accommodate the
+ * weights-pool extents: a 1.5 GB IOVMM-stitched allocation
+ * empirically decomposes into 2-1100 contiguous runs on Tegra
+ * GA10B (depends on CMA fragmentation at allocation time on a
+ * freshly-booted vs long-running Linux). 2048 caps the array at
+ * 32 KB (2048 × 16 bytes) — generous over the highest observed
+ * extent count (~1033 on a fragmented allocation), and small
+ * enough that the boot-time BSS bloat is well within the
+ * kernel image's existing budget. If a future helper logs
+ * "extents truncated", bump this cap and the helper's
+ * `GA10B_WEIGHTS_EXTENTS_MAX` together.
+ *
+ * The helper-side cap in `ga10b_channel_handoff.h`
+ * (`GA10B_WEIGHTS_EXTENTS_MAX = 8192`) is larger than this cap on
+ * purpose: the helper publishes the full list, and SLM-OS picks
+ * the prefix that fits — anything past entry 2048 won't get a
+ * PMM reservation but WILL still get a GMMU mapping (the rebuild
+ * path walks the entire list, only the reservation hook truncates).
+ * A page mapped but not reserved is at risk if PMM also allocates
+ * from it; in practice the helper's IOVMM phys range and SLM-OS
+ * PMM's allocations rarely overlap, so the partial protection is
+ * sufficient until a future bump. */
+#define PMM_MAX_USER_RESERVES 2048
 static dtb_memreserve_t pmm_user_reserves[PMM_MAX_USER_RESERVES];
 static size_t           pmm_n_user_reserves = 0;
 
@@ -502,6 +519,23 @@ int pmm_user_reserve_add(uint64_t phys, uint64_t size)
     pmm_user_reserves[pmm_n_user_reserves].size = size;
     pmm_n_user_reserves++;
     return 0;
+}
+
+int pmm_user_reserve_add_array(const dtb_memreserve_t *extents,
+                                size_t n_extents)
+{
+    if (extents == NULL) {
+        return 0;
+    }
+    int added = 0;
+    for (size_t i = 0; i < n_extents; i++) {
+        if (pmm_user_reserve_add(extents[i].addr,
+                                  extents[i].size) != 0) {
+            break;
+        }
+        added++;
+    }
+    return added;
 }
 
 size_t pmm_user_reserve_count(void)

--- a/kernel/tests/test_pmm.c
+++ b/kernel/tests/test_pmm.c
@@ -1118,13 +1118,13 @@ static void test_user_reserve_table_full_rejects(void)
 {
     pmm_user_reserve_reset();
 
-    /* Fill the table — capacity = PMM_MAX_USER_RESERVES (16, file-
-     * static in pmm.c). Use an inflated upper bound (32) to avoid
-     * the test breaking when the capacity is bumped; the loop just
-     * notices when adds start failing and asserts the count tops
-     * out at the natural cap. */
+    /* Fill the table — capacity = PMM_MAX_USER_RESERVES (file-static
+     * in pmm.c). The current value is 8192 (#788 Stage 4 bumped from
+     * 16 to fit the weights-pool extents list); the upper-bound here
+     * is 10000 so the loop has headroom over the cap and the
+     * test still works if the cap is bumped further. */
     int last_ok_count = 0;
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < 10000; i++) {
         int rc = pmm_user_reserve_add(
             (uint64_t)(0x100000 + (uint64_t)i * 0x1000), 0x1000);
         if (rc == 0) {

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -771,6 +771,149 @@ int main(int argc, char **argv)
                (unsigned long long)weights_pool_gva);
     }
 
+    /* #788 Stage 4: walk the weights pool's pages via
+     * /proc/self/pagemap, coalesce consecutive physical pages
+     * into extents, and publish the list in a separate dmabuf
+     * so SLM-OS can re-establish GMMU PTEs covering the entire
+     * pool post-kexec.
+     *
+     * The 1.5 GB IOVMM-stitched pool is physically scattered
+     * (CMA backing returns hundreds-to-thousands of separate
+     * contiguous physical runs depending on fragmentation).
+     * `weights_pool_phys` records only the first page's phys;
+     * the rest is invisible without the explicit per-page walk
+     * this loop performs.
+     *
+     * Cap matches `GA10B_WEIGHTS_EXTENTS_MAX` in the shared
+     * handoff header (8192 entries × 16 bytes = 128 KB dmabuf).
+     * If a future allocation fragments more than that, we
+     * truncate and warn; the operator's fix is to bump the cap
+     * on both sides in lock-step. */
+    int      extents_dmabuf = -1;
+    void    *extents_va     = NULL;
+    uint64_t extents_phys   = 0;
+    uint32_t n_extents      = 0;
+    const uint32_t MAX_EXTENTS = 8192u;  /* matches GA10B_WEIGHTS_EXTENTS_MAX */
+    const size_t   extents_bytes_total =
+        (size_t)MAX_EXTENTS * sizeof(struct ga10b_phys_extent);
+    if (weights_pool_size > 0 && weights_pool_va != NULL) {
+        extents_dmabuf = nvmap_alloc_dmabuf(nvmap_fd,
+                                            (uint64_t)extents_bytes_total,
+                                            4096);
+        extents_va = mmap(NULL, extents_bytes_total,
+                          PROT_READ | PROT_WRITE,
+                          MAP_SHARED, extents_dmabuf, 0);
+        if (extents_va == MAP_FAILED) {
+            perror("[gpu-helper] mmap extents dmabuf");
+            extents_va = NULL;
+        } else {
+            memset(extents_va, 0, extents_bytes_total);
+            msync(extents_va, extents_bytes_total, MS_SYNC);
+            extents_phys = virt_to_phys(extents_va);
+            if (extents_phys == 0) {
+                fprintf(stderr, "[gpu-helper] extents dmabuf phys "
+                        "resolution failed — extents disabled\n");
+                extents_va = NULL;
+            }
+        }
+    }
+
+    if (extents_va != NULL) {
+        /* First-touch the weights pool to force every page to
+         * fault in. NVMAP's IOVMM-backed dmabuf creates a userspace
+         * mmap that's lazy — pages aren't bound to physical backing
+         * until accessed. Without touching them first,
+         * /proc/self/pagemap reports "page not present" for the
+         * entire 1.5 GB and the extent walk finds nothing.
+         *
+         * A single byte read per page is enough to fault it in.
+         * 393,216 pages × ~ns-scale read ≈ ~1-2 s on Tegra Orin
+         * Nano — a one-time pre-kexec cost; nothing on the hot
+         * path. */
+        {
+            volatile uint8_t *touch = (volatile uint8_t *)weights_pool_va;
+            for (size_t pi = 0;
+                 pi < weights_pool_size / 4096u;
+                 pi++) {
+                (void)touch[pi * 4096u];
+            }
+        }
+
+        /* Walk every 4 KB page in the weights pool, resolving
+         * its physical address via /proc/self/pagemap. Coalesce
+         * consecutive pages whose physes match `prev_phys +
+         * 4 KB` into one extent entry, and flush the current
+         * extent when a discontinuity appears or we reach the
+         * pool's end. */
+        struct ga10b_phys_extent *extents = extents_va;
+        size_t   total_pages  = weights_pool_size / 4096u;
+        uint64_t cur_run_phys = 0;
+        uint32_t cur_run_pages = 0;
+        size_t   pagemap_failures = 0;
+        uint8_t *base = (uint8_t *)weights_pool_va;
+
+        for (size_t pi = 0; pi < total_pages; pi++) {
+            uint64_t va = (uint64_t)(uintptr_t)base + pi * 4096ull;
+            uint64_t phys = virt_to_phys((void *)(uintptr_t)va);
+            if (phys == 0) {
+                pagemap_failures++;
+                /* Flush current run; skip this page. SLM-OS
+                 * will leave the corresponding 4 KB hole in
+                 * the GMMU and a CE memcpy that lands there
+                 * will MMU-fault. */
+                if (cur_run_pages > 0 && n_extents < MAX_EXTENTS) {
+                    extents[n_extents].phys = cur_run_phys;
+                    extents[n_extents].n_pages = cur_run_pages;
+                    extents[n_extents].reserved = 0;
+                    n_extents++;
+                    cur_run_phys = 0;
+                    cur_run_pages = 0;
+                }
+                continue;
+            }
+            if (cur_run_pages == 0) {
+                cur_run_phys = phys;
+                cur_run_pages = 1;
+            } else if (phys ==
+                       cur_run_phys + (uint64_t)cur_run_pages * 4096ull) {
+                cur_run_pages++;
+            } else {
+                /* Discontinuity — flush. */
+                if (n_extents < MAX_EXTENTS) {
+                    extents[n_extents].phys = cur_run_phys;
+                    extents[n_extents].n_pages = cur_run_pages;
+                    extents[n_extents].reserved = 0;
+                    n_extents++;
+                } else {
+                    /* Table full — break out, will warn below. */
+                    break;
+                }
+                cur_run_phys = phys;
+                cur_run_pages = 1;
+            }
+        }
+        /* Flush final run. */
+        if (cur_run_pages > 0 && n_extents < MAX_EXTENTS) {
+            extents[n_extents].phys = cur_run_phys;
+            extents[n_extents].n_pages = cur_run_pages;
+            extents[n_extents].reserved = 0;
+            n_extents++;
+        }
+        msync(extents_va, extents_bytes_total, MS_SYNC);
+
+        printf("[gpu-helper] Weights extents: %u runs (%zu pages "
+               "total) → phys=0x%llx",
+               (unsigned)n_extents, total_pages,
+               (unsigned long long)extents_phys);
+        if (n_extents == MAX_EXTENTS) {
+            printf(" [TRUNCATED — bump MAX_EXTENTS]");
+        }
+        if (pagemap_failures > 0) {
+            printf(" [%zu pagemap failures]", pagemap_failures);
+        }
+        printf("\n");
+    }
+
     /* Allocate a dedicated dmabuf for the handoff block. Writing via
      * /dev/mem is blocked by CONFIG_STRICT_DEVMEM for System RAM, but
      * we can write to dmabuf memory via its own mmap. SLM-OS scans
@@ -795,10 +938,11 @@ int main(int argc, char **argv)
      *   v8 — weights pool allocated (W1, this commit)
      *   v7 — QMD pool allocated (no weights pool)
      *   v2 — channel-only (no v7 pool, no weights pool)
-     * Each higher version is a strict superset: v7 readers can
-     * consume v8 handoffs by ignoring the trailing weights_pool_*
-     * fields, v2 readers ignore both v7 and v8 trailing bytes. */
-    uint32_t handoff_version = (weights_pool_size > 0) ? 8u
+     * Each higher version is a strict superset: v9 readers can
+     * consume v8 handoffs by ignoring the trailing weights_extents_*
+     * fields, v8 readers ignore v9, etc. */
+    uint32_t handoff_version = (n_extents > 0)         ? 9u
+                              : (weights_pool_size > 0) ? 8u
                               : (qmd_pool_slots > 0)   ? 7u
                               :                          2u;
     struct ga10b_channel_handoff hoff = {
@@ -846,6 +990,10 @@ int main(int argc, char **argv)
         .weights_pool_phys       = weights_pool_phys,
         .weights_pool_gpu_va     = weights_pool_gva,
         .weights_pool_size_bytes = weights_pool_size,
+        /* v9-only: weights-pool per-page extents. Zero in v2..v8
+         * mode (no pagemap walk done). #788 Stage 4. */
+        .weights_extents_phys    = extents_phys,
+        .weights_n_extents       = n_extents,
     };
     memcpy(handoff, &hoff, sizeof(hoff));
     msync(handoff, 4096, MS_SYNC);


### PR DESCRIPTION
**Stacked on #805 (Stage 3). Opened as DRAFT — Stage 4 introduces a regression in `nvgpu submit` that Stage 5 needs to root-cause.** Review #801 → #803 → #805 first.

## What works (framework end-to-end)

### Helper (`scripts/gpu-channel-helper.c`)
- Walks `/proc/self/pagemap` over the 1.5 GB IOVMM-stitched weights pool, touching every page first to fault them in (nvmap dmabufs are lazy-bound — without the touch loop, pagemap reports "page not present" for the entire 1.5 GB).
- Coalesces consecutive physical pages into `struct ga10b_phys_extent` entries (phys + n_pages).
- Allocates a separate dmabuf for the extents array (capped at 8192 entries = 128 KB), populates it, publishes its phys in the v9 handoff.
- Observed extents: 1-10 on fresh boots (most contiguous CMA), up to ~1100 on long-running systems.

### Handoff struct (v9)
- New fields: `weights_extents_phys` + `weights_n_extents` (with `_pad_v9`).
- New `struct ga10b_phys_extent` (phys u64 + n_pages u32 + reserved u32 = 16 B), `_Static_assert`-pinned.
- Struct grew 280 → 296 B; `_Static_assert` updated.
- `GA10B_WEIGHTS_EXTENTS_MAX = 8192` (matches helper).
- v9 added to `ga10b_validate_handoff` allow-list + bringup-channel field-copy block per the project's handoff-version-bump checklist (memory: `jetson_handoff_version_bump_checklist.md`).

### PMM
- `PMM_MAX_USER_RESERVES` bumped 16 → 2048 (BSS bloat ~32 KB).
- New `pmm_user_reserve_add_array` bulk-add helper.
- `test_user_reserve_table_full_rejects` loop bound bumped 32 → 10000.

### Reserve hook (`ga10b_handoff_reserve.c`)
- After the inst-block reserve, scans DRAM for the v9 handoff magic.
- Reserves: handoff page + every helper dmabuf (USERD, GPFIFO, pushbuf, sem, SASS pool, cbuf, QMD pool) + extents dmabuf + every weights-pool extent run.
- Typical 2-extent fresh-boot allocation produces ~12 reservations.

### GMMU rebuild
- After the fixed-buffer loop, walks the v9 extents and installs PTEs covering the full 1.5 GB at `weights_pool_gpu_va`.
- Bounds-checks the extents dmabuf before dereferencing.

## Hardware verification on jetson-nano-1 (2026-05-12) — what works

```
[ga10b-reserve] reserved kexec'd channel inst block at phys=0x12452b000
[ga10b-reserve] scanning DRAM for handoff magic + weights-pool extents...
[ga10b-reserve]   reserved handoff dmabuf @0x1aafc7000 (4 KB)
[ga10b-reserve]   reserved userd @0x1462db000 (4 KB)
[ga10b-reserve]   reserved gpfifo @0x13c40b000 (4 KB)
[ga10b-reserve]   reserved pushbuf @0x134b80000 (64 KB)
[ga10b-reserve]   reserved sem / shader / cbuf / qmd_pool ...
[ga10b-reserve]   reserved extents dmabuf @0x1aaad0000 (32 B)
[ga10b-reserve]   weights extents: 2 reserved (393216 pages, ~1536 MB)
...
nvgpu rebuild-gmmu
[rebuild-gmmu] inst_block@0x12452b000 written: PDB_lo=0xaaad1c07 PDB_hi=0x00000001
[rebuild-gmmu]  ok   pushbuf / sem / shader / cbuf / qmd_pool ...
[rebuild-gmmu]  ok   weights_extents  n=2 total_pages=393216 (~1536 MB) end_va=0x1f64000000
[rebuild-gmmu] TLB invalidate rc=0, 6 buffer(s) mapped
rebuild-gmmu: rc=0
```

Full 1.5 GB pool is now mapped. Inst block contents verified correct via `peek` (PDB pointer + RAMFC fields all match what the rebuild wrote).

## Regression vs Stage 3 (#805)

`nvgpu submit` (host-family pushbuffer smoke test) reports `GP_GET did not advance — PBDMA didn't see our submit` with no FECS error:

```
[GA10B-P7]   gr_intr=0x00000000 gr_exception=0x00000000 class_error=0x00000000
[GA10B-P7]   fecs_host_int=0x00000000 ctxsw_mb6=0x00000000 current_ctx=0x30124aab
```

Stage 3 passes the same test with `rc=0, state=7`. Stage 4 fails.

Pattern: Stage 4 has many more PMM reservations (helper bufs + extents) and a much larger GMMU PTE footprint (~3 MB of page-table pages for 1.5 GB at 4 KB pages vs a few pages in Stage 3 with only first-page mapping). The combination breaks PBDMA somehow.

`nvgpu instdump` post-submit confirms the inst block's RAMFC fields + PDB pointer are intact — so the inst block itself isn't getting clobbered. Something else in the GPU's view of the channel is.

## Working hypothesis for Stage 5

One of the extra PMM allocations during the rebuild's page-table creation lands on a page that some GPU FW component (FECS/PMU/runlist scratch) reads from, even though that component isn't supposed to use any channel-listed buffer. Stage 5 should:

1. **Bisect the regression.** Gate just the extent-mapping off; keep extra reservations. If `nvgpu submit` passes, the regression is from the larger PTE footprint. If it still fails, the regression is from the new reservations themselves.
2. **Dump intermediate page-table pages.** After the rebuild, dump the PDE3 / PDE2 / PDE1 / PDE0 pages and check none have been clobbered.
3. **Identify the unknown FW range.** If FW state isn't in any helper buffer, find where it is (read FECS scratch registers, dump FECS-bookkeeping pages).

## What this PR is good for

- Framework + helper changes are reviewable and reusable as scaffolding.
- v9 handoff is a documented stable wire format that future stages can extend.
- The pagemap walk + extents publishing on the helper side is independent infrastructure that doesn't regress anything; it could land separately if Stage 4 needs to be split.

## Test plan

- [x] `make test` passes (QEMU ARM64)
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] `make kernel PLATFORM=RASPI5` builds clean
- [x] Hardware: helper pagemap walk produces extents, handoff v9 published, SLM-OS reserves + maps all extents, inst block verified correct
- [ ] **Hardware: `nvgpu submit` rc=0 — REGRESSED. Stage 5 work needed.**
- [ ] Hardware: Qwen xload completes — blocked on the submit regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)