### PR TITLE
host-tools(hailo-re): Phase 1 bootstrap integration — #795

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -290,13 +290,17 @@ def _write_pending_corpus(corpus: Corpus, request: ExtendRequest) -> Path:
         dir=corpus.path.parent,
     )
     pending_path = Path(tmp_name)
-    # mkstemp creates the file before returning; if anything below raises
-    # (corpus moved/permissions lost between iterations, disk full on the
-    # write side, etc.) we still own the empty temp file and must clean it
-    # up before propagating.
+    # mkstemp returns both an open fd and a path on disk; if anything below
+    # raises (corpus moved/permissions lost between iterations, disk full on
+    # the write side, etc.) we own both the fd and the temp file and must
+    # release both before propagating. Wrap the fd in os.fdopen as the FIRST
+    # context manager so its __exit__ closes the fd even when the corpus
+    # open() that follows raises — `with A, B:` only enters B after A
+    # succeeds, so flipping the order means we don't leak the raw fd from
+    # mkstemp on an early failure in opening the source.
     try:
-        with corpus.path.open("r", encoding="utf-8") as src, \
-                open(fd, "w", encoding="utf-8") as dst:
+        with os.fdopen(fd, "w", encoding="utf-8") as dst, \
+                corpus.path.open("r", encoding="utf-8") as src:
             dst.write(src.read())
             if not dst.tell() or not _ends_with_newline(corpus.path):
                 dst.write("\n")

--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import datetime as _dt
 import json
 import logging
+import os
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -289,20 +290,30 @@ def _write_pending_corpus(corpus: Corpus, request: ExtendRequest) -> Path:
         dir=corpus.path.parent,
     )
     pending_path = Path(tmp_name)
-    with corpus.path.open("r", encoding="utf-8") as src, \
-            open(fd, "w", encoding="utf-8") as dst:
-        dst.write(src.read())
-        if not dst.tell() or not _ends_with_newline(corpus.path):
+    # mkstemp creates the file before returning; if anything below raises
+    # (corpus moved/permissions lost between iterations, disk full on the
+    # write side, etc.) we still own the empty temp file and must clean it
+    # up before propagating.
+    try:
+        with corpus.path.open("r", encoding="utf-8") as src, \
+                open(fd, "w", encoding="utf-8") as dst:
+            dst.write(src.read())
+            if not dst.tell() or not _ends_with_newline(corpus.path):
+                dst.write("\n")
+            dst.write(json.dumps(
+                placeholder.to_json_obj(), separators=(",", ":")
+            ))
             dst.write("\n")
-        dst.write(json.dumps(placeholder.to_json_obj(), separators=(",", ":")))
-        dst.write("\n")
+    except BaseException:
+        pending_path.unlink(missing_ok=True)
+        raise
     return pending_path
 
 
 def _ends_with_newline(path: Path) -> bool:
     with path.open("rb") as f:
         try:
-            f.seek(-1, 2)  # SEEK_END
+            f.seek(-1, os.SEEK_END)
         except OSError:
             return True  # empty file — nothing to terminate
         return f.read(1) == b"\n"

--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -18,7 +18,9 @@ Pseudocode from KICKOFF.md (with rollback hooked up):
 from __future__ import annotations
 
 import datetime as _dt
+import json
 import logging
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Optional
@@ -108,6 +110,11 @@ def run_loop(
             iteration, corpus_path, corpus.last_validated_seq, corpus.next_seq,
         )
         event = qemu.run(corpus_path)
+        # The Task 0.2 stub appends unknown writes to the corpus file in
+        # place during its run (per hailo8.c::hailo8_bar_write). Reload so
+        # our in-memory view picks up those appended writes before deciding
+        # what to do with the event.
+        corpus = corpus_mod.load(corpus_path)
 
         if isinstance(event, ConfigureCompleteEvent):
             return LoopOutcome(
@@ -177,7 +184,19 @@ def _extend_corpus(
             ),
         )
 
-    result = slmos.replay_step(corpus.path, request.seq)
+    # SLM-OS `hailo replay-step` (Task 0.4) requires the seq=N entry to pre-
+    # exist in the corpus so it knows what to read. Build a per-iteration
+    # pending corpus = the persistent corpus + a placeholder read entry at
+    # the EXTEND seq. SLM-OS reads this pending corpus from the SD card;
+    # only the real RESPONSE value is appended to the persistent corpus.
+    pending_path = _write_pending_corpus(corpus, request)
+    try:
+        result = slmos.replay_step(pending_path, request.seq)
+    finally:
+        try:
+            pending_path.unlink()
+        except FileNotFoundError:
+            pass
 
     if isinstance(result, ReplayError):
         return _StepOutcome(
@@ -241,6 +260,52 @@ def _handle_divergence(
         ),
         rollback=rb,
     )
+
+
+def _write_pending_corpus(corpus: Corpus, request: ExtendRequest) -> Path:
+    """Materialize a temp corpus = persistent corpus + a placeholder seq=N read.
+
+    The placeholder's value is a zero-filled hex string of the correct width;
+    SLM-OS replay-step ignores the corpus's recorded value at seq=N (it issues
+    a real BAR read) and only consumes (bar, offset, size), so the value is a
+    don't-care. The pending file lives next to the persistent corpus and is
+    deleted by the caller once replay_step returns.
+    """
+    placeholder = OpEntry(
+        seq=request.seq,
+        bar=request.bar,
+        offset=request.offset,
+        size=request.size,
+        dir="read",
+        value="0" * (request.size * 2),
+        source="slmos_observed",
+        validated_at_commit=None,
+        validated_at=None,
+        note="pending: placeholder for replay-step",
+    )
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=corpus.path.stem + "-pending-",
+        suffix=corpus.path.suffix,
+        dir=corpus.path.parent,
+    )
+    pending_path = Path(tmp_name)
+    with corpus.path.open("r", encoding="utf-8") as src, \
+            open(fd, "w", encoding="utf-8") as dst:
+        dst.write(src.read())
+        if not dst.tell() or not _ends_with_newline(corpus.path):
+            dst.write("\n")
+        dst.write(json.dumps(placeholder.to_json_obj(), separators=(",", ":")))
+        dst.write("\n")
+    return pending_path
+
+
+def _ends_with_newline(path: Path) -> bool:
+    with path.open("rb") as f:
+        try:
+            f.seek(-1, 2)  # SEEK_END
+        except OSError:
+            return True  # empty file — nothing to terminate
+        return f.read(1) == b"\n"
 
 
 # Internal step outcome that carries forward into the top-level LoopOutcome.

--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -8,10 +8,16 @@ parameterised so tests pass a fake.
 Steps for one replay:
 
 1. (Optional) `labctl sdwire info <sbc>` — verify card identity before flash.
-2. `labctl sdwire update <sbc> -p 1 -c <kernel>:kernel_2712.img --reboot`
+2. `labctl sdwire update <sbc> -p 1 -c <kernel>:kernel_2712.img
+                                       -c <corpus>:corpus.jsonl --reboot`
 3. Poll `labctl serial capture <sbc> --until '<shell-prompt>'` for the prompt.
-4. `labctl serial send <sbc> 'hailo replay-step <corpus> <N>' --capture ... --until 'HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE)'`.
+4. `labctl serial send <sbc> 'hailo replay-step 0:/corpus.jsonl <N>'
+       --capture ... --until 'HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE)'`.
 5. Parse the captured line.
+
+The corpus is flashed onto the boot partition alongside the kernel, so the
+on-card path that SLM-OS sees is FatFs `0:/corpus.jsonl` per the Task 0.4
+`hailo replay-step` reference (docs/hailo-re-replay-step.md §Usage).
 """
 
 from __future__ import annotations
@@ -160,6 +166,8 @@ class SlmosRunner:
     sbc: str = "pi-5-1"
     kernel_path: Path = Path("build/kernel/slmos.bin")
     kernel_dst: str = "kernel_2712.img"
+    corpus_dst: str = "corpus.jsonl"
+    corpus_on_card_path: str = "0:/corpus.jsonl"
     boot_partition: int = 1
     shell_prompt: str = r"slmos>"
     boot_timeout_s: float = 45.0
@@ -175,18 +183,37 @@ class SlmosRunner:
 
     # ----- pipeline steps --------------------------------------------------
 
+    def power_off(self) -> CmdResult:
+        return self.transport(
+            ["labctl", "power", "off", self.sbc], self.cmd_timeout_s
+        )
+
     def verify_card(self) -> CmdResult:
+        # sdwire info needs the SD card switched to the host, which requires
+        # the board powered off. Each replay iteration leaves the board ON
+        # (the previous `sdwire update --reboot` finishes with power ON), so
+        # power-off must precede info on every iteration.
+        off = self.transport(
+            ["labctl", "power", "off", self.sbc], self.cmd_timeout_s
+        )
+        if off.returncode != 0:
+            return off
         return self.transport(
             ["labctl", "sdwire", "info", self.sbc], self.cmd_timeout_s
         )
 
-    def flash_and_reboot(self, kernel_path: Optional[Path] = None) -> CmdResult:
+    def flash_and_reboot(
+        self,
+        corpus_path: Path,
+        kernel_path: Optional[Path] = None,
+    ) -> CmdResult:
         kp = kernel_path or self.kernel_path
         return self.transport(
             [
                 "labctl", "sdwire", "update", self.sbc,
                 "-p", str(self.boot_partition),
                 "-c", f"{kp}:{self.kernel_dst}",
+                "-c", f"{corpus_path}:{self.corpus_dst}",
                 "--reboot",
             ],
             self.cmd_timeout_s,
@@ -205,19 +232,27 @@ class SlmosRunner:
     def send_replay_command(
         self, corpus_path: Path, seq: int
     ) -> CmdResult:
-        # Command shape per docs/hailo-re-corpus-format.md §SLM-OS hailo
-        # replay-step: single seq argument. corpus_path is dev-side and not
-        # visible to SLM-OS; how SLM-OS obtains the corpus (baked-in blob,
-        # UART stream, etc.) is the Task 0.4 deliverable. We retain the
-        # corpus_path parameter on this method so callers can pass it
-        # through once Task 0.4 commits to a transport.
-        del corpus_path  # currently unused; see comment above
-        cmd = f"hailo replay-step {seq}"
+        # The dev-side corpus_path is unused here — the SD-card flash step
+        # has already copied the corpus to `corpus_on_card_path` on the FAT
+        # boot partition, which is the path SLM-OS reads from. Task 0.4's
+        # `hailo replay-step` command (docs/hailo-re-replay-step.md §Usage)
+        # takes the on-card path as its first argument.
+        del corpus_path
+        cmd = f"hailo replay-step {self.corpus_on_card_path} {seq}"
+        # labctl --until evaluates the regex against the receive buffer as
+        # bytes arrive, so a prefix-only anchor like
+        # `^HAILO_RE_CORPUS_RESPONSE` cuts the line off mid-value. Anchor on
+        # tokens that only land near end-of-line: the full slmos_sha for the
+        # success path, the reason= tag for the divergence path.
+        until_re = (
+            r"(?:slmos_sha=[0-9a-f]{40}|"
+            r"HAILO_RE_CORPUS_DIVERGENCE.*reason=[a-z_]+)"
+        )
         return self.transport(
             [
                 "labctl", "serial", "send", self.sbc, cmd,
                 "--capture", str(self.replay_timeout_s),
-                "--until", r"^HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE)",
+                "--until", until_re,
             ],
             self.replay_timeout_s + 5.0,
         )
@@ -241,7 +276,7 @@ class SlmosRunner:
                     stderr=info.stderr,
                 )
         if fresh_boot:
-            flash = self.flash_and_reboot()
+            flash = self.flash_and_reboot(corpus_path)
             if flash.returncode != 0:
                 return ReplayError(
                     kind="error",

--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -189,10 +189,19 @@ class SlmosRunner:
         )
 
     def verify_card(self) -> CmdResult:
-        # sdwire info needs the SD card switched to the host, which requires
-        # the board powered off. Each replay iteration leaves the board ON
-        # (the previous `sdwire update --reboot` finishes with power ON), so
-        # power-off must precede info on every iteration.
+        """Power off the board, then query `labctl sdwire info`.
+
+        WARNING: this method has a side effect — it powers off the SBC
+        before running sdwire info. The power-off is required because
+        sdwire info needs the SD card switched to the host bus, which
+        labctl refuses to do while the board is powered on. Each replay
+        iteration leaves the board ON (the previous `sdwire update
+        --reboot` finishes with power ON), so the power-off cycle must
+        precede info on every iteration.
+
+        Returns the labctl power-off result (with a non-zero returncode)
+        if that step fails; otherwise returns the sdwire info result.
+        """
         off = self.transport(
             ["labctl", "power", "off", self.sbc], self.cmd_timeout_s
         )
@@ -244,9 +253,15 @@ class SlmosRunner:
         # `^HAILO_RE_CORPUS_RESPONSE` cuts the line off mid-value. Anchor on
         # tokens that only land near end-of-line: the full slmos_sha for the
         # success path, the reason= tag for the divergence path.
+        #
+        # The reason= alternative uses `\S+` rather than `[a-z_]+` because
+        # the corpus spec (docs/hailo-re-corpus-format.md §Divergence
+        # report) explicitly says tools must accept any string for the
+        # reason tag — additive tags can be added without bumping the
+        # corpus format_version, so the matcher must not narrow that.
         until_re = (
             r"(?:slmos_sha=[0-9a-f]{40}|"
-            r"HAILO_RE_CORPUS_DIVERGENCE.*reason=[a-z_]+)"
+            r"HAILO_RE_CORPUS_DIVERGENCE.*reason=\S+)"
         )
         return self.transport(
             [

--- a/host-tools/hailo-re-driver/tests/test_loop_mocked.py
+++ b/host-tools/hailo-re-driver/tests/test_loop_mocked.py
@@ -174,5 +174,110 @@ class LoopE2ETests(unittest.TestCase):
                              "original corpus must be renamed to .poisoned")
 
 
+class StubAppendDuringRunTests(unittest.TestCase):
+    """Regression coverage for the "QEMU stub appends writes to the corpus
+    file in place during its run, so the driver's in-memory view is stale
+    when it returns" gap. The fix is the `corpus_mod.load` call placed
+    immediately after `qemu.run` in `run_loop`; this test would catch a
+    future refactor that drops it.
+    """
+
+    SHA = "cd" * 20
+
+    def _header(self) -> Header:
+        return Header(
+            format_version=1, hailort_version="4.23.0",
+            fw_version="4.23.0",
+            capture_host="qemu-x86_64",
+            slmos_base_sha=self.SHA,
+            capture_started_at="2026-05-12T18:30:00Z",
+        )
+
+    def test_extend_seq_matches_post_run_next_seq(self) -> None:
+        """A QEMU run that appends writes to the corpus file before
+        emitting EXTEND must not be flagged as
+        'EXTEND seq=N but corpus next_seq=M — corpus and stub disagree'.
+        """
+        from hailo_re_driver.line_protocols import ExtendRequest
+        from hailo_re_driver.qemu_runner import ExtendEvent
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = Path(d) / "c.jsonl"
+            corpus_mod.init(corpus_path, self._header())
+            c = corpus_mod.load(corpus_path)
+            # Pre-existing seq=1..3 to put the in-memory snapshot at
+            # next_seq=4.
+            for s in (1, 2, 3):
+                corpus_mod.append_op(c, OpEntry(
+                    seq=s, bar=4, offset=0x100 + s, size=4, dir="read",
+                    value="00000000", source="slmos_observed",
+                    validated_at_commit=self.SHA,
+                    validated_at="2026-05-12T19:00:00Z",
+                ))
+
+            # Build a runner that mutates the corpus file as a side effect
+            # before returning its EXTEND (simulating Task 0.2's stub
+            # appending captured writes during its run). The driver must
+            # reload the corpus after the run; if it doesn't, request.seq
+            # (8) and the stale corpus.next_seq (4) disagree and the loop
+            # bails with status=error.
+            class _AppendingRunner:
+                def __init__(self, corpus_path: Path):
+                    self.calls = 0
+                    self.corpus_path = corpus_path
+
+                def run(self, path: Path):
+                    self.calls += 1
+                    if self.calls == 1:
+                        # Simulate four writes the stub recorded during
+                        # the run, immediately before halting on the
+                        # unknown read at seq=8.
+                        fresh = corpus_mod.load(path)
+                        for s in range(4, 8):
+                            corpus_mod.append_op(fresh, OpEntry(
+                                seq=s, bar=4, offset=0x200 + s, size=4,
+                                dir="write", value="ffffffff",
+                                source="qemu_capture",
+                                validated_at_commit=None,
+                                validated_at=None,
+                            ))
+                        return ExtendEvent(
+                            kind="extend",
+                            request=ExtendRequest(
+                                seq=8, bar=4, offset=0x800, size=4,
+                                reason="unknown_read",
+                            ),
+                            raw_line=(
+                                "HAILO_RE_CORPUS_EXTEND seq=8 bar=4 "
+                                "offset=2048 size=4 reason=unknown_read"
+                            ),
+                        )
+                    return ConfigureCompleteEvent()
+
+            slmos = _ScriptedSlmosRunner([
+                ExtendResponse(seq=8, bar=4, offset=0x800, size=4,
+                               value="42424242", slmos_sha=self.SHA),
+            ])
+
+            outcome = loop_mod.run_loop(
+                corpus_path,
+                _AppendingRunner(corpus_path),  # type: ignore[arg-type]
+                slmos,  # type: ignore[arg-type]
+                loop_mod.LoopConfig(
+                    max_iterations=5,
+                    reachable=lambda _sha: True,
+                ),
+            )
+            self.assertEqual(
+                outcome.status, "complete",
+                f"loop must reload corpus after qemu.run; "
+                f"got status={outcome.status} detail={outcome.detail}",
+            )
+            reloaded = corpus_mod.load(corpus_path)
+            self.assertEqual(reloaded.next_seq, 9)
+            self.assertEqual(reloaded.ops[-1].seq, 8)
+            self.assertEqual(reloaded.ops[-1].value, "42424242")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_loop_mocked.py
+++ b/host-tools/hailo-re-driver/tests/test_loop_mocked.py
@@ -279,5 +279,70 @@ class StubAppendDuringRunTests(unittest.TestCase):
             self.assertEqual(reloaded.ops[-1].value, "42424242")
 
 
+class WritePendingCorpusCleanupTests(unittest.TestCase):
+    """Regression coverage for the resource-cleanup contract on
+    `_write_pending_corpus`: if anything in the construction window
+    raises, the temp file is unlinked AND the fd from mkstemp is closed.
+    Both must hold — leaking either across thousands of iterations would
+    exhaust /tmp or the process fd table.
+    """
+
+    SHA = "ef" * 20
+
+    def _make_corpus(self, d: Path) -> Path:
+        p = d / "c.jsonl"
+        from hailo_re_driver.corpus import Header
+        corpus_mod.init(p, Header(
+            format_version=1, hailort_version="4.23.0",
+            fw_version="4.23.0",
+            capture_host="qemu-x86_64",
+            slmos_base_sha=self.SHA,
+            capture_started_at="2026-05-12T18:30:00Z",
+        ))
+        return p
+
+    def _open_fds(self) -> set[int]:
+        import os
+        try:
+            return {int(name) for name in os.listdir("/proc/self/fd")}
+        except FileNotFoundError:
+            self.skipTest("/proc/self/fd not available on this host")
+
+    def test_corpus_open_failure_cleans_up_temp_file_and_fd(self) -> None:
+        """If `corpus.path.open()` raises after mkstemp succeeds, neither
+        the on-disk temp file nor the OS fd should leak."""
+        from hailo_re_driver.line_protocols import ExtendRequest
+        from hailo_re_driver.loop import _write_pending_corpus
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = self._make_corpus(Path(d))
+            corpus = corpus_mod.load(corpus_path)
+
+            # Snapshot fd table BEFORE the call, then sabotage the source
+            # open by unlinking the corpus between load() and _write_pending.
+            fds_before = self._open_fds()
+            corpus_path.unlink()
+
+            req = ExtendRequest(
+                seq=1, bar=4, offset=0, size=4, reason="unknown_read",
+            )
+            with self.assertRaises(FileNotFoundError):
+                _write_pending_corpus(corpus, req)
+
+            # No `*-pending-*` siblings in the dir.
+            siblings = list(Path(d).glob("*-pending-*"))
+            self.assertEqual(
+                siblings, [],
+                f"temp file leaked after failure: {siblings!r}",
+            )
+
+            # fd table back to baseline (no leaked fds).
+            fds_after = self._open_fds()
+            self.assertEqual(
+                fds_after, fds_before,
+                f"fd leaked: before={fds_before!r} after={fds_after!r}",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_slmos_runner.py
+++ b/host-tools/hailo-re-driver/tests/test_slmos_runner.py
@@ -1,0 +1,208 @@
+"""Regression coverage for the labctl-shaped behaviour of SlmosRunner.
+
+The host-side driver never owns hardware in tests — the `transport` field
+is a callable returning `CmdResult`, so we drop in a recorder that
+captures argv + timeout and never spawns a process.
+
+These tests pin the wire-level contract with labctl: the argv shape of
+each pipeline step, the regex used for `--until`, and the corpus-flash
+multi-`-c` invocation. They are the regression net the slmos-review
+called out as missing.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Optional
+
+import conftest  # noqa: F401
+
+from hailo_re_driver.slmos_runner import (
+    CmdResult,
+    SlmosRunner,
+)
+
+
+class _RecordingTransport:
+    """Drop-in for SlmosRunner.transport that records every invocation."""
+
+    def __init__(self, returncodes: Optional[list[int]] = None,
+                 stdouts: Optional[list[str]] = None) -> None:
+        self.calls: list[tuple[list[str], Optional[float]]] = []
+        self._returncodes = list(returncodes or [])
+        self._stdouts = list(stdouts or [])
+
+    def __call__(self, argv: list[str],
+                 timeout: Optional[float]) -> CmdResult:
+        self.calls.append((argv, timeout))
+        rc = self._returncodes.pop(0) if self._returncodes else 0
+        out = self._stdouts.pop(0) if self._stdouts else ""
+        return CmdResult(returncode=rc, stdout=out, stderr="")
+
+
+class FlashArgvTests(unittest.TestCase):
+    """The flash step must copy BOTH the kernel and the corpus onto the
+    SD card in a single `labctl sdwire update` invocation, using two
+    `-c <host>:<dest>` pairs."""
+
+    def test_flash_argv_contains_kernel_and_corpus(self) -> None:
+        rec = _RecordingTransport()
+        runner = SlmosRunner(
+            sbc="pi-5-1",
+            kernel_path=Path("build/kernel/slmos.bin"),
+            kernel_dst="kernel_2712.img",
+            corpus_dst="corpus.jsonl",
+            transport=rec,
+        )
+        runner.flash_and_reboot(Path("/tmp/c.jsonl"))
+
+        self.assertEqual(len(rec.calls), 1)
+        argv, _ = rec.calls[0]
+        self.assertEqual(
+            argv[:5],
+            ["labctl", "sdwire", "update", "pi-5-1", "-p"],
+        )
+        # Two -c pairs must be present in order: kernel, then corpus.
+        c_indices = [i for i, a in enumerate(argv) if a == "-c"]
+        self.assertEqual(
+            len(c_indices), 2,
+            f"expected two -c flags, got argv={argv!r}",
+        )
+        self.assertEqual(
+            argv[c_indices[0] + 1],
+            "build/kernel/slmos.bin:kernel_2712.img",
+        )
+        self.assertEqual(
+            argv[c_indices[1] + 1],
+            "/tmp/c.jsonl:corpus.jsonl",
+        )
+        self.assertIn("--reboot", argv)
+
+
+class ReplayCommandArgvTests(unittest.TestCase):
+    """The replay-step shell command must include the on-card corpus
+    path (FatFs `0:/corpus.jsonl`), and its `--until` regex must anchor
+    on tokens that only land at end-of-line."""
+
+    def test_replay_command_uses_on_card_path(self) -> None:
+        rec = _RecordingTransport()
+        runner = SlmosRunner(
+            sbc="pi-5-1",
+            corpus_on_card_path="0:/corpus.jsonl",
+            transport=rec,
+        )
+        runner.send_replay_command(Path("/dev/null"), 42)
+        self.assertEqual(len(rec.calls), 1)
+        argv, _ = rec.calls[0]
+        # 4th positional arg is the command string.
+        cmd_index = argv.index("send") + 2
+        self.assertEqual(
+            argv[cmd_index],
+            "hailo replay-step 0:/corpus.jsonl 42",
+        )
+
+    def test_replay_command_until_regex_matches_full_response_only(self) -> None:
+        """`--until` must NOT match a truncated RESPONSE line that
+        lacks slmos_sha. Otherwise labctl returns before the line is
+        fully received and the parser fails with 'missing slmos_sha'.
+        """
+        import re
+
+        rec = _RecordingTransport()
+        runner = SlmosRunner(sbc="pi-5-1", transport=rec)
+        runner.send_replay_command(Path("/dev/null"), 1)
+        argv, _ = rec.calls[0]
+        # Pull the regex out of argv: `--until` is followed by the value.
+        until_idx = argv.index("--until")
+        until_re = argv[until_idx + 1]
+        rx = re.compile(until_re)
+
+        truncated = (
+            "HAILO_RE_CORPUS_RESPONSE seq=1 bar=0 offset=152 size=4 value=f"
+        )
+        self.assertIsNone(
+            rx.search(truncated),
+            f"truncated line must NOT match until regex {until_re!r}",
+        )
+
+        full = (
+            "HAILO_RE_CORPUS_RESPONSE seq=1 bar=0 offset=152 size=4 "
+            "value=601e6428 slmos_sha=" + "ab" * 20
+        )
+        self.assertIsNotNone(
+            rx.search(full),
+            f"full RESPONSE must match until regex {until_re!r}",
+        )
+
+    def test_replay_command_until_accepts_arbitrary_divergence_reason(
+        self,
+    ) -> None:
+        """Per docs/hailo-re-corpus-format.md §Divergence report:
+        'Tools must accept any string' for the reason tag. A narrower
+        pattern like `reason=[a-z_]+` would wait the full timeout on a
+        future tag like `dma-violation` or `mismatch_v2`.
+        """
+        import re
+
+        rec = _RecordingTransport()
+        runner = SlmosRunner(sbc="pi-5-1", transport=rec)
+        runner.send_replay_command(Path("/dev/null"), 1)
+        until_idx = rec.calls[0][0].index("--until")
+        until_re = rec.calls[0][0][until_idx + 1]
+        rx = re.compile(until_re)
+
+        for tag in (
+            "write_value_mismatch",        # spec-listed
+            "op_shape_mismatch",           # spec-listed
+            "inline_read_mismatch",        # spec-listed
+            "dma-violation",               # hypothetical future tag w/ dash
+            "mismatch_v2",                 # hypothetical future tag w/ digit
+            "ECC_FATAL",                   # hypothetical uppercase tag
+        ):
+            line = (
+                "HAILO_RE_CORPUS_DIVERGENCE seq=5 bar=4 offset=0 size=4 "
+                "dir=write expected=00000000 observed=01000000 "
+                f"source=qemu reason={tag}"
+            )
+            self.assertIsNotNone(
+                rx.search(line),
+                f"until regex must accept reason={tag!r}: pattern={until_re!r}",
+            )
+
+
+class VerifyCardSideEffectTests(unittest.TestCase):
+    """`verify_card` is documented to power off the board before running
+    sdwire info. The argv sequence must therefore be `power off` first,
+    then `sdwire info` — and `sdwire info` must not run if power-off
+    failed."""
+
+    def test_verify_card_powers_off_first(self) -> None:
+        rec = _RecordingTransport()
+        runner = SlmosRunner(sbc="pi-5-1", transport=rec)
+        runner.verify_card()
+        self.assertEqual(len(rec.calls), 2)
+        self.assertEqual(
+            rec.calls[0][0],
+            ["labctl", "power", "off", "pi-5-1"],
+        )
+        self.assertEqual(
+            rec.calls[1][0],
+            ["labctl", "sdwire", "info", "pi-5-1"],
+        )
+
+    def test_verify_card_skips_info_on_power_off_failure(self) -> None:
+        rec = _RecordingTransport(returncodes=[1])
+        runner = SlmosRunner(sbc="pi-5-1", transport=rec)
+        result = runner.verify_card()
+        self.assertEqual(result.returncode, 1)
+        # Only the power-off call should have happened.
+        self.assertEqual(len(rec.calls), 1)
+        self.assertEqual(
+            rec.calls[0][0],
+            ["labctl", "power", "off", "pi-5-1"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host-tools/hailort-vm/README.md
+++ b/host-tools/hailort-vm/README.md
@@ -6,9 +6,20 @@ This directory contains environment + automation. No SLM-OS or HailoRT source li
 
 ## Status
 
-Phase 0 scaffolding. Pre-integration with [Task 0.2 (QEMU stub device)](https://github.com/SLM-OS/SLM-Operating-System/issues/795).
+Phase 1 integrated 2026-05-12. The custom QEMU built by `build-qemu.sh` now
+registers two devices:
 
-Until Task 0.2 lands a corpus-driven Hailo stub, this environment uses a **stub-stub**: a ~150-line QEMU device patch (`qemu-patch/hw/misc/hailo-stub-stub.c`) that advertises Hailo-8 PCI IDs (0x1e60:0x2864) and three BARs (4 KB / 16 KB / 1 MB) where every read returns 0 and writes are discarded. That's enough for the upstream `hailo_pci` driver to probe successfully and for HailoRT to begin issuing MMIO. Trace capture goes through QEMU's `--trace memory_region_ops_*` channel and is post-processed into the corpus format.
+- `-device hailo-stub-stub` — the original throwaway placeholder. Read traffic
+  goes through `launch-capture.sh` + `tools/qemu-trace-to-corpus.py` as the
+  determinism-check artifact path. Kept to keep that artifact reproducible.
+- `-device hailo8,corpus=<path>` — Task 0.2's real corpus-driven stub
+  (sources at `../qemu-hailo8-stub/`). Used by Phase 1's
+  `launch-bootstrap.sh`, which is the launcher the Task 0.5 driver script
+  invokes via `HAILO_RE_QEMU_LAUNCHER`. This is the path that closes the
+  capture-replay loop end-to-end against real pi-5-1 hardware.
+
+The historical "stub-stub" mode below is retained for reference; the
+corpus-driven path is what Phase 1+ actually uses.
 
 Why a separate stub-stub instead of just using the QEMU `edu` device: `edu` exposes only BAR0. The Hailo driver hard-requires BAR0 + BAR2 + BAR4 to be present and non-zero-size — it fails probe with `Invalid PCIe BAR 2` against any device with fewer BARs. Hence the minimal patch.
 
@@ -19,7 +30,8 @@ Why a separate stub-stub instead of just using the QEMU `edu` device: `edu` expo
 | `README.md` | This file |
 | `build-qemu.sh` | Fetches QEMU 8.2 source, applies the hailo-stub-stub patch, builds a custom `qemu-system-x86_64` binary. Output: `~/slmos-ref/derivatives/hailort-vm-qemu/qemu-system-x86_64` |
 | `build-vm-image.sh` | Builds a customized Ubuntu 24.04 qcow2 via cloud-init seed ISO. Output: `~/slmos-ref/derivatives/hailort-vm-images/`, **not in this repo** |
-| `launch-capture.sh` | Boots the qcow2 with the custom QEMU + `-device hailo-stub-stub`, captures MMIO trace, emits a corpus JSONL |
+| `launch-capture.sh` | Boots the qcow2 with the custom QEMU + `-device hailo-stub-stub`, captures MMIO trace, emits a corpus JSONL. Legacy stub-stub path. |
+| `launch-bootstrap.sh` | Phase 1+ launcher. Boots the qcow2 with `-device hailo8,corpus=<path>` and propagates the corpus-driven stub's `HAILO_RE_CORPUS_*` stdout. Wired into the Task 0.5 driver via `HAILO_RE_QEMU_LAUNCHER`. |
 | `verify-determinism.sh` | Runs `launch-capture.sh` twice from a cold snapshot, diffs the traces, reports match / first divergence |
 | `qemu-patch/hw/misc/hailo-stub-stub.c` | Minimal QEMU PCI device with Hailo-8 IDs (0x1e60:0x2864) and three BARs (4 KB / 16 KB / 1 MB). Reads return 0; writes are discarded. Throwaway placeholder for Task 0.2's real stub |
 | `qemu-patch/apply.sh` | Copies hailo-stub-stub.c into a QEMU source tree and registers it in `hw/misc/meson.build` |

--- a/host-tools/hailort-vm/build-qemu.sh
+++ b/host-tools/hailort-vm/build-qemu.sh
@@ -7,8 +7,15 @@
 #
 # launch-capture.sh prefers this binary if present.
 #
-# This is throwaway: Task 0.2 ships a corpus-driven stub that this script's
-# binary will be retired in favour of.
+# The binary registers two PCI devices:
+#
+#  - hailo-stub-stub  (the throwaway placeholder originally shipped with
+#    Task 0.3 — kept for the determinism-check artifact).
+#  - hailo8           (Task 0.2's real corpus-driven stub — used by
+#    Phase 1's launch-bootstrap.sh).
+#
+# Both source trees live in this repo and are installed into the same QEMU
+# tree before build.
 
 set -euo pipefail
 
@@ -37,6 +44,7 @@ done
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PATCH_DIR="${HERE}/qemu-patch"
+HAILO8_STUB_DIR="$(cd "${HERE}/../qemu-hailo8-stub" && pwd)"
 
 mkdir -p "${QEMU_OUT_DIR}" "${QEMU_BUILD_ROOT}"
 
@@ -59,11 +67,17 @@ fi
 if [[ -x "${OUT_BIN}" && "${FORCE_REBUILD}" -eq 0 ]]; then
     echo "Custom QEMU already built: ${OUT_BIN}"
     "${OUT_BIN}" --version | head -1
-    if "${OUT_BIN}" -device help 2>&1 | grep -q hailo-stub-stub; then
-        echo "Confirmed: -device hailo-stub-stub is registered."
+    DEVS="$("${OUT_BIN}" -device help 2>&1 || true)"
+    HAVE_STUB_STUB=0
+    HAVE_HAILO8=0
+    grep -q hailo-stub-stub <<<"${DEVS}" && HAVE_STUB_STUB=1
+    grep -q '"hailo8"'      <<<"${DEVS}" && HAVE_HAILO8=1
+    if [[ "${HAVE_STUB_STUB}" -eq 1 && "${HAVE_HAILO8}" -eq 1 ]]; then
+        echo "Confirmed: -device hailo-stub-stub AND -device hailo8 are registered."
         exit 0
     else
-        echo "Binary exists but hailo-stub-stub not registered. Rebuilding." >&2
+        echo "Binary exists but missing one of {hailo-stub-stub, hailo8}. Rebuilding." >&2
+        echo "  stub-stub registered: ${HAVE_STUB_STUB}, hailo8 registered: ${HAVE_HAILO8}" >&2
         FORCE_REBUILD=1
     fi
 fi
@@ -103,9 +117,15 @@ if [[ ! -d "${SRC_DIR}" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Apply patch
+# Apply Task 0.3 placeholder + Task 0.2 real-stub patches
 # ---------------------------------------------------------------------------
 "${PATCH_DIR}/apply.sh" "${SRC_DIR}"
+
+if [[ ! -x "${HAILO8_STUB_DIR}/install.sh" ]]; then
+    echo "ERROR: Task 0.2 stub not found at ${HAILO8_STUB_DIR}/install.sh" >&2
+    exit 4
+fi
+"${HAILO8_STUB_DIR}/install.sh" "${SRC_DIR}"
 
 # ---------------------------------------------------------------------------
 # Configure (minimal — just x86_64-softmmu, KVM, slirp, no GUI).
@@ -164,13 +184,18 @@ cp -a "${SRC_DIR}/pc-bios" "${PC_BIOS_OUT}"
 # Verify
 # ---------------------------------------------------------------------------
 "${OUT_BIN}" --version | head -1
-if ! "${OUT_BIN}" -device help 2>&1 | grep -q hailo-stub-stub; then
+DEVS="$("${OUT_BIN}" -device help 2>&1 || true)"
+if ! grep -q hailo-stub-stub <<<"${DEVS}"; then
     echo "ERROR: built QEMU does not register hailo-stub-stub" >&2
+    exit 4
+fi
+if ! grep -q '"hailo8"' <<<"${DEVS}"; then
+    echo "ERROR: built QEMU does not register hailo8 (Task 0.2 real stub)" >&2
     exit 4
 fi
 if [[ ! -f "${PC_BIOS_OUT}/bios-256k.bin" ]]; then
     echo "ERROR: pc-bios/bios-256k.bin not copied to ${PC_BIOS_OUT}" >&2
     exit 4
 fi
-echo "OK: ${OUT_BIN} ready (hailo-stub-stub registered)."
+echo "OK: ${OUT_BIN} ready (hailo-stub-stub + hailo8 registered)."
 echo "    pc-bios at ${PC_BIOS_OUT}"

--- a/host-tools/hailort-vm/launch-bootstrap.sh
+++ b/host-tools/hailort-vm/launch-bootstrap.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Phase 1 launcher — boots the HailoRT VM against Task 0.2's corpus-driven
+# stub, propagating the stub's stdout (HAILO_RE_CORPUS_* lines) so the
+# Task 0.5 driver script can consume them.
+#
+# Contract (matches hailo_re_driver/qemu_runner.py default_command_factory):
+#   launch-bootstrap.sh --corpus <path-to-corpus.jsonl>
+#
+# Outputs:
+#   - stdout: anything QEMU writes to fd 1, which includes the Task 0.2
+#     stub's HAILO_RE_CORPUS_EXTEND / HAILO_RE_CORPUS_DIVERGENCE lines.
+#   - stderr: QEMU diagnostics + HAILO_RE_MSI_FIRE.
+#   - exit code: QEMU's exit code (1 on EXTEND/DIVERGENCE, 0 on a clean
+#     `Configure() + Activate()` — the Phase 1 exit gate from KICKOFF).
+#
+# This is the Phase 1 sibling of launch-capture.sh. That script kept the
+# placeholder hailo-stub-stub flow alive for the determinism-check
+# artifact; this one wires the real corpus-driven stub into the same VM.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+CORPUS=""
+VARIANT="bootstrap"
+RUN_TIMEOUT="${CAPTURE_TIMEOUT:-180}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --corpus)  CORPUS="$2"; shift 2;;
+        --variant) VARIANT="$2"; shift 2;;
+        --timeout) RUN_TIMEOUT="$2"; shift 2;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# //; s/^#//'
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 2;;
+    esac
+done
+
+if [[ -z "${CORPUS}" ]]; then
+    echo "Usage: $0 --corpus <path-to-corpus.jsonl> [--variant N] [--timeout S]" >&2
+    exit 2
+fi
+
+# Resolve to absolute — the stub re-opens the corpus from QEMU's cwd.
+if [[ ! -f "${CORPUS}" ]]; then
+    echo "Corpus not found: ${CORPUS}" >&2
+    exit 2
+fi
+CORPUS="$(readlink -f "${CORPUS}")"
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+HAILORT_VERSION="${HAILORT_VERSION:-4.23.0}"
+UBUNTU_RELEASE="${UBUNTU_RELEASE:-noble}"
+VM_IMG_DIR="${VM_IMG_DIR:-$HOME/slmos-ref/derivatives/hailort-vm-images}"
+VM_IMG_NAME="${VM_IMG_NAME:-hailort-vm-${HAILORT_VERSION}-ubuntu-${UBUNTU_RELEASE}.qcow2}"
+VM_IMG="${VM_IMG_DIR}/${VM_IMG_NAME}"
+QEMU_CUSTOM="${QEMU_CUSTOM:-$HOME/slmos-ref/derivatives/hailort-vm-qemu/qemu-system-x86_64}"
+PC_BIOS="${PC_BIOS:-$HOME/slmos-ref/derivatives/hailort-vm-qemu/pc-bios}"
+
+if [[ ! -x "${QEMU_CUSTOM}" ]]; then
+    echo "Custom QEMU missing: ${QEMU_CUSTOM}" >&2
+    echo "Run ./build-qemu.sh first." >&2
+    exit 3
+fi
+if ! "${QEMU_CUSTOM}" -device help 2>&1 | grep -q '"hailo8"'; then
+    echo "${QEMU_CUSTOM} does not register -device hailo8." >&2
+    echo "Rebuild via ./build-qemu.sh --force." >&2
+    exit 3
+fi
+if [[ ! -f "${VM_IMG}" ]]; then
+    echo "VM image missing: ${VM_IMG}" >&2
+    echo "Run ./build-vm-image.sh first." >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Working directory — fresh disk overlay per run.
+# ---------------------------------------------------------------------------
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-${VARIANT}"
+RUN_DIR="${VM_IMG_DIR}/.runs/${RUN_ID}"
+mkdir -p "${RUN_DIR}"
+
+DISK_CLONE="${RUN_DIR}/disk.qcow2"
+SERIAL_LOG="${RUN_DIR}/serial.log"
+
+qemu-img create -f qcow2 -b "${VM_IMG}" -F qcow2 "${DISK_CLONE}" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Accelerator selection.
+#
+# KVM if available; TCG single-thread otherwise. Determinism flags match the
+# capture variant (see launch-capture.sh + README §Determinism).
+# ---------------------------------------------------------------------------
+ACCEL_ARGS=(-accel tcg,thread=single)
+if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+    ACCEL_ARGS=(-accel kvm -cpu host,migratable=no)
+fi
+
+# ---------------------------------------------------------------------------
+# QEMU invocation.
+#
+# - No -nographic (that aliases to -serial mon:stdio, stealing stdout from
+#   the stub's fprintf path).
+# - -serial file:SERIAL_LOG keeps the guest serial off stdout.
+# - -monitor none disables the HMP monitor so stdout stays clean.
+# - -display none + no -vnc/-spice means no UI surfaces.
+# - The Task 0.2 stub's HAILO_RE_CORPUS_* fprintf goes straight to the QEMU
+#   process's stdout, which this script does not redirect — so it appears
+#   on this script's stdout in turn, where the driver script captures it.
+# ---------------------------------------------------------------------------
+set +e
+timeout "${RUN_TIMEOUT}" "${QEMU_CUSTOM}" \
+    -L "${PC_BIOS}" \
+    "${ACCEL_ARGS[@]}" \
+    -smp 1 \
+    -m 1G \
+    -rtc base=2026-05-12T00:00:00,clock=vm \
+    -drive "file=${DISK_CLONE},format=qcow2,if=virtio" \
+    -nic user,model=virtio-net-pci \
+    -device "hailo8,corpus=${CORPUS}" \
+    -display none \
+    -serial "file:${SERIAL_LOG}" \
+    -monitor none \
+    -no-reboot
+QEMU_STATUS=$?
+set -e
+
+# 124 == GNU `timeout` SIGTERM; QEMU itself returns 0 on a clean -no-reboot
+# halt and 1 on the stub's exit(1). Anything else is unexpected — propagate
+# the status so the driver script can react.
+exit "${QEMU_STATUS}"

--- a/host-tools/hailort-vm/launch-bootstrap.sh
+++ b/host-tools/hailort-vm/launch-bootstrap.sh
@@ -20,6 +20,18 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Hard prerequisites
+# ---------------------------------------------------------------------------
+# GNU coreutils `timeout` caps the QEMU run; we don't have a portable
+# fallback. Check up-front so the error message is actionable instead of
+# the bash "command not found" further down.
+if ! command -v timeout >/dev/null 2>&1; then
+    echo "ERROR: GNU coreutils 'timeout' is required but not on PATH." >&2
+    echo "       Install coreutils (apt: 'sudo apt install coreutils')." >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
 # Args
 # ---------------------------------------------------------------------------
 CORPUS=""
@@ -50,6 +62,17 @@ if [[ ! -f "${CORPUS}" ]]; then
     exit 2
 fi
 CORPUS="$(readlink -f "${CORPUS}")"
+
+# QEMU's `-device key=value,key=value` parser splits on commas. A corpus
+# path containing a comma would be silently truncated. Reject early.
+case "${CORPUS}" in
+    *,*)
+        echo "ERROR: corpus path contains a comma — QEMU's -device parser" >&2
+        echo "       splits on commas and would mis-parse this path:" >&2
+        echo "       ${CORPUS}" >&2
+        exit 2
+        ;;
+esac
 
 # ---------------------------------------------------------------------------
 # Environment


### PR DESCRIPTION
## Summary

Wires Task 0.2's corpus-driven `hailo8` QEMU device into Task 0.3's VM environment and closes the four integration gaps between Phase 0 tasks that only surface at the integration boundary. **Phase 1 exit gate is cleared** end-to-end on pi-5-1 with the driver running unattended (writeup: #795 comment).

## What changed

- `host-tools/hailort-vm/build-qemu.sh` — also runs Task 0.2's `install.sh` against the same QEMU source tree so the resulting binary registers both `-device hailo-stub-stub` (kept for the Task 0.3 determinism-check artifact) and `-device hailo8` (the corpus-driven path used by Phase 1+).
- `host-tools/hailort-vm/launch-bootstrap.sh` *(new)* — Phase 1 launcher that fits the Task 0.5 driver's `HAILO_RE_QEMU_LAUNCHER` contract. Takes `--corpus <path>`, runs the VM with `-device hailo8,corpus=...`, propagates the stub's stdout (`HAILO_RE_CORPUS_*` lines) and exit code.
- `host-tools/hailo-re-driver/hailo_re_driver/loop.py` — synthesizes a per-iteration "pending" corpus before invoking `slmos.replay_step` (closes Task 0.4 ↔ Task 0.5 chicken-and-egg); reloads the corpus from disk after `qemu.run` returns (closes stale-in-memory-view bug after the stub appends writes in place).
- `host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py` — flash also copies the corpus as `corpus.jsonl`; `send_replay_command` issues `hailo replay-step 0:/corpus.jsonl <N>`; `--until` regex moved to end-of-line anchors (`slmos_sha=[0-9a-f]{40}`) so the truncate-on-prefix-match bug doesn't lose the tail of the RESPONSE line; `verify_card` powers off the board first as a precondition.
- `host-tools/hailort-vm/README.md` — status block updated; new `launch-bootstrap.sh` row added to the layout table.

Full landmine-by-landmine breakdown in the #795 comment.

## Verification

- `python3 -m unittest discover -s tests` in `host-tools/hailo-re-driver`: 45/45 pass.
- `make -C tests test` in `host-tools/qemu-hailo8-stub`: 16/16 pass.
- pi-5-1 hardware, single SLMOS-only card (verified `sdwire info` before flash):
  - Run 1: 6 iterations / 865 s from empty corpus → 6 validated reads + 4 captured writes. Iter 2 surfaced a new unknown after iter 1's answer landed, proving the loop actually closes.
  - Run 2: 20 iterations / 2880 s continuing from Run 1's 10-entry corpus → 46 ops total (26 validated reads + 20 captured writes), no manual intervention, no divergence. HailoRT progressed from device probe through to the BAR4 fw_control window.

## Test plan

- [ ] CI: host-tools/hailo-re-driver unit tests
- [ ] CI: host-tools/qemu-hailo8-stub corpus tests
- [ ] Manual: a fresh `hailo-re-bootstrap` run against an empty corpus on pi-5-1 (verified above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)