### PR TITLE
camera: IMX219 first light on Jetson Orin Nano (closes #518)

### DIFF
--- a/kernel/drivers/camrtc/camrtc_capture.c
+++ b/kernel/drivers/camrtc/camrtc_capture.c
@@ -217,12 +217,35 @@ int camrtc_capture_csi_stream_set_config(uint32_t stream_id,
     req.body.stream_id  = stream_id;
     req.body.csi_port   = csi_port;
     /* config_flags=0, brick.phy_mode=0 (DPHY), lane_swizzle=0,
-     * lane_polarity[]=0, error_config zeroed — all correct from
-     * the bulk-zero above. */
+     * error_config zeroed — all correct from the bulk-zero above. */
     req.body.cil_config.num_lanes       = num_lanes;
     req.body.cil_config.mipi_clock_rate = mipi_clock_rate;
-    /* lp_bypass_mode=0, t_hs_settle=0/SoC default, t_clk_settle=0,
-     * cil_clock_rate=0 (deprecated upstream) — also from bulk zero. */
+    /* lp_bypass_mode = 1 for D-PHY, per L4T csi5_stream_set_config
+     * (`~/slmos-ref/tegra-l4t/l4t-csi5_fops.c:286`):
+     *     cil_config.lp_bypass_mode = is_cphy ? 0 : 1;
+     * Tells the CIL receiver to expect D-PHY's LP-11 → HS line-state
+     * transitions. With 0 the receiver behaves as if C-PHY and never
+     * locks on a D-PHY signal — the symptom is no SOF. Hardcoded
+     * here because csidiag is D-PHY-only; productize as a parameter
+     * if a C-PHY path ever lands. */
+    req.body.cil_config.lp_bypass_mode  = 1u;
+    /* Lane polarity per IMX219-A binning-mode DT
+     * (`tegra234-p3767-camera-p3768-imx219-A.dtbo:mode3:lane_polarity = "6"`).
+     * The DT value packs per-lane polarity bits LSB-first; L4T expands
+     * `(lane_polarity >> i) & 1` into `brick_config.lane_polarity[i]`
+     * (`~/slmos-ref/tegra-l4t/l4t-csi5_fops.c:279-281`).
+     * 6 = 0b0110 → lane[0]=0, lane[1]=1, lane[2]=1, lane[3]=0.
+     * Wrong polarity on a connected lane decodes the differential
+     * signal inverted, no valid packets reach NVCSI. */
+    req.body.brick_config.lane_polarity[0] = 0u;
+    req.body.brick_config.lane_polarity[1] = 1u;
+    req.body.brick_config.lane_polarity[2] = 1u;
+    req.body.brick_config.lane_polarity[3] = 0u;
+    /* t_hs_settle=0 / SoC default, t_clk_settle=0, cil_clock_rate=0
+     * (deprecated upstream) — left at zero per bulk-zero above. The
+     * L4T DT specifies cil_settletime=0 for ALL IMX219 modes
+     * (`tegra234-p3767-camera-p3768-imx219-A.dtbo`), so the SoC
+     * default is correct. */
 
     INFO("csi_stream_set_config: send REQ tx=0x%x stream=%u port=%u "
          "lanes=%u mipi_kHz=%u",
@@ -309,8 +332,14 @@ int camrtc_capture_channel_setup(uint32_t stream_id,
     req.hdr.transaction = tx;
 
     struct camrtc_capture_channel_config *cfg = &req.body.channel_config;
+    /* EMBDATA matches L4T's vi5 default_setup
+     * (`~/slmos-ref/tegra-l4t/l4t-vi5_fops.c:46-52`); without it, RCE
+     * configures the VI channel to reject embedded-data lines and
+     * raises CHANSEL_EMBED_INFRINGE on every frame for sensors (like
+     * IMX219) that emit metadata lines by default. */
     cfg->channel_flags  = CAPTURE_CHANNEL_FLAG_VIDEO
                         | CAPTURE_CHANNEL_FLAG_RAW
+                        | CAPTURE_CHANNEL_FLAG_EMBDATA
                         | CAPTURE_CHANNEL_FLAG_CSI;
     /* channel_id stays 0 — RCE assigns it in the response. */
     cfg->vi_unit_id     = VI_UNIT_VI;

--- a/kernel/include/camrtc_capture.h
+++ b/kernel/include/camrtc_capture.h
@@ -185,6 +185,7 @@ struct camrtc_syncpoint_info {
  * compatible channel. */
 #define CAPTURE_CHANNEL_FLAG_VIDEO    0x0001u  /* video frames */
 #define CAPTURE_CHANNEL_FLAG_RAW      0x0002u  /* raw Bayer (no ISP) */
+#define CAPTURE_CHANNEL_FLAG_EMBDATA  0x0040u  /* sensor embedded-data lines */
 #define CAPTURE_CHANNEL_FLAG_CSI      0x10000u /* CSI source (vs SLVS-EC) */
 
 /* VI unit selector (`l4t-camrtc-capture.h:355`). Orin Nano has VI0
@@ -272,6 +273,12 @@ struct camrtc_capture_descriptor_header {
 /* Number of atom-packer surface slots in `camrtc_vi_channel_config`
  * — fixed at 4 for T194/T234 per L4T `l4t-camrtc-capture.h:231`. */
 #define VI_NUM_ATOMP_SURFACES   4u
+
+/* atomp surface indices (`~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h:240-258`).
+ * Surfaces 0/1/2 carry the main pixel plane(s); surface 3 carries
+ * sensor embedded-data lines when CAPTURE_CHANNEL_FLAG_EMBDATA is set. */
+#define VI_ATOMP_SURFACE_MAIN     0u
+#define VI_ATOMP_SURFACE_EMBEDDED 3u
 
 /* `struct vi_channel_config` — 160 bytes wire format
  * (`l4t-camrtc-capture.h:538`). Per-frame VI-unit register

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -9649,10 +9649,30 @@ int cmd_csidiag(int argc, char *argv[])
         return 0;
     }
 
+    /*
+     * Port + stream selection — IMX219-A on Orin Nano carrier (J20)
+     * is wired to NVCSI **port B** (= 1), not port A (= 0). NVIDIA's
+     * L4T R36.4.4 DTBO is the source of truth:
+     *   /home/john/slmos-ref/nvidia/Linux_for_Tegra-R36.4.4/Linux_for_Tegra/
+     *     kernel/dtb/tegra234-p3767-camera-p3768-imx219-A.dtbo
+     * specifies `port-index = <1>` for cam0/A on every endpoint
+     * (sensor → vi-port → nvcsi-port). Confirmed by reading the same
+     * value out of the dual overlay (cam0=1, cam1=2 — port 0 is unused
+     * on this carrier).
+     *
+     * For NVCSI ports A..D, csi5_port_to_stream(csi_port) returns the
+     * port id unchanged (`~/slmos-ref/tegra-l4t/l4t-csi5_fops.c:32-36`),
+     * so stream_id == csi_port == 1 here.
+     *
+     * NVCSI_PHY_TYPE_DPHY = 0 (`~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h:1443`).
+     */
+    const uint32_t kCsiPort  = 1u;          /* NVCSI_PORT_B */
+    const uint32_t kStreamId = 1u;          /* csi5_port_to_stream(B) */
+    const uint32_t kPhyDphy  = 0u;          /* NVCSI_PHY_TYPE_DPHY */
+
     uint32_t result = 0xDEADBEEFu;
-    /* NVCSI_STREAM_0 = 0, NVCSI_PORT_A = 0, NVCSI_PHY_TYPE_DPHY = 0
-     * (`~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h:1372/1387/1443`). */
-    rc = camrtc_capture_phy_stream_open(0u, 0u, 0u, &result);
+    rc = camrtc_capture_phy_stream_open(kStreamId, kCsiPort, kPhyDphy,
+                                        &result);
     uart_printf("  PHY_STREAM_OPEN: rc=%d result=0x%x\r\n",
                 rc, (unsigned)result);
     if (rc != 0 || result != 0u) {
@@ -9673,7 +9693,8 @@ int cmd_csidiag(int argc, char *argv[])
      * default link freq from `~/slmos-ref/linux/linux-imx219.c:139`).
      * SoC-default t_hs_settle / t_clk_settle (0). */
     uint32_t cfg_result = 0xDEADBEEFu;
-    rc = camrtc_capture_csi_stream_set_config(0u, 0u, 2u, 456000u,
+    rc = camrtc_capture_csi_stream_set_config(kStreamId, kCsiPort,
+                                              2u, 456000u,
                                               &cfg_result);
     uart_printf("  CSI_SET_CONFIG:  rc=%d result=0x%x\r\n",
                 rc, (unsigned)cfg_result);
@@ -9696,7 +9717,7 @@ int cmd_csidiag(int argc, char *argv[])
     uint32_t ch_result = 0xDEADBEEFu;
     uint32_t ch_id     = 0xDEADBEEFu;
     uint64_t vi_mask   = 0xDEADBEEFDEADBEEFull;
-    rc = camrtc_capture_channel_setup(0u, 0u,
+    rc = camrtc_capture_channel_setup(kStreamId, kCsiPort,
                                       camrtc_vi_req_ring_iova(),
                                       camrtc_vi_req_meminfo_iova(),
                                       camrtc_vi_req_queue_depth(),
@@ -9810,16 +9831,37 @@ int cmd_csidiag(int argc, char *argv[])
      * doesn't set them. */
     vi->match.datatype       = 43u;             /* NVCSI_DATATYPE_RAW10 */
     vi->match.datatype_mask  = 0x3fu;
-    vi->match.stream         = (uint8_t)(1u << 0); /* one-hot: NVCSI_STREAM_0 */
+    vi->match.stream         = (uint8_t)(1u << kStreamId); /* one-hot for the open stream */
     vi->match.stream_mask    = 0x3fu;
     vi->match.vc             = (uint16_t)(1u << 0);/* one-hot: NVCSI_VIRTUAL_CHANNEL_0 */
     vi->match.vc_mask        = 0xFFFFu;
 
-    /* Frame geometry — IMX219 binning mode 1640×1232. embed_*
-     * = 0 disables embedded-data lines (we don't need sensor
-     * metadata). skip + crop = 0 means "emit the full frame". */
-    vi->frame.frame_x = (uint16_t)camrtc_frame_buffer_width();
-    vi->frame.frame_y = (uint16_t)camrtc_frame_buffer_height();
+    /* Frame geometry — IMX219 binning mode 1640×1232. The sensor
+     * emits 2 lines of embedded metadata per frame by default
+     * (`tegra234-p3767-camera-p3768-imx219-A.dtbo:embedded_metadata_height
+     * = "2"` for every mode). VI must be told to expect them or it
+     * raises CHANSEL_EMBED_INFRINGE — what blocked #518 on the prior
+     * iteration once port=B was correct.
+     *
+     * Per L4T `vi5_fops.c:420-431`, all three of these need to land:
+     *   - frame.embed_x = embedded_data_width × BPP_MEM
+     *   - frame.embed_y = embedded_metadata_height
+     *   - embdata_enable = 1
+     *
+     * For IMX219 the embedded line width equals the active line width
+     * in pixels and goes through the same T_R16 (BPP_MEM=2) expansion
+     * as RAW10 pixels, so the byte count happens to match the main
+     * pixel-row stride — but treat it as its own quantity here so a
+     * future change to either the main pixel format or the embedded
+     * line width can't silently desync the routing. */
+    const uint32_t kEmbedLineBytes = (uint32_t)camrtc_frame_buffer_width()
+                                   * 2u; /* BPP_MEM = T_R16 = 2 B */
+    const uint32_t kEmbedLines     = 2u;
+    vi->frame.frame_x  = (uint16_t)camrtc_frame_buffer_width();
+    vi->frame.frame_y  = (uint16_t)camrtc_frame_buffer_height();
+    vi->frame.embed_x  = kEmbedLineBytes;
+    vi->frame.embed_y  = kEmbedLines;
+    vi->embdata_enable = 1u;
 
     /* Pixel formatter — T_R16 (= 196 in L4T `vi5_formats.h:74`)
      * is the standard memory format for any RAW8/10/12 sensor on
@@ -9831,22 +9873,38 @@ int cmd_csidiag(int argc, char *argv[])
     vi->pixfmt.format          = 196u;       /* TEGRA_IMAGE_FORMAT_T_R16 */
     vi->pixfmt.pad0_en         = 0u;
 
-    /* Atomic packer stride — bytes between rows (= width × 2 for
-     * T_R16). The surface IOVA goes in the *memoryinfo* ring,
-     * NOT here in vi_channel_config — see below. */
+    /* Atomic packer stride — bytes between rows. Main surface uses
+     * the frame-buffer stride (width × 2 for T_R16). Embedded
+     * surface stride matches its own per-line byte count. Per L4T
+     * `vi5_fops.c:430-431`. Surface IOVAs go in the *memoryinfo*
+     * ring below, not here. */
     uintptr_t fb_iova               = camrtc_frame_buffer_iova();
-    vi->atomp.surface_stride[0]     = camrtc_frame_buffer_stride();
+    vi->atomp.surface_stride[VI_ATOMP_SURFACE_MAIN]     =
+        camrtc_frame_buffer_stride();
+    vi->atomp.surface_stride[VI_ATOMP_SURFACE_EMBEDDED] = kEmbedLineBytes;
 
     /* memoryinfo ring slot 0 — RCE reads the per-surface IOVA +
      * size from here in lock-step with the request_ring slot.
      * Per L4T `vi5_fops.c:416-417`. The ring was zeroed inside
-     * camrtc_ch_setup_capture_control. */
+     * camrtc_ch_setup_capture_control.
+     *
+     * Embedded surface is parked at the tail of the same 4 MB
+     * frame-buffer carveout — the active frame is 1640×1232 ×
+     * 2 B = 4,040,960 B (~3.85 MB), leaving ~150 KB of slack
+     * before the carveout end at +4 MB. 2 lines × 3280 B = 6560 B
+     * fits comfortably. */
+    uint64_t main_size = (uint64_t)camrtc_frame_buffer_stride()
+                       * camrtc_frame_buffer_height();
+    uint64_t embed_size = (uint64_t)kEmbedLineBytes * kEmbedLines;
     volatile struct camrtc_capture_descriptor_memoryinfo *meminfo =
         (volatile struct camrtc_capture_descriptor_memoryinfo *)
         camrtc_vi_req_meminfo_iova();
-    meminfo->surface[0].base_address = (uint64_t)fb_iova;
-    meminfo->surface[0].size         = (uint64_t)camrtc_frame_buffer_stride()
-                                     * camrtc_frame_buffer_height();
+    meminfo->surface[VI_ATOMP_SURFACE_MAIN].base_address     =
+        (uint64_t)fb_iova;
+    meminfo->surface[VI_ATOMP_SURFACE_MAIN].size             = main_size;
+    meminfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address =
+        (uint64_t)fb_iova + main_size;
+    meminfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size         = embed_size;
 
     __asm__ volatile("dsb sy" ::: "memory");
 

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -1192,8 +1192,14 @@ _Static_assert(CAPTURE_CHANNEL_FLAG_VIDEO == 0x0001u,
     "CAPTURE_CHANNEL_FLAG_VIDEO drift");
 _Static_assert(CAPTURE_CHANNEL_FLAG_RAW == 0x0002u,
     "CAPTURE_CHANNEL_FLAG_RAW drift");
+_Static_assert(CAPTURE_CHANNEL_FLAG_EMBDATA == 0x0040u,
+    "CAPTURE_CHANNEL_FLAG_EMBDATA drift — IMX219 first-light needs this set");
 _Static_assert(CAPTURE_CHANNEL_FLAG_CSI == 0x10000u,
     "CAPTURE_CHANNEL_FLAG_CSI drift");
+_Static_assert(VI_ATOMP_SURFACE_MAIN == 0u,
+    "VI_ATOMP_SURFACE_MAIN drift — pixel plane on surface 0");
+_Static_assert(VI_ATOMP_SURFACE_EMBEDDED == 3u,
+    "VI_ATOMP_SURFACE_EMBEDDED drift — sensor metadata on surface 3");
 
 /* CAPTURE_REQUEST_REQ + CAPTURE_STATUS_IND wire-format pins
  * (PR4 of HW Task 4). Both message bodies are 8 B (just buffer_index


### PR DESCRIPTION
## Summary

`csidiag` on jetson-nano-1 now returns a successful capture (`CAPTURE_STATUS_SUCCESS`, real SOF + EOF timestamps, 4 MB RAW10 in the carveout). Three independent bugs had to be fixed together.

```
capture_status: status=1 frame_id=3 src_stream=1 vc=0
sof_ts=0x2f58f462a0 eof_ts=0x2f5a5798a0 (ticks)
*** CAPTURE SUCCESS — first frame in buffer at 0xa1000000 (~4096 KB). ***
```

## What changed

### 1. NVCSI port — B not A
IMX219-A on the Orin Nano carrier is wired to NVCSI port 1 (B), not port 0 (A). NVIDIA's R36.4.4 DTBO is the source of truth (`tegra234-p3767-camera-p3768-imx219-A.dtbo`: `port-index = <1>` on every endpoint). The earlier "csi_port=0 is correct, verified via LineageOS DTS" was a misread. csidiag now passes `kCsiPort=1`, `kStreamId=1`, `match.stream=(1<<1)`.

### 2. D-PHY CIL config in `CAPTURE_CSI_STREAM_SET_CONFIG_REQ`
- `cil_config.lp_bypass_mode = 1` for D-PHY (`l4t-csi5_fops.c:286`: `is_cphy ? 0 : 1`). Without this the CIL receiver doesn't expect LP-11→HS line-state transitions.
- `brick_config.lane_polarity[]` per IMX219-A DT (`lane_polarity = "6"` → bytes `[0,1,1,0]`). Wrong polarity decodes the differential signal inverted.

### 3. Embedded data lines
IMX219 emits 2 lines of metadata per frame by default (`embedded_metadata_height = "2"` for every mode). VI was raising `CHANSEL_EMBED_INFRINGE` on every frame. Per L4T `vi5_fops.c:420-431`, all five of these need to land:
- `CAPTURE_CHANNEL_FLAG_EMBDATA` in `channel_setup.channel_flags`
- `vi_channel_config.embdata_enable = 1`
- `vi_channel_config.frame.embed_x = width × 2` (T_R16 expansion)
- `vi_channel_config.frame.embed_y = 2`
- atomp `surface_stride[VI_ATOMP_SURFACE_EMBEDDED] = width × 2` plus the surface IOVA in the memoryinfo ring

## Rejected hypotheses (logged in #518 for the record)

- `CSI_STREAM_SET_CONFIG` ↔ `PHY_STREAM_OPEN` ordering — RCE accepts either.
- Non-zero `cil_settletime` — L4T DT specifies 0 for ALL IMX219 modes.
- `cam_pwr` (PH.03) HIGH — Linux leaves it LOW during streaming.
- LP-11 force at power-on (PR #812) — independently correct, but doesn't unblock SOF on its own.

## Test plan

- [x] `make test` (QEMU ARM64) — all integration tests pass
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build
- [x] kexec to nano-1 + `imx219` + `csidiag` — `CAPTURE_STATUS_SUCCESS`
- [x] Drift assertions for `CAPTURE_CHANNEL_FLAG_EMBDATA`, `VI_ATOMP_SURFACE_MAIN`, `VI_ATOMP_SURFACE_EMBEDDED` added to `test_camera.c`

## Out of scope

- Decoding the captured frame (RAW10 → MNIST 28×28 grayscale) — `camera_preprocess_mnist` already exists; wiring `csidiag` into a `camera_open("imx219-0")` backend is the follow-on for #396.
- Migrating camrtc HSP polling to GIC IRQs — separately tracked; not required for first light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)