### PR TITLE
camera: imx219-0 backend for camera_open

### DIFF
--- a/kernel/drivers/camera/imx219.c
+++ b/kernel/drivers/camera/imx219.c
@@ -17,9 +17,14 @@
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "bpmp.h"
+#include "cache.h"
+#include "camera.h"
+#include "camrtc.h"
+#include "camrtc_capture.h"
 #include "debug.h"
 #include "gpio_tegra.h"
 #include "i2c_tegra.h"
@@ -415,6 +420,234 @@ int imx219_streaming_disable(void)
                                  IMX219_MODE_STANDBY);
 }
 
+/*
+ * Capture-pipeline parameters discovered (the hard way) by issue #518:
+ *
+ *   IMX219-A on the J20 connector of the Jetson Orin Nano carrier is
+ *   wired to NVCSI port B (= 1), not port A. The L4T R36.4.4 DTBO
+ *   `tegra234-p3767-camera-p3768-imx219-A.dtbo` carries
+ *   `port-index = <1>` on every endpoint (sensor → vi-port → nvcsi-
+ *   port), and for ports A..D `csi5_port_to_stream(port)` returns the
+ *   port id unchanged so stream_id == csi_port == 1.
+ *
+ *   The sensor emits 2 lines of embedded metadata per frame by
+ *   default (`embedded_metadata_height = "2"` for every mode in the
+ *   L4T DT). VI must be told to expect them or it raises
+ *   CHANSEL_EMBED_INFRINGE — the embedded surface is parked at the
+ *   tail of the same 4 MB frame-buffer carveout because the active
+ *   frame (1640 × 1232 × 2 B = 4,040,960 B) only consumes ~3.85 MB,
+ *   leaving ~150 KB of slack before the carveout end.
+ */
+#define IMX219_NVCSI_PORT          1u   /* NVCSI_PORT_B */
+#define IMX219_STREAM_ID           1u   /* csi5_port_to_stream(B) */
+#define IMX219_PHY_DPHY            0u   /* NVCSI_PHY_TYPE_DPHY */
+#define IMX219_LANES               2u   /* IMX219 = 2-lane CSI-2 */
+#define IMX219_MIPI_CLK_KHZ   456000u   /* default link freq, see
+                                         * ~/slmos-ref/linux/linux-imx219.c:139 */
+#define IMX219_VC                  0u   /* virtual channel 0 */
+#define IMX219_CSI2_RAW10_DT      43u   /* CSI-2 datatype 0x2B */
+#define VI5_PIXFMT_T_R16         196u   /* TEGRA_IMAGE_FORMAT_T_R16,
+                                         * see ~/slmos-ref/tegra-l4t/...vi5_formats.h:74 */
+#define VI5_BPP_MEM                2u   /* T_R16 bytes per sample */
+#define IMX219_EMBED_LINES         2u   /* IMX219 default embedded metadata */
+#define IMX219_FRAME_TIMEOUT_MS 1500u
+#define IMX219_CAPTURE_WAIT_US 2000000u /* 2 s — see csidiag note */
+
+int imx219_capture_one_frame(struct camera_frame *out)
+{
+    if (out == NULL) {
+        WARN("imx219_capture: NULL out");
+        return -1;
+    }
+
+    /* 1. Sensor power. imx219_power_on is idempotent. */
+    int rc = imx219_power_on();
+    if (rc != 0) {
+        WARN("imx219_capture: power_on rc=%d", rc);
+        return -1;
+    }
+
+    /* 2. RCE/HSP/IVC session. Also idempotent. */
+    rc = camrtc_capture_init();
+    if (rc != 0) {
+        WARN("imx219_capture: camrtc_capture_init rc=%d", rc);
+        return -1;
+    }
+
+    /* 3. NVCSI port + stream config (see header comment for why
+     * port=B). Both RCE replies must carry result=0 to indicate the
+     * brick/CIL config landed. */
+    uint32_t result = 0;
+    rc = camrtc_capture_phy_stream_open(IMX219_STREAM_ID, IMX219_NVCSI_PORT,
+                                        IMX219_PHY_DPHY, &result);
+    if (rc != 0 || result != 0u) {
+        WARN("imx219_capture: PHY_STREAM_OPEN rc=%d result=0x%x",
+             rc, (unsigned)result);
+        return -1;
+    }
+
+    rc = camrtc_capture_csi_stream_set_config(IMX219_STREAM_ID,
+                                              IMX219_NVCSI_PORT,
+                                              IMX219_LANES,
+                                              IMX219_MIPI_CLK_KHZ,
+                                              &result);
+    if (rc != 0 || result != 0u) {
+        WARN("imx219_capture: CSI_SET_CONFIG rc=%d result=0x%x",
+             rc, (unsigned)result);
+        return -1;
+    }
+
+    /* 4. CHANNEL_SETUP — RCE allocates a VI channel for us and
+     * returns its id + mask. */
+    uint32_t ch_id = 0;
+    uint64_t vi_mask = 0;
+    rc = camrtc_capture_channel_setup(IMX219_STREAM_ID, IMX219_NVCSI_PORT,
+                                      camrtc_vi_req_ring_iova(),
+                                      camrtc_vi_req_meminfo_iova(),
+                                      camrtc_vi_req_queue_depth(),
+                                      camrtc_vi_req_request_size(),
+                                      camrtc_vi_req_meminfo_size(),
+                                      &result, &ch_id, &vi_mask);
+    if (rc != 0 || result != 0u) {
+        WARN("imx219_capture: CHANNEL_SETUP rc=%d result=0x%x",
+             rc, (unsigned)result);
+        return -1;
+    }
+
+    /* 5. Sensor mode-init + streaming on. Without the register-bank
+     * write the sensor stays in default state and never emits a
+     * SOF (PR #513). */
+    rc = imx219_set_mode_binning_1640x1232();
+    if (rc != 0) {
+        WARN("imx219_capture: mode-init rc=%d", rc);
+        return -1;
+    }
+    rc = imx219_streaming_enable();
+    if (rc != 0) {
+        WARN("imx219_capture: streaming_enable rc=%d", rc);
+        return -1;
+    }
+    /* PLL lock + AGC settle. One full frame at 30 fps. */
+    timer_busy_wait_us(50000u);
+
+    /* 6. Build per-frame descriptor in slot 0 of the request ring.
+     * The slot is in NC memory, so descriptor stores are
+     * RCE-visible without cache maintenance — only the trailing
+     * `dsb sy` is needed to order them before the IVC kick. */
+    uintptr_t desc_base = camrtc_vi_req_ring_iova();
+    volatile uint32_t *desc_words = (volatile uint32_t *)desc_base;
+    uint32_t slot_words = camrtc_vi_req_request_size() / 4u;
+    for (uint32_t i = 0; i < slot_words; i++) desc_words[i] = 0u;
+
+    volatile struct camrtc_capture_descriptor_header *desc =
+        (volatile struct camrtc_capture_descriptor_header *)desc_base;
+    desc->sequence                 = 1u;
+    desc->capture_flags            = CAPTURE_FLAG_STATUS_REPORT_ENABLE
+                                   | CAPTURE_FLAG_ERROR_REPORT_ENABLE;
+    desc->frame_start_timeout      = IMX219_FRAME_TIMEOUT_MS;
+    desc->frame_completion_timeout = IMX219_FRAME_TIMEOUT_MS;
+
+    volatile struct camrtc_vi_channel_config *vi =
+        (volatile struct camrtc_vi_channel_config *)
+        (desc_base + CAMRTC_DESC_CH_CFG_OFFSET);
+
+    /* CHANSEL match — RAW10 on stream `IMX219_STREAM_ID`, VC 0.
+     * `stream` and `vc` are one-hot bit fields, not raw IDs. */
+    vi->match.datatype       = IMX219_CSI2_RAW10_DT;
+    vi->match.datatype_mask  = 0x3fu;
+    vi->match.stream         = (uint8_t)(1u << IMX219_STREAM_ID);
+    vi->match.stream_mask    = 0x3fu;
+    vi->match.vc             = (uint16_t)(1u << IMX219_VC);
+    vi->match.vc_mask        = 0xFFFFu;
+
+    /* Frame geometry + embedded-data routing. embed_x is the
+     * per-line byte count after T_R16 expansion (= width × BPP_MEM,
+     * not the raw RAW10 wire bytes). embdata_enable=1 plus
+     * CAPTURE_CHANNEL_FLAG_EMBDATA in CHANNEL_SETUP is what tells
+     * VI to expect the IMX219's 2 metadata lines instead of
+     * tossing the frame with CHANSEL_EMBED_INFRINGE. */
+    uint32_t fb_w     = camrtc_frame_buffer_width();
+    uint32_t fb_h     = camrtc_frame_buffer_height();
+    uint32_t fb_stride = camrtc_frame_buffer_stride();
+    uint32_t embed_line_bytes = fb_w * VI5_BPP_MEM;
+
+    vi->frame.frame_x  = (uint16_t)fb_w;
+    vi->frame.frame_y  = (uint16_t)fb_h;
+    vi->frame.embed_x  = embed_line_bytes;
+    vi->frame.embed_y  = IMX219_EMBED_LINES;
+    vi->embdata_enable = 1u;
+
+    vi->pixfmt_enable          = 1u;
+    vi->pixfmt.format          = VI5_PIXFMT_T_R16;
+    vi->pixfmt.pad0_en         = 0u;
+
+    uintptr_t fb_iova = camrtc_frame_buffer_iova();
+    vi->atomp.surface_stride[VI_ATOMP_SURFACE_MAIN]     = fb_stride;
+    vi->atomp.surface_stride[VI_ATOMP_SURFACE_EMBEDDED] = embed_line_bytes;
+
+    /* Memoryinfo ring slot 0. Main + embedded surfaces both live in
+     * the 4 MB frame-buffer carveout; embedded is parked past the
+     * active frame. The carveout is reserved by `pmm.c` so it
+     * can't be reused under us. */
+    uint64_t main_size  = (uint64_t)fb_stride * fb_h;
+    uint64_t embed_size = (uint64_t)embed_line_bytes * IMX219_EMBED_LINES;
+
+    volatile struct camrtc_capture_descriptor_memoryinfo *meminfo =
+        (volatile struct camrtc_capture_descriptor_memoryinfo *)
+        camrtc_vi_req_meminfo_iova();
+    meminfo->surface[VI_ATOMP_SURFACE_MAIN].base_address     =
+        (uint64_t)fb_iova;
+    meminfo->surface[VI_ATOMP_SURFACE_MAIN].size             = main_size;
+    meminfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address =
+        (uint64_t)fb_iova + main_size;
+    meminfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size         = embed_size;
+
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    /* 7. Trigger the capture and wait for STATUS_IND. */
+    uint32_t status_index = 0xDEADBEEFu;
+    rc = camrtc_capture_request(0u, &status_index, IMX219_CAPTURE_WAIT_US);
+    if (rc != 0) {
+        WARN("imx219_capture: CAPTURE_REQUEST rc=%d (IVC error or timeout)",
+             rc);
+        return -1;
+    }
+
+    /* 8. Decode capture_status. status=1 (CAPTURE_STATUS_SUCCESS)
+     * means the frame is in the buffer; anything else is a
+     * Falcon/CHANSEL/CSIMUX error. err_data + notify_bits in the
+     * descriptor identify the specific failure for post-mortem. */
+    volatile const struct camrtc_capture_status *cap_status =
+        (volatile const struct camrtc_capture_status *)
+        (desc_base + CAMRTC_DESC_STATUS_OFFSET);
+    uint32_t code = cap_status->status;
+    if (code != CAPTURE_STATUS_SUCCESS) {
+        WARN("imx219_capture: status=%u err_data=0x%x notify_bits=0x%lx",
+             (unsigned)code, (unsigned)cap_status->err_data,
+             (unsigned long)cap_status->notify_bits);
+        return -1;
+    }
+
+    /* VI's atomp packer DMA-wrote the frame to the cached carveout
+     * without going through the AP's cache. Invalidate the
+     * caller-visible region before returning so consumers
+     * (`camera_preprocess_mnist`, future ISP / preview paths) read
+     * the fresh frame instead of cache lines populated by a prior
+     * capture's read. First-capture-after-boot is correct without
+     * this — there are no cache lines for the carveout before any
+     * AP touch — but back-to-back captures depend on it. */
+    cache_invalidate_range((const volatile void *)fb_iova,
+                           (size_t)main_size);
+
+    out->data   = (const uint8_t *)fb_iova;
+    out->size   = (size_t)main_size;
+    out->width  = fb_w;
+    out->height = fb_h;
+    out->bayer  = CAMERA_BAYER_RGGB;
+    out->format = CAMERA_FORMAT_T_R16;
+    return 0;
+}
+
 #else /* !PLATFORM_JETSON_ORIN_NANO — stubs for cross-platform builds */
 
 int imx219_power_on(void) { return -1; }
@@ -427,5 +660,9 @@ int imx219_read_chip_id(uint16_t *out)
 int imx219_set_mode_binning_1640x1232(void) { return -1; }
 int imx219_streaming_enable(void)  { return -1; }
 int imx219_streaming_disable(void) { return -1; }
+int imx219_capture_one_frame(struct camera_frame *out) {
+    (void)out;
+    return -1;
+}
 
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/include/camera.h
+++ b/kernel/include/camera.h
@@ -28,37 +28,70 @@
 #define CAMERA_BAYER_GBRG 2u
 #define CAMERA_BAYER_BGGR 3u
 
+/* Per-sample byte layout in `camera_frame.data`. Bayer pattern
+ * (`CAMERA_BAYER_*`) is orthogonal to this — both fields must be
+ * set by the producing backend.
+ *
+ *   RAW10_PACKED: CSI-2 RAW10 packed, 4 pixels in 5 bytes
+ *     (bytes 0..3 = high 8 bits of pixels 0..3, byte 4 = packed
+ *     low 2 bits). What the mock embed produces.
+ *   T_R16:        VI atomp output for any RAW8/10/12 sensor on
+ *     Tegra VI5: each sample stored as a little-endian u16 with
+ *     the RAW value in bits [15:6] (high 10 bits) and bits [5:0]
+ *     either zeroed or left undefined depending on
+ *     `vi_channel_config.pixfmt.pad0_en`. What `camera_open
+ *     ("imx219-0")` returns on Jetson.
+ */
+#define CAMERA_FORMAT_RAW10_PACKED  0u
+#define CAMERA_FORMAT_T_R16         1u
+
 /* MNIST input: 28*28 fp32 little-endian. Pinned by the runtime
  * inference path; see runtime/src/inference/gpu.rs. */
 #define CAMERA_MNIST_OUT_BYTES (28u * 28u * 4u)
 
 /* Bound used by callers to size temporary stack buffers when probing
- * a capture. The IMX219 2-lane RAW10 1640x1232 mode is the largest
- * single frame any current backend produces. */
-#define CAMERA_FRAME_MAX_BYTES (1640u * 1232u * 10u / 8u)
+ * a capture. The IMX219 T_R16 1640x1232 buffer is the largest single
+ * frame any current backend produces (~4 MB; double the packed RAW10
+ * size because each sample occupies a full u16). */
+#define CAMERA_FRAME_MAX_BYTES (1640u * 1232u * 2u)
 
 struct camera_frame {
     /* Pointer into kernel-owned storage. The mock backend returns
-     * a pointer into .rodata; real backends would point into a DMA
+     * a pointer into .rodata; real backends point into a DMA
      * buffer. Lifetime is tied to the camera handle. */
     const uint8_t *data;
     size_t         size;
     uint32_t       width;
     uint32_t       height;
-    uint32_t       bayer;   /* CAMERA_BAYER_* */
+    uint32_t       bayer;   /* CAMERA_BAYER_*  */
+    uint32_t       format;  /* CAMERA_FORMAT_* */
 };
 
 /*
  * Resolve a camera by name and write a frame descriptor into *out.
- * Currently recognised names: "mock" (when MOCK_CAMERA_FRAME is
- * compiled in). Returns 0 on success, negative on error:
- *   -1 = unknown camera name
- *   -2 = backend not built (e.g. MOCK_CAMERA_FRAME=OFF)
+ * Currently recognised names:
+ *   "mock"     — embedded test frame (when MOCK_CAMERA_FRAME=ON;
+ *                returns RAW10_PACKED).
+ *   "imx219-0" — IMX219 on the J20 connector of the Jetson Orin
+ *                Nano carrier (only when built for
+ *                PLATFORM_JETSON_ORIN_NANO; returns T_R16).
+ * Each call to `camera_open("imx219-0", …)` powers the sensor (if
+ * needed), brings the RCE capture path online (idempotent), and
+ * triggers ONE fresh capture. The returned frame buffer is kernel-
+ * owned and overwritten on the next call.
+ *
+ * Returns 0 on success, negative on error:
+ *   -1 = unknown camera name / NULL args
+ *   -2 = backend not built (MOCK_CAMERA_FRAME=OFF, or imx219-0 on
+ *        a non-Jetson platform)
+ *   -3 = backend reached but capture failed (see WARN log for the
+ *        failing stage; for imx219-0 this includes power-on,
+ *        RCE IVC, sensor I²C, or VI Falcon errors).
  */
 int camera_open(const char *name, struct camera_frame *out);
 
 /*
- * Decode a RAW10 RGGB Bayer frame into a 28x28 fp32 grayscale image
+ * Decode an RGGB Bayer frame into a 28x28 fp32 grayscale image
  * suitable for the MNIST classifier. Pipeline:
  *   1. Centred crop to a 1232x1232 square (drops the 204-pixel L/R
  *      margins of the 1640-wide source). Crop offsets are forced to
@@ -68,17 +101,24 @@ int camera_open(const char *name, struct camera_frame *out);
  *   3. Box-average each 44x44 source block into one output pixel.
  *      28*44 == 1232, so the grid covers the cropped square exactly.
  *   4. Normalise to fp32 in [0, 1] using the high 8 bits of each
- *      RAW10 sample (skips the 5th-byte low bits — the green-only
- *      MNIST classifier doesn't need 10-bit precision).
+ *      sample (low bits are dropped; the green-only MNIST classifier
+ *      doesn't need 10-bit precision).
+ *
+ * `format` is `CAMERA_FORMAT_RAW10_PACKED` (mock) or
+ * `CAMERA_FORMAT_T_R16` (IMX219 via VI atomp). Both formats yield
+ * the same high-8-bit value per pixel, so the produced fp32 output
+ * is byte-identical regardless of source format for a given scene.
  *
  * Returns 0 on success. Negative on bad arguments:
  *   -1 = NULL pointer / out_bytes too small
- *   -2 = unsupported width/height/bayer (only RGGB 1640x1232 today)
+ *   -2 = unsupported width/height/bayer/format (only RGGB 1640x1232
+ *        in RAW10_PACKED or T_R16 today)
  */
-int camera_preprocess_mnist(const uint8_t *raw10,
-                            size_t         raw10_len,
+int camera_preprocess_mnist(const uint8_t *data,
+                            size_t         data_len,
                             uint32_t       width,
                             uint32_t       height,
                             uint32_t       bayer,
+                            uint32_t       format,
                             uint8_t       *out_bytes,
                             size_t         out_capacity);

--- a/kernel/include/imx219.h
+++ b/kernel/include/imx219.h
@@ -175,3 +175,46 @@ int imx219_streaming_enable(void);
  * Returns 0 on success, negative on I²C write error.
  */
 int imx219_streaming_disable(void);
+
+/* Forward declaration to avoid pulling camera.h into the IMX219
+ * header. Defined in `kernel/include/camera.h`. */
+struct camera_frame;
+
+/*
+ * Capture exactly one frame end-to-end and fill *out with a pointer
+ * into the kernel-owned IMX219 frame-buffer carveout at
+ * `CAMRTC_FRAME_BUFFER_PHYS`. Each call walks the full bring-up
+ * pipeline:
+ *
+ *   1. imx219_power_on() if the sensor isn't already responsive.
+ *   2. camrtc_capture_init() to bring up the RCE HSP/IVC session
+ *      (idempotent — returns immediately if already up).
+ *   3. CAPTURE_PHY_STREAM_OPEN_REQ on NVCSI_PORT_B.
+ *   4. CAPTURE_CSI_STREAM_SET_CONFIG_REQ — D-PHY, 2 lanes,
+ *      lp_bypass_mode=1, IMX219-A lane_polarity from the L4T DT.
+ *   5. CAPTURE_CHANNEL_SETUP_REQ with EMBDATA enabled.
+ *   6. imx219_set_mode_binning_1640x1232() + streaming_enable +
+ *      ~50 ms PLL/AGC settle.
+ *   7. Build the per-frame descriptor (vi_channel_config +
+ *      memoryinfo ring slot 0) and fire CAPTURE_REQUEST_REQ.
+ *   8. Block up to 2 s on the STATUS_IND. On
+ *      CAPTURE_STATUS_SUCCESS, populate `*out` and return 0.
+ *
+ * On success `*out` is set to:
+ *   data   = `camrtc_frame_buffer_iova()` (kernel-owned; pointer
+ *            remains valid until the next call to
+ *            `imx219_capture_one_frame`, which overwrites it).
+ *   size   = width × height × 2  (T_R16, ~4 MB)
+ *   width  = 1640
+ *   height = 1232
+ *   bayer  = CAMERA_BAYER_RGGB
+ *   format = CAMERA_FORMAT_T_R16
+ *
+ * Returns 0 on success, negative on any failure (errors logged via
+ * `WARN(...)` along the way; see the file-level comment in
+ * `kernel/drivers/camera/imx219.c` for the specific RCE status
+ * codes that can fire).
+ *
+ * QEMU stub: returns -1 (no hardware) without touching *out.
+ */
+int imx219_capture_one_frame(struct camera_frame *out);

--- a/kernel/src/camera.c
+++ b/kernel/src/camera.c
@@ -21,6 +21,10 @@
 
 #include "string.h"   /* strcmp */
 
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#include "imx219.h"   /* imx219_capture_one_frame */
+#endif
+
 /* The embed file declares these as global symbols when MOCK_CAMERA_FRAME
  * is ON. Both are weak so kernels built with MOCK_CAMERA_FRAME=OFF link
  * cleanly — camera_open("mock") then reports "backend not built". */
@@ -28,12 +32,13 @@ extern const uint8_t mock_camera_frame_start[] __attribute__((weak));
 extern const uint8_t mock_camera_frame_end[]   __attribute__((weak));
 
 /* Frame geometry — pinned to IMX219 2-lane RAW10 1640x1232 binned
- * mode, the only shape the mock and the in-progress IMX219 driver
- * produce. Generalising preprocess_mnist to other shapes is fine
- * later but not in scope today. */
+ * mode, the only shape the mock and the IMX219 driver produce.
+ * Generalising preprocess_mnist to other shapes is fine later but
+ * not in scope today. */
 #define MOCK_FRAME_W       1640u
 #define MOCK_FRAME_H       1232u
-#define MOCK_FRAME_BYTES   (MOCK_FRAME_W * MOCK_FRAME_H * 10u / 8u)
+#define MOCK_FRAME_RAW10_BYTES (MOCK_FRAME_W * MOCK_FRAME_H * 10u / 8u)
+#define MOCK_FRAME_T_R16_BYTES (MOCK_FRAME_W * MOCK_FRAME_H * 2u)
 
 #define MNIST_DIM          28u
 #define MNIST_BLOCK        44u   /* 28 * 44 == 1232 */
@@ -61,11 +66,34 @@ _Static_assert(MNIST_CROP == MOCK_FRAME_H,
  * high 8 bits of each pixel and byte 4 packs the four 2-bit low
  * remainders. We discard the low bits — see the file header for why.
  */
-static inline uint8_t raw10_hi8(const uint8_t *raw10, uint32_t pixel_index)
+static inline uint8_t raw10_packed_hi8(const uint8_t *raw10,
+                                       uint32_t pixel_index)
 {
     uint32_t group   = pixel_index >> 2;
     uint32_t in_grp  = pixel_index & 3u;
     return raw10[group * 5u + in_grp];
+}
+
+/*
+ * Read the high 8 bits of pixel `pixel_index` from a T_R16 buffer.
+ * T_R16 is little-endian u16 with the RAW10 sample in bits [15:6],
+ * so the high 8 bits live in the high byte of each u16 — i.e. byte
+ * `pixel_index * 2 + 1`. ARM64 little-endian is the build's
+ * universal endianness; no cross-platform endianness wrapper needed.
+ */
+static inline uint8_t t_r16_hi8(const uint8_t *t_r16, uint32_t pixel_index)
+{
+    return t_r16[pixel_index * 2u + 1u];
+}
+
+static inline uint8_t pixel_hi8(const uint8_t *buf,
+                                uint32_t pixel_index,
+                                uint32_t format)
+{
+    if (format == CAMERA_FORMAT_T_R16) {
+        return t_r16_hi8(buf, pixel_index);
+    }
+    return raw10_packed_hi8(buf, pixel_index);
 }
 
 /*
@@ -125,29 +153,51 @@ int camera_open(const char *name, struct camera_frame *out)
         out->width  = MOCK_FRAME_W;
         out->height = MOCK_FRAME_H;
         out->bayer  = CAMERA_BAYER_RGGB;
+        out->format = CAMERA_FORMAT_RAW10_PACKED;
         return 0;
+    }
+
+    if (strcmp(name, "imx219-0") == 0) {
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+        int rc = imx219_capture_one_frame(out);
+        if (rc != 0) return -3;
+        return 0;
+#else
+        return -2;
+#endif
     }
 
     return -1;
 }
 
-int camera_preprocess_mnist(const uint8_t *raw10,
-                            size_t         raw10_len,
+int camera_preprocess_mnist(const uint8_t *data,
+                            size_t         data_len,
                             uint32_t       width,
                             uint32_t       height,
                             uint32_t       bayer,
+                            uint32_t       format,
                             uint8_t       *out_bytes,
                             size_t         out_capacity)
 {
-    if (!raw10 || !out_bytes) return -1;
+    if (!data || !out_bytes) return -1;
     if (out_capacity < CAMERA_MNIST_OUT_BYTES) return -1;
 
-    /* Hard-coded geometry — see file header. Generalising to other
-     * sensor modes is a follow-up once the real IMX219 driver lands
-     * and we know which mode tables it ships with. */
+    /* Hard-coded geometry — see file header. */
     if (width != MOCK_FRAME_W || height != MOCK_FRAME_H) return -2;
     if (bayer != CAMERA_BAYER_RGGB) return -2;
-    if (raw10_len < MOCK_FRAME_BYTES) return -1;
+
+    size_t min_bytes;
+    switch (format) {
+    case CAMERA_FORMAT_RAW10_PACKED:
+        min_bytes = MOCK_FRAME_RAW10_BYTES;
+        break;
+    case CAMERA_FORMAT_T_R16:
+        min_bytes = MOCK_FRAME_T_R16_BYTES;
+        break;
+    default:
+        return -2;
+    }
+    if (data_len < min_bytes) return -1;
 
     for (uint32_t i = 0; i < MNIST_DIM; i++) {
         uint32_t r0 = i * MNIST_BLOCK;
@@ -163,7 +213,7 @@ int camera_preprocess_mnist(const uint8_t *raw10,
                  * stride by 2. */
                 uint32_t c_start = c0 + ((r & 1u) ? 0u : 1u);
                 for (uint32_t c = c_start; c < c0 + MNIST_BLOCK; c += 2u) {
-                    sum += raw10_hi8(raw10, r * MOCK_FRAME_W + c);
+                    sum += pixel_hi8(data, r * MOCK_FRAME_W + c, format);
                 }
             }
 

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -4057,7 +4057,8 @@ static int l_camera_preprocess_mnist(lua_State *L) {
      * leaking the page. Stack-resident output unwinds for free. */
     uint8_t out[CAMERA_MNIST_OUT_BYTES];
     int rc = camera_preprocess_mnist(frame.data, frame.size,
-                                     frame.width, frame.height, frame.bayer,
+                                     frame.width, frame.height,
+                                     frame.bayer, frame.format,
                                      out, sizeof(out));
     if (rc != 0) {
         lua_pushnil(L);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -9515,6 +9515,7 @@ int cmd_nvcsi(int argc, char *argv[])
     return 0;
 }
 
+#include "camera.h"
 #include "camrtc.h"
 #include "camrtc_capture.h"
 
@@ -9622,343 +9623,75 @@ int cmd_rcediag(int argc, char *argv[])
 }
 
 /*
- * csidiag — first capture-control IVC round-trip:
- *   1. camrtc_capture_init (HSP-VM session + CH_SETUP + IVC ring init)
- *   2. CAPTURE_PHY_STREAM_OPEN_REQ (NVCSI port A, stream 0, D-PHY)
- *   3. Print the response result.
+ * csidiag — single-shot IMX219 capture via the camera_open backend.
  *
- * Result codes are in `~/slmos-ref/tegra-l4t/l4t-camrtc-capture-messages.h`
- * (CAPTURE_OK = 0, CAPTURE_ERROR_* otherwise). Anything other than
- * 0 means the request reached RCE, came back, but RCE rejected it
- * — e.g. NVCSI not powered, port already open, bad PHY type. The
- * goal here is to *prove the IVC ring works end-to-end*; an
- * RCE-side error is still a successful round-trip from SLM-OS's
- * perspective.
+ * Thin wrapper around `camera_open("imx219-0", ...)` (the real
+ * capture pipeline lives in `imx219_capture_one_frame`,
+ * `kernel/drivers/camera/imx219.c`). Prints the resulting frame
+ * descriptor on success; on failure decodes the most recent
+ * `capture_status` from the NC descriptor ring so the user sees a
+ * named status code without grepping for WARN.
+ *
+ * Result code reference: `~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h`
+ * (CAPTURE_STATUS_*). Pre-RCE failures (power-on, I²C, IVC ring) log
+ * to WARN; the status decode below only applies when the failure
+ * happened on the RCE/VI side (i.e. CAPTURE_REQUEST returned).
  */
 int cmd_csidiag(int argc, char *argv[])
 {
     (void)argc; (void)argv;
-    uart_puts("\r\n=== NVCSI port A open via RCE IVC ===\r\n");
+    uart_puts("\r\n=== IMX219 capture via camera_open(\"imx219-0\") ===\r\n");
 
-    int rc = camrtc_capture_init();
-    uart_printf("  capture_init:   rc=%d\r\n", rc);
-    if (rc != 0) {
-        uart_puts("  *** capture_init failed — see WARN log; ***\r\n");
-        uart_puts("  *** can't proceed without IVC channel.   ***\r\n");
-        uart_puts("=== End ===\r\n");
-        return 0;
-    }
-
-    /*
-     * Port + stream selection — IMX219-A on Orin Nano carrier (J20)
-     * is wired to NVCSI **port B** (= 1), not port A (= 0). NVIDIA's
-     * L4T R36.4.4 DTBO is the source of truth:
-     *   /home/john/slmos-ref/nvidia/Linux_for_Tegra-R36.4.4/Linux_for_Tegra/
-     *     kernel/dtb/tegra234-p3767-camera-p3768-imx219-A.dtbo
-     * specifies `port-index = <1>` for cam0/A on every endpoint
-     * (sensor → vi-port → nvcsi-port). Confirmed by reading the same
-     * value out of the dual overlay (cam0=1, cam1=2 — port 0 is unused
-     * on this carrier).
-     *
-     * For NVCSI ports A..D, csi5_port_to_stream(csi_port) returns the
-     * port id unchanged (`~/slmos-ref/tegra-l4t/l4t-csi5_fops.c:32-36`),
-     * so stream_id == csi_port == 1 here.
-     *
-     * NVCSI_PHY_TYPE_DPHY = 0 (`~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h:1443`).
-     */
-    const uint32_t kCsiPort  = 1u;          /* NVCSI_PORT_B */
-    const uint32_t kStreamId = 1u;          /* csi5_port_to_stream(B) */
-    const uint32_t kPhyDphy  = 0u;          /* NVCSI_PHY_TYPE_DPHY */
-
-    uint32_t result = 0xDEADBEEFu;
-    rc = camrtc_capture_phy_stream_open(kStreamId, kCsiPort, kPhyDphy,
-                                        &result);
-    uart_printf("  PHY_STREAM_OPEN: rc=%d result=0x%x\r\n",
-                rc, (unsigned)result);
-    if (rc != 0 || result != 0u) {
-        if (rc != 0) {
-            uart_puts("  *** PHY_STREAM_OPEN failed at the IVC layer  ***\r\n");
-            uart_puts("  *** (see WARN log); skipping SET_CONFIG.     ***\r\n");
-        } else {
-            uart_puts("  *** RCE rejected PHY_STREAM_OPEN; skipping   ***\r\n");
-            uart_puts("  *** SET_CONFIG. Decode result via            ***\r\n");
-            uart_puts("  *** l4t-camrtc-capture-messages.h.           ***\r\n");
-        }
-        uart_puts("=== End ===\r\n");
-        return 0;
-    }
-
-    /* PHY_STREAM_OPEN succeeded. Configure the brick + CIL for
-     * IMX219: 2 D-PHY lanes, 456 MHz MIPI clock (the IMX219
-     * default link freq from `~/slmos-ref/linux/linux-imx219.c:139`).
-     * SoC-default t_hs_settle / t_clk_settle (0). */
-    uint32_t cfg_result = 0xDEADBEEFu;
-    rc = camrtc_capture_csi_stream_set_config(kStreamId, kCsiPort,
-                                              2u, 456000u,
-                                              &cfg_result);
-    uart_printf("  CSI_SET_CONFIG:  rc=%d result=0x%x\r\n",
-                rc, (unsigned)cfg_result);
-    if (rc != 0 || cfg_result != 0u) {
-        if (rc == 0) {
-            uart_puts("  *** RCE rejected SET_CONFIG; decode result   ***\r\n");
-            uart_puts("  *** via l4t-camrtc-capture-messages.h.       ***\r\n");
-        } else {
-            uart_puts("  *** SET_CONFIG failed at the IVC layer.      ***\r\n");
-        }
-        uart_puts("=== End ===\r\n");
-        return 0;
-    }
-
-    /* CSI_SET_CONFIG succeeded — fire CHANNEL_SETUP_REQ with the
-     * real VI request ring + memoryinfo ring carved out of the
-     * NC region by camrtc.c. RCE should now accept the request
-     * (queue_depth=1 + valid IOVAs) and assign a channel_id; the
-     * actual CAPTURE_REQUEST_REQ to fill a frame lands in PR4. */
-    uint32_t ch_result = 0xDEADBEEFu;
-    uint32_t ch_id     = 0xDEADBEEFu;
-    uint64_t vi_mask   = 0xDEADBEEFDEADBEEFull;
-    rc = camrtc_capture_channel_setup(kStreamId, kCsiPort,
-                                      camrtc_vi_req_ring_iova(),
-                                      camrtc_vi_req_meminfo_iova(),
-                                      camrtc_vi_req_queue_depth(),
-                                      camrtc_vi_req_request_size(),
-                                      camrtc_vi_req_meminfo_size(),
-                                      &ch_result, &ch_id, &vi_mask);
-    uart_printf("  CHANNEL_SETUP:   rc=%d result=0x%x channel_id=0x%x "
-                "vi_mask=0x%lx\r\n",
-                rc, (unsigned)ch_result, (unsigned)ch_id,
-                (unsigned long)vi_mask);
-    if (rc != 0 || ch_result != 0u) {
-        if (rc == 0) {
-            uart_puts("  *** Round-trip OK; RCE rejected the request   ***\r\n");
-            uart_puts("  *** — see WARN log + decode result via        ***\r\n");
-            uart_puts("  *** l4t-camrtc-capture-messages.h.            ***\r\n");
-        } else {
-            uart_puts("  *** CHANNEL_SETUP failed at the IVC layer.   ***\r\n");
-        }
-        uart_puts("=== End ===\r\n");
-        return 0;
-    }
-    uart_printf("  *** CHANNEL_SETUP OK — RCE allocated VI      ***\r\n");
-    uart_printf("  *** channel %u (vi_mask=0x%lx).              ***\r\n",
-                (unsigned)ch_id, (unsigned long)vi_mask);
-
-    /* CHANNEL_SETUP succeeded — populate slot 0 of the request
-     * ring with a *full* capture_descriptor (header + populated
-     * vi_channel_config) and fire CAPTURE_REQUEST_REQ over the
-     * capture IVC channel.
-     *
-     * vi_channel_config carries IMX219 binning-mode RAW10 frame
-     * geometry (1640×1232) and atomp surface[0] = the 4 MB
-     * frame-buffer carveout at 0xA1000000 (PMM-reserved in
-     * pmm.c). RCE programs the VI hardware, the sensor (newly
-     * told to STREAMING via I²C below) emits a frame, the VI
-     * pipeline writes ~4 MB of T_R16 pixels into the buffer, and
-     * RCE sends CAPTURE_STATUS_IND with `capture_status.status`
-     * = CAPTURE_STATUS_SUCCESS (1). */
-
-    /* Apply IMX219 mode-init register bank — 1640×1232 RAW10
-     * binning. ~45 register writes (PLL + lane mode + crop +
-     * binning + format). Without this the sensor stays in
-     * default state and never emits a SOF — verified hardware
-     * blocker on jetson-nano-1, PR #513. */
-    rc = imx219_set_mode_binning_1640x1232();
-    uart_printf("  imx219 mode-init: rc=%d (1640x1232 RAW10 binning)\r\n", rc);
-    if (rc != 0) {
-        uart_puts("  *** IMX219 mode-init failed — see WARN log.   ***\r\n");
-        uart_puts("  *** Run `imx219` first to power the sensor.   ***\r\n");
-        uart_puts("=== End ===\r\n");
-        return 0;
-    }
-
-    /* Tell IMX219 to start streaming. MODE_SELECT (0x0100) goes
-     * 0 → 1; sensor begins emitting CSI-2 frames on the next
-     * frame boundary (~33 ms at 30 fps). */
-    rc = imx219_streaming_enable();
-    uart_printf("  imx219 stream-on: rc=%d (MODE_SELECT=0x01)\r\n", rc);
-    if (rc != 0) {
-        uart_puts("  *** I²C write to IMX219 MODE_SELECT failed.  ***\r\n");
-        uart_puts("=== End ===\r\n");
-        return 0;
-    }
-    /* Wait ~50 ms for the sensor to settle. At 30 fps the first
-     * SOF appears within 33 ms; one full frame interval gives the
-     * sensor's PLL time to lock and the AGC to converge. */
-    timer_busy_wait_us(50000u);
-
-    /* Zero the entire descriptor slot first so any RCE-side read
-     * of an unset field (pfsd_cfg, prefence, pad) lands as 0. */
-    volatile uint32_t *desc_words =
-        (volatile uint32_t *)camrtc_vi_req_ring_iova();
-    uint32_t slot_words = camrtc_vi_req_request_size() / 4u;
-    for (uint32_t i = 0; i < slot_words; i++) desc_words[i] = 0u;
-    uintptr_t desc_base = camrtc_vi_req_ring_iova();
-
-    /* Header overlay — sequence + capture_flags + timeouts. */
-    volatile struct camrtc_capture_descriptor_header *desc =
-        (volatile struct camrtc_capture_descriptor_header *)desc_base;
-    desc->sequence                 = 1u;
-    desc->capture_flags            = CAPTURE_FLAG_STATUS_REPORT_ENABLE
-                                   | CAPTURE_FLAG_ERROR_REPORT_ENABLE;
-    /* Cap RCE-side waits at 1500 ms each so STATUS_IND fires
-     * within our 2 s IVC poll even on a "no frame" path. The
-     * channel default is 5000 ms which is too long for first-
-     * light debugging. */
-    desc->frame_start_timeout      = 1500u;
-    desc->frame_completion_timeout = 1500u;
-
-    /* vi_channel_config overlay — IMX219 binning-mode RAW10
-     * (1640×1232) on NVCSI stream 0 / virtual channel 0, written
-     * to the frame-buffer carveout as 16-bit-per-pixel (T_R16).
-     * Layout: ch_cfg sits at offset 64 of the descriptor (per
-     * CAMRTC_DESC_CH_CFG_OFFSET in camrtc_capture.h, which is
-     * computed from header(12) + prefence_count(4) + prefence[2]
-     * (48) = 64). */
-    volatile struct camrtc_vi_channel_config *vi =
-        (volatile struct camrtc_vi_channel_config *)
-        (desc_base + CAMRTC_DESC_CH_CFG_OFFSET);
-
-    /* Channel selector: match RAW10 datatype (CSI-2 datatype
-     * 0x2B = 43) on stream 0 / VC 0. Per L4T `vi5_fops.c:61-78`
-     * (capture_template) + `vi5_fops.c:407-412` (per-frame
-     * overrides), the masks are NOT zero — they enable matching
-     * on the corresponding fields:
-     *   stream_mask = 0x3f   (6 NVCSI streams)
-     *   vc_mask     = 0xffff (16-bit VC field)
-     *   datatype_mask = 0x3f (6-bit CSI-2 datatype field)
-     * `match.stream` and `match.vc` use ONE-HOT bit encoding
-     * (1 << id). frameid* / dol* stay zero — L4T's template
-     * doesn't set them. */
-    vi->match.datatype       = 43u;             /* NVCSI_DATATYPE_RAW10 */
-    vi->match.datatype_mask  = 0x3fu;
-    vi->match.stream         = (uint8_t)(1u << kStreamId); /* one-hot for the open stream */
-    vi->match.stream_mask    = 0x3fu;
-    vi->match.vc             = (uint16_t)(1u << 0);/* one-hot: NVCSI_VIRTUAL_CHANNEL_0 */
-    vi->match.vc_mask        = 0xFFFFu;
-
-    /* Frame geometry — IMX219 binning mode 1640×1232. The sensor
-     * emits 2 lines of embedded metadata per frame by default
-     * (`tegra234-p3767-camera-p3768-imx219-A.dtbo:embedded_metadata_height
-     * = "2"` for every mode). VI must be told to expect them or it
-     * raises CHANSEL_EMBED_INFRINGE — what blocked #518 on the prior
-     * iteration once port=B was correct.
-     *
-     * Per L4T `vi5_fops.c:420-431`, all three of these need to land:
-     *   - frame.embed_x = embedded_data_width × BPP_MEM
-     *   - frame.embed_y = embedded_metadata_height
-     *   - embdata_enable = 1
-     *
-     * For IMX219 the embedded line width equals the active line width
-     * in pixels and goes through the same T_R16 (BPP_MEM=2) expansion
-     * as RAW10 pixels, so the byte count happens to match the main
-     * pixel-row stride — but treat it as its own quantity here so a
-     * future change to either the main pixel format or the embedded
-     * line width can't silently desync the routing. */
-    const uint32_t kEmbedLineBytes = (uint32_t)camrtc_frame_buffer_width()
-                                   * 2u; /* BPP_MEM = T_R16 = 2 B */
-    const uint32_t kEmbedLines     = 2u;
-    vi->frame.frame_x  = (uint16_t)camrtc_frame_buffer_width();
-    vi->frame.frame_y  = (uint16_t)camrtc_frame_buffer_height();
-    vi->frame.embed_x  = kEmbedLineBytes;
-    vi->frame.embed_y  = kEmbedLines;
-    vi->embdata_enable = 1u;
-
-    /* Pixel formatter — T_R16 (= 196 in L4T `vi5_formats.h:74`)
-     * is the standard memory format for any RAW8/10/12 sensor on
-     * VI5: each sample stored as a u16 with the upper 10 bits
-     * carrying the RAW10 value. pad0_en=0 means "leave the lower
-     * 6 bits untouched" — fine for first-light; setting pad0_en=1
-     * would zero them. */
-    vi->pixfmt_enable          = 1u;
-    vi->pixfmt.format          = 196u;       /* TEGRA_IMAGE_FORMAT_T_R16 */
-    vi->pixfmt.pad0_en         = 0u;
-
-    /* Atomic packer stride — bytes between rows. Main surface uses
-     * the frame-buffer stride (width × 2 for T_R16). Embedded
-     * surface stride matches its own per-line byte count. Per L4T
-     * `vi5_fops.c:430-431`. Surface IOVAs go in the *memoryinfo*
-     * ring below, not here. */
-    uintptr_t fb_iova               = camrtc_frame_buffer_iova();
-    vi->atomp.surface_stride[VI_ATOMP_SURFACE_MAIN]     =
-        camrtc_frame_buffer_stride();
-    vi->atomp.surface_stride[VI_ATOMP_SURFACE_EMBEDDED] = kEmbedLineBytes;
-
-    /* memoryinfo ring slot 0 — RCE reads the per-surface IOVA +
-     * size from here in lock-step with the request_ring slot.
-     * Per L4T `vi5_fops.c:416-417`. The ring was zeroed inside
-     * camrtc_ch_setup_capture_control.
-     *
-     * Embedded surface is parked at the tail of the same 4 MB
-     * frame-buffer carveout — the active frame is 1640×1232 ×
-     * 2 B = 4,040,960 B (~3.85 MB), leaving ~150 KB of slack
-     * before the carveout end at +4 MB. 2 lines × 3280 B = 6560 B
-     * fits comfortably. */
-    uint64_t main_size = (uint64_t)camrtc_frame_buffer_stride()
-                       * camrtc_frame_buffer_height();
-    uint64_t embed_size = (uint64_t)kEmbedLineBytes * kEmbedLines;
-    volatile struct camrtc_capture_descriptor_memoryinfo *meminfo =
-        (volatile struct camrtc_capture_descriptor_memoryinfo *)
-        camrtc_vi_req_meminfo_iova();
-    meminfo->surface[VI_ATOMP_SURFACE_MAIN].base_address     =
-        (uint64_t)fb_iova;
-    meminfo->surface[VI_ATOMP_SURFACE_MAIN].size             = main_size;
-    meminfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address =
-        (uint64_t)fb_iova + main_size;
-    meminfo->surface[VI_ATOMP_SURFACE_EMBEDDED].size         = embed_size;
-
-    __asm__ volatile("dsb sy" ::: "memory");
-
-    uart_printf("  vi_channel_config populated: %ux%u T_R16 → "
-                "surface[0]=0x%lx stride=%u\r\n",
-                (unsigned)camrtc_frame_buffer_width(),
-                (unsigned)camrtc_frame_buffer_height(),
-                (unsigned long)fb_iova,
-                (unsigned)camrtc_frame_buffer_stride());
-
-    uart_printf("  CAPTURE_REQUEST: send buffer_index=0 "
-                "(descriptor at 0x%lx)\r\n", (unsigned long)desc_base);
-    uint32_t status_index = 0xDEADBEEFu;
-    /* Allow up to 2 s for the request: ~33 ms first-frame
-     * latency on a streaming sensor, plus headroom for sensor
-     * warm-up + CSI training + the 1500 ms RCE-side timeouts to
-     * fire if no frame ever arrives. */
-    rc = camrtc_capture_request(0u, &status_index, 2000000u);
-    uart_printf("  CAPTURE_REQUEST: rc=%d status_buffer_index=0x%x\r\n",
-                rc, (unsigned)status_index);
-
+    struct camera_frame frame = {0};
+    int rc = camera_open("imx219-0", &frame);
     if (rc == 0) {
-        /* STATUS_IND received — RCE has filled the descriptor's
-         * `capture_status` substruct at offset 272 with the
-         * per-frame outcome. Decode it. */
-        volatile const struct camrtc_capture_status *cap_status =
+        uart_printf("  *** CAPTURE SUCCESS — %ux%u %s, %u bytes @ 0x%lx ***\r\n",
+                    (unsigned)frame.width, (unsigned)frame.height,
+                    frame.format == CAMERA_FORMAT_T_R16 ? "T_R16" :
+                    frame.format == CAMERA_FORMAT_RAW10_PACKED ? "RAW10_PACKED" :
+                    "?",
+                    (unsigned)frame.size, (unsigned long)frame.data);
+
+        /* Echo the most recent capture_status fields too — useful for
+         * confirming SOF/EOF timestamps and frame_id increments on
+         * back-to-back csidiag runs. The descriptor ring slot 0 is
+         * NC and stays valid until the next CAPTURE_REQUEST_REQ. */
+        volatile const struct camrtc_capture_status *cs =
             (volatile const struct camrtc_capture_status *)
-            (desc_base + CAMRTC_DESC_STATUS_OFFSET);
-        uint32_t code = cap_status->status;
+            (camrtc_vi_req_ring_iova() + CAMRTC_DESC_STATUS_OFFSET);
         uart_printf("  capture_status: status=%u frame_id=%u "
                     "src_stream=%u vc=%u\r\n",
-                    (unsigned)code,
-                    (unsigned)cap_status->frame_id,
-                    (unsigned)cap_status->src_stream,
-                    (unsigned)cap_status->virtual_channel);
-        if (code == CAPTURE_STATUS_SUCCESS) {
-            uint64_t sof = cap_status->sof_timestamp;
-            uint64_t eof = cap_status->eof_timestamp;
-            uart_printf("  sof_ts=0x%lx eof_ts=0x%lx (ticks)\r\n",
-                        (unsigned long)sof, (unsigned long)eof);
-            uart_puts("  *** CAPTURE SUCCESS — first frame in       ***\r\n");
-            uart_printf("  *** buffer at 0x%lx (~%u KB).             ***\r\n",
-                        (unsigned long)fb_iova,
-                        (unsigned)(camrtc_frame_buffer_size() / 1024u));
+                    (unsigned)cs->status, (unsigned)cs->frame_id,
+                    (unsigned)cs->src_stream, (unsigned)cs->virtual_channel);
+        uart_printf("  sof_ts=0x%lx eof_ts=0x%lx (ticks)\r\n",
+                    (unsigned long)cs->sof_timestamp,
+                    (unsigned long)cs->eof_timestamp);
+    } else {
+        uart_printf("  camera_open: rc=%d\r\n", rc);
+        if (rc == -2) {
+            uart_puts("  *** backend not built for this platform.   ***\r\n");
         } else {
-            uint64_t notify = cap_status->notify_bits;
+            /* rc == -3 (capture failed). Decode the descriptor's
+             * capture_status to surface the RCE/VI failure mode
+             * without forcing the user to grep WARN. The descriptor
+             * is valid even on failure — RCE fills it before sending
+             * STATUS_IND. */
+            volatile const struct camrtc_capture_status *cs =
+                (volatile const struct camrtc_capture_status *)
+                (camrtc_vi_req_ring_iova() + CAMRTC_DESC_STATUS_OFFSET);
+            uint32_t code = cs->status;
+            uint64_t notify = cs->notify_bits;
+            uart_printf("  capture_status: status=%u frame_id=%u "
+                        "src_stream=%u vc=%u\r\n",
+                        (unsigned)code, (unsigned)cs->frame_id,
+                        (unsigned)cs->src_stream,
+                        (unsigned)cs->virtual_channel);
             uart_printf("  err_data=0x%x flags=0x%x notify_bits=0x%lx\r\n",
-                        (unsigned)cap_status->err_data,
-                        (unsigned)cap_status->flags,
+                        (unsigned)cs->err_data, (unsigned)cs->flags,
                         (unsigned long)notify);
-            /* Print symbolic name for the most common first-light
-             * failure paths (full enum in l4t-camrtc-capture.h:833).
-             * Indexed by status code 0..15; SUCCESS is unreachable
-             * here (handled in the if-branch above). */
+            /* Symbolic decode for the codes most likely to show up on
+             * first-light regressions. Full enum at
+             * `~/slmos-ref/tegra-l4t/l4t-camrtc-capture.h:833`. */
             static const char *const names[] = {
                 [CAPTURE_STATUS_UNKNOWN]               = "UNKNOWN",
                 [CAPTURE_STATUS_SUCCESS]               = "SUCCESS",
@@ -9983,27 +9716,19 @@ int cmd_csidiag(int argc, char *argv[])
             uart_printf("  *** Capture FAILED — status=%u (%s).       ***\r\n",
                         (unsigned)code, name);
             if (notify & CAPTURE_STATUS_NOTIFY_BIT_FRAME_START_TIMEOUT) {
-                uart_puts("  *** notify: FRAME_START_TIMEOUT — sensor    ***\r\n");
-                uart_puts("  *** never produced an SOF on CSI-2.         ***\r\n");
-                uart_puts("  *** Likely fix: full IMX219 register-bank   ***\r\n");
-                uart_puts("  *** init (binning mode + format + AE)       ***\r\n");
-                uart_puts("  *** before MODE_SELECT=1.                   ***\r\n");
+                uart_puts("  *** notify: FRAME_START_TIMEOUT — no SOF.   ***\r\n");
             } else if (notify & CAPTURE_STATUS_NOTIFY_BIT_FRAME_COMPLETION_TIMEOUT) {
                 uart_puts("  *** notify: FRAME_COMPLETION_TIMEOUT —      ***\r\n");
                 uart_puts("  *** SOF arrived but EOF didn't.             ***\r\n");
             } else if (notify & CAPTURE_STATUS_NOTIFY_BIT_CHANSEL_NO_MATCH) {
                 uart_puts("  *** notify: CHANSEL_NO_MATCH — frame        ***\r\n");
-                uart_puts("  *** received but no VI channel selector     ***\r\n");
-                uart_puts("  *** matched. Check vi_channel_config.match. ***\r\n");
+                uart_puts("  *** received but no channel selector hit.   ***\r\n");
             }
         }
-    } else {
-        uart_puts("  *** CAPTURE_REQUEST failed at the IVC layer ***\r\n");
-        uart_puts("  *** — see WARN log for details.             ***\r\n");
     }
 
-    /* Stop streaming so the sensor doesn't keep firing CSI
-     * frames into a now-stale VI configuration. */
+    /* Stop streaming so the sensor doesn't keep firing CSI frames
+     * into a now-stale VI configuration. Best-effort. */
     int stop_rc = imx219_streaming_disable();
     if (stop_rc != 0) {
         uart_printf("  imx219 stream-off: rc=%d (sensor still streaming)\r\n",

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -65,6 +65,7 @@ static void test_camera_open_mock(void)
     TEST_ASSERT_EQUAL_UINT(1640u, frame.width);
     TEST_ASSERT_EQUAL_UINT(1232u, frame.height);
     TEST_ASSERT_EQUAL_UINT(CAMERA_BAYER_RGGB, frame.bayer);
+    TEST_ASSERT_EQUAL_UINT(CAMERA_FORMAT_RAW10_PACKED, frame.format);
 }
 
 /*
@@ -74,7 +75,14 @@ static void test_camera_open_mock(void)
 static void test_camera_open_unknown_returns_minus_one(void)
 {
     struct camera_frame frame;
-    TEST_ASSERT_EQUAL_INT(-1, camera_open("imx219-0", &frame));
+    /* "imx219-0" is recognised on JETSON_ORIN_NANO builds (returns
+     * 0 or -3 depending on whether the sensor is actually wired);
+     * on every other platform the dispatch resolves to -2
+     * ("backend not built"). Either way, it's NOT -1 — that's
+     * reserved for "unknown name". */
+#if !defined(PLATFORM_JETSON_ORIN_NANO)
+    TEST_ASSERT_EQUAL_INT(-2, camera_open("imx219-0", &frame));
+#endif
     TEST_ASSERT_EQUAL_INT(-1, camera_open("",         &frame));
     TEST_ASSERT_EQUAL_INT(-1, camera_open("nonsense", &frame));
 }
@@ -107,28 +115,33 @@ static void test_camera_preprocess_bad_args(void)
     /* NULL guards. */
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         NULL, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        NULL, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, NULL, sizeof(dummy_out)));
 
     /* out_capacity too small. */
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        dummy_out, CAMERA_MNIST_OUT_BYTES - 1u));
+        CAMERA_FORMAT_RAW10_PACKED, dummy_out, CAMERA_MNIST_OUT_BYTES - 1u));
 
     /* Wrong geometry — only 1640x1232 supported today. */
     TEST_ASSERT_EQUAL_INT(-2, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 640u, 480u, CAMERA_BAYER_RGGB,
-        dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
     TEST_ASSERT_EQUAL_INT(-2, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_GRBG,
-        dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
 
-    /* Right geometry but raw10_len smaller than the frame requires. */
+    /* Unknown format — must reject before reading data. */
+    TEST_ASSERT_EQUAL_INT(-2, camera_preprocess_mnist(
+        dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
+        99u, dummy_out, sizeof(dummy_out)));
+
+    /* Right geometry but data_len smaller than the frame requires. */
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
 }
 
 /*
@@ -148,7 +161,8 @@ static void test_camera_preprocess_mock_first_pixel(void)
 
     uint8_t out[CAMERA_MNIST_OUT_BYTES];
     int rc = camera_preprocess_mnist(frame.data, frame.size,
-                                     frame.width, frame.height, frame.bayer,
+                                     frame.width, frame.height,
+                                     frame.bayer, frame.format,
                                      out, sizeof(out));
     TEST_ASSERT_EQUAL_INT(0, rc);
 
@@ -160,6 +174,54 @@ static void test_camera_preprocess_mock_first_pixel(void)
     uint32_t bits;
     __builtin_memcpy(&bits, &out[0], sizeof(bits));
     TEST_ASSERT_EQUAL_HEX32(0x00000000u, bits);
+}
+
+/*
+ * Test: T_R16 and RAW10_PACKED produce byte-identical fp32 output
+ * when the high-8-bit samples match. Synthesises a 4 MB T_R16
+ * buffer from the embedded mock RAW10 frame, runs preprocess on
+ * both, and asserts the outputs are equal. Catches regressions in
+ * `t_r16_hi8` (the IMX219 backend's read path) without needing
+ * real Jetson hardware. Skipped when MOCK_CAMERA_FRAME=OFF.
+ */
+static uint8_t t_r16_synth_buffer[1640u * 1232u * 2u];
+
+static void test_camera_preprocess_t_r16_matches_raw10(void)
+{
+    if (!mock_frame_embedded()) {
+        TEST_IGNORE_MESSAGE("MOCK_CAMERA_FRAME=OFF — mock backend skipped");
+    }
+    struct camera_frame frame;
+    TEST_ASSERT_EQUAL_INT(0, camera_open("mock", &frame));
+
+    /* For each pixel, copy the RAW10 high-8 byte into the high byte
+     * of a u16 (little-endian: byte[i*2 + 1]); leave the low byte
+     * zero (matches `pad0_en=0` behaviour — VI writes the low 6
+     * bits + 2 high bits of the 10-bit sample, but our reader
+     * discards those anyway). */
+    const uint8_t *raw10 = frame.data;
+    for (uint32_t pi = 0; pi < 1640u * 1232u; pi++) {
+        uint32_t group  = pi >> 2;
+        uint32_t in_grp = pi & 3u;
+        t_r16_synth_buffer[pi * 2u]     = 0u;
+        t_r16_synth_buffer[pi * 2u + 1u] = raw10[group * 5u + in_grp];
+    }
+
+    uint8_t out_raw10[CAMERA_MNIST_OUT_BYTES];
+    uint8_t out_t_r16[CAMERA_MNIST_OUT_BYTES];
+
+    TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
+        frame.data, frame.size, frame.width, frame.height,
+        frame.bayer, CAMERA_FORMAT_RAW10_PACKED,
+        out_raw10, sizeof(out_raw10)));
+    TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
+        t_r16_synth_buffer, sizeof(t_r16_synth_buffer),
+        frame.width, frame.height, frame.bayer,
+        CAMERA_FORMAT_T_R16, out_t_r16, sizeof(out_t_r16)));
+
+    for (uint32_t i = 0; i < CAMERA_MNIST_OUT_BYTES; i++) {
+        TEST_ASSERT_EQUAL_UINT8(out_raw10[i], out_t_r16[i]);
+    }
 }
 
 /* ---- Tegra HSI2C driver ----
@@ -900,6 +962,7 @@ int test_suite_camera(void)
     RUN_TEST(test_camera_open_null_safe);
     RUN_TEST(test_camera_preprocess_bad_args);
     RUN_TEST(test_camera_preprocess_mock_first_pixel);
+    RUN_TEST(test_camera_preprocess_t_r16_matches_raw10);
     RUN_TEST(test_tegra_i2c_stubs_return_minus_one);
     RUN_TEST(test_tegra_i2c_cam_bus_wiring);
     RUN_TEST(test_tegra_i2c_api_arg_validation);


### PR DESCRIPTION
## Summary

Wires `camera_open(\"imx219-0\", &frame)` to the full CSI capture pipeline behind the existing `camera.h` contract. The capture sequencing is extracted from `csidiag` into a reusable `imx219_capture_one_frame()` helper in `kernel/drivers/camera/imx219.c`; csidiag becomes a thin wrapper around the new backend, dropping ~280 lines of duplicated bring-up.

This is the follow-on to PR #813 (first light) and unblocks the real camera-on-Jetson half of #396.

### `struct camera_frame.format`

The mock backend produces RAW10 packed (4 px in 5 B); the IMX219 backend produces T_R16 (each sample in a u16, high 10 bits = RAW value). Adding a `format` field lets both flow through the same `struct camera_frame` and through `camera_preprocess_mnist`, which now branches its high-8-bit pixel read on `format`. Output bytes are identical for a given scene — both formats expose the same high 8 bits.

| Constant | Value | Producer |
|---|---|---|
| `CAMERA_FORMAT_RAW10_PACKED` | 0 | mock |
| `CAMERA_FORMAT_T_R16` | 1 | `imx219-0` (via VI atomp) |

### csidiag

Now ~100 lines (was 376). Calls `camera_open(\"imx219-0\", …)`, prints the resulting frame, decodes `capture_status` symbolically on failure. Every csidiag invocation now exercises the camera_open dispatch as a free integration test.

### Test plan

- [x] `make test` (QEMU ARM64) — all integration tests pass, including:
  - mock backend reports `format = RAW10_PACKED`
  - `imx219-0` resolves to -2 (backend-not-built) on non-Jetson builds
  - `preprocess_mnist` rejects unknown formats
  - T_R16 round-trip: synthesise a T_R16 buffer from the mock's high-8-bit samples → preprocess output byte-identical to the RAW10 path
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build
- [x] kexec to nano-1 + `imx219` + `csidiag` — `CAPTURE SUCCESS — 1640x1232 T_R16, 4040960 bytes @ 0xa1000000`, real SOF/EOF timestamps, status=1.

## Out of scope

- Streaming / multi-frame buffering — `camera_open(\"imx219-0\", …)` triggers exactly one capture per call. A queued-buffer API can layer on top later.
- IRQ-driven camrtc mailbox waits — `camrtc_send_msg` still polls; tracked separately.
- `slm camera capture` Lua bindings already work with the mock and will work with the IMX219 backend automatically (the existing l_camera_open passes the name through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)