### PR TITLE
lua_slm: optional camera-name on preprocess_mnist

### DIFF
--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -4029,6 +4029,14 @@ static int l_camera_preprocess_mnist(lua_State *L) {
     lua_Integer width    = luaL_checkinteger(L, 2);
     lua_Integer height   = luaL_checkinteger(L, 3);
     lua_Integer bayer    = luaL_checkinteger(L, 4);
+    /* Optional camera-name (5th arg). Defaults to "mock" so existing
+     * Lua callers continue to work unchanged; pass "imx219-0" on
+     * Jetson to feed a real captured frame through the same
+     * MNIST preprocess pipeline. The whole `preprocess_mnist` shape
+     * is MNIST-specific (1640×1232 RGGB → green-only → 28×28 fp32)
+     * and will be replaced by composable Rust-side preprocessing
+     * — see follow-up issue. */
+    const char *name = luaL_optstring(L, 5, "mock");
 
     if (frame_id != 0) {
         lua_pushnil(L);
@@ -4036,7 +4044,7 @@ static int l_camera_preprocess_mnist(lua_State *L) {
         return 2;
     }
     struct camera_frame frame;
-    if (camera_open("mock", &frame) != 0) {
+    if (camera_open(name, &frame) != 0) {
         lua_pushnil(L);
         lua_pushinteger(L, -2);
         return 2;


### PR DESCRIPTION
## Summary

Adds an optional 5th argument to `slm.camera.preprocess_mnist(...)` selecting the camera backend. Default stays `\"mock\"` so existing tests / Lua callers are unchanged; on Jetson pass `\"imx219-0\"` to feed a real captured frame through the MNIST preprocess pipeline end-to-end.

```lua
-- existing call still works (mock):
local out = slm.camera.preprocess_mnist(0, 1640, 1232, 0)

-- new on Jetson:
local out = slm.camera.preprocess_mnist(0, 1640, 1232, 0, \"imx219-0\")
```

## Scope

Deliberately minimal. The `preprocess_mnist` pipeline is still MNIST-specific (1640×1232 RGGB → green-only → 28×28 fp32). Generalising it across models is **out of scope** here and tracked in #815 — replace `camera_preprocess_mnist` with composable Rust-side preprocessing **before the second model lands**.

## Test plan

- [x] `make test` (QEMU ARM64) — all green; existing 4-arg Lua test path keeps working via `luaL_optstring` default.
- [ ] Hardware verification on jetson-nano-1 with a Lua one-liner against `imx219-0` deferred to the #815 refactor — the C-side `imx219_capture_one_frame` is already hardware-verified in PR #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)