### PR TITLE
demo: IMX219 → MNIST Lua demo (#396)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1206,8 +1206,8 @@ if(EMBED_DEMO_SCRIPTS)
     set_source_files_properties(
         kernel/src/demo_scripts.S
         PROPERTIES
-        COMPILE_DEFINITIONS "DEMO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo.lua;DEMO_MENU_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;DEMO_AUTO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;DEMO_MULTIPROC_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;DEMO_HAILO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;DEMO_ADMIN_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/admin.lua"
-        OBJECT_DEPENDS "${CMAKE_SOURCE_DIR}/scripts/demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua"
+        COMPILE_DEFINITIONS "DEMO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo.lua;DEMO_MENU_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;DEMO_AUTO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;DEMO_MULTIPROC_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;DEMO_HAILO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;DEMO_ADMIN_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/admin.lua;DEMO_IMX219_MNIST_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua"
+        OBJECT_DEPENDS "${CMAKE_SOURCE_DIR}/scripts/demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua"
     )
 endif()
 

--- a/kernel/src/demo_init.c
+++ b/kernel/src/demo_init.c
@@ -37,6 +37,8 @@ extern const unsigned char demo_hailo_lua_start[];
 extern const unsigned char demo_hailo_lua_end[];
 extern const unsigned char demo_admin_lua_start[];
 extern const unsigned char demo_admin_lua_end[];
+extern const unsigned char demo_imx219_mnist_lua_start[];
+extern const unsigned char demo_imx219_mnist_lua_end[];
 
 int demo_init(void)
 {
@@ -107,6 +109,17 @@ int demo_init(void)
         littlefs_file_write(mnt, fad, demo_admin_lua_start,
                             (size_t)(demo_admin_lua_end - demo_admin_lua_start));
         littlefs_file_close(mnt, fad);
+    }
+
+    /* #396: IMX219 -> MNIST capstone demo. Runnable as
+     * `lua /mnt/files/demo_imx219_mnist.lua` from the shell. */
+    int fim = littlefs_file_open(mnt, "/demo_imx219_mnist.lua",
+                                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fim >= 0) {
+        littlefs_file_write(mnt, fim, demo_imx219_mnist_lua_start,
+                            (size_t)(demo_imx219_mnist_lua_end -
+                                     demo_imx219_mnist_lua_start));
+        littlefs_file_close(mnt, fim);
     }
 
     /* #64: boot-time model preload config. One model name per line.

--- a/kernel/src/demo_scripts.S
+++ b/kernel/src/demo_scripts.S
@@ -17,10 +17,12 @@
 
 #if !defined(DEMO_LUA_PATH) || !defined(DEMO_MENU_LUA_PATH) || \
     !defined(DEMO_AUTO_LUA_PATH) || !defined(DEMO_MULTIPROC_LUA_PATH) || \
-    !defined(DEMO_HAILO_LUA_PATH) || !defined(DEMO_ADMIN_LUA_PATH)
+    !defined(DEMO_HAILO_LUA_PATH) || !defined(DEMO_ADMIN_LUA_PATH) || \
+    !defined(DEMO_IMX219_MNIST_LUA_PATH)
 # error "DEMO_LUA_PATH, DEMO_MENU_LUA_PATH, DEMO_AUTO_LUA_PATH, "\
-        "DEMO_MULTIPROC_LUA_PATH, DEMO_HAILO_LUA_PATH, and "\
-        "DEMO_ADMIN_LUA_PATH must be supplied by the build system"
+        "DEMO_MULTIPROC_LUA_PATH, DEMO_HAILO_LUA_PATH, "\
+        "DEMO_ADMIN_LUA_PATH, and DEMO_IMX219_MNIST_LUA_PATH "\
+        "must be supplied by the build system"
 #endif
 
 #define xstr(s) str(s)
@@ -83,6 +85,17 @@ demo_hailo_lua_end:
 demo_admin_lua_start:
     .incbin xstr(DEMO_ADMIN_LUA_PATH)
 demo_admin_lua_end:
+
+    /* #396: IMX219 -> MNIST capstone demo. Pipes a real camera frame
+     * through slm.camera.preprocess_mnist + slm.model_infer_bytes
+     * from a single Lua entry point. Degrades to a clean "camera not
+     * available" message on platforms without IMX219 hardware. */
+    .global demo_imx219_mnist_lua_start
+    .global demo_imx219_mnist_lua_end
+    .align 4
+demo_imx219_mnist_lua_start:
+    .incbin xstr(DEMO_IMX219_MNIST_LUA_PATH)
+demo_imx219_mnist_lua_end:
 
 #if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__))
     .section .note.GNU-stack, "", @progbits

--- a/scripts/demo_imx219_mnist.lua
+++ b/scripts/demo_imx219_mnist.lua
@@ -53,7 +53,7 @@ local cam = slm.camera.open(cam_name)
 if cam == nil then
     note("Camera open failed — no '" .. cam_name .. "' backend on this build.")
     note("On Jetson Orin Nano, kexec a JETSON_ORIN_NANO build first.")
-    note("On other platforms try:  lua /mnt/files/demo_imx219_mnist.lua mock")
+    note("On other platforms try:  lua-admin /mnt/files/demo_imx219_mnist.lua mock")
     return
 end
 note(string.format("camera.open: %d ms", slm.uptime() - t_open))
@@ -106,12 +106,16 @@ note(string.format("model_load:  %d ms  (model_id=%d)",
 header("4. Inference — slm.model_infer_bytes()")
 
 local t_inf = slm.uptime()
-local logits, argmax = slm.model_infer_bytes(mid, bytes)
+-- model_infer_bytes returns (logits_string, argmax) on success or
+-- (nil, rc<0) on failure. Capture as a second name so the failure
+-- branch reads correctly; rebind to argmax once success is confirmed.
+local logits, argmax_or_rc = slm.model_infer_bytes(mid, bytes)
 if logits == nil then
-    note(string.format("model_infer_bytes failed: rc=%d", argmax or 0))
+    note(string.format("model_infer_bytes failed: rc=%d", argmax_or_rc or 0))
     cam:close()
     return
 end
+local argmax = argmax_or_rc
 note(string.format("inference:   %d ms", slm.uptime() - t_inf))
 note("")
 note("Logits (class -> score):")

--- a/scripts/demo_imx219_mnist.lua
+++ b/scripts/demo_imx219_mnist.lua
@@ -1,0 +1,138 @@
+-- SLM-OS IMX219 → MNIST Demo
+--
+-- End-to-end capstone walkthrough: capture one frame from the IMX219
+-- camera on the Jetson Orin Nano, preprocess it through the MNIST
+-- pipeline (1640×1232 RGGB → green-only → 28×28 fp32), and run
+-- inference on the built-in MNIST classifier. Prints the captured
+-- geometry, the 10-class logits vector, and the argmax digit
+-- prediction.
+--
+-- The camera is not pointed at a hand-drawn digit by default, so the
+-- argmax has no semantic meaning beyond "the full pipeline produced
+-- a valid logits vector." The demo's purpose is to show every stage
+-- — sensor power-up, CSI capture, VI DMA, MNIST preprocess, on-CPU
+-- inference — running through a single Lua entry point.
+--
+-- Platforms without IMX219 hardware (QEMU, Pi 5, x86-64) get a clean
+-- "camera not available" message and exit without running inference.
+--
+-- Usage:  lua-admin /mnt/files/demo_imx219_mnist.lua [camera-name]
+--
+-- camera-name  defaults to "imx219-0" — pass "mock" to exercise the
+--              same pipeline against the embedded synthetic frame on
+--              any platform.
+--
+-- Must be run from the admin Lua context — slm.model_load_mnist and
+-- slm.model_infer_bytes are admin-only bindings (mutate the global
+-- model table / run inference).
+
+local P = slm.print
+
+local function header(title)
+    P("")
+    P("============================================================")
+    P("  " .. title)
+    P("============================================================")
+end
+
+local function note(s) P("  " .. s) end
+
+local cam_name = (arg and arg[1]) or "imx219-0"
+
+header("SLM-OS IMX219 → MNIST Demo")
+note("Camera:  " .. cam_name)
+note("Script:  scripts/demo_imx219_mnist.lua")
+
+-- ------------------------------------------------------------------
+-- Step 1: open the camera + capture one frame
+-- ------------------------------------------------------------------
+header("1. Capture — slm.camera.open() + cam:capture()")
+
+local t_open = slm.uptime()
+local cam = slm.camera.open(cam_name)
+if cam == nil then
+    note("Camera open failed — no '" .. cam_name .. "' backend on this build.")
+    note("On Jetson Orin Nano, kexec a JETSON_ORIN_NANO build first.")
+    note("On other platforms try:  lua /mnt/files/demo_imx219_mnist.lua mock")
+    return
+end
+note(string.format("camera.open: %d ms", slm.uptime() - t_open))
+
+local t_cap = slm.uptime()
+local frame_id, width, height, bayer = cam:capture()
+if frame_id == nil then
+    note("Capture failed — IMX219 power-up or CSI/VI bring-up returned an error.")
+    note("Check kprintf output above for the specific stage that failed.")
+    cam:close()
+    return
+end
+note(string.format("capture:     %d ms  (frame_id=%d, %dx%d, bayer=%d)",
+                   slm.uptime() - t_cap, frame_id, width, height, bayer))
+
+-- ------------------------------------------------------------------
+-- Step 2: MNIST preprocess (1640x1232 RGGB → 28x28 fp32)
+-- ------------------------------------------------------------------
+header("2. Preprocess — slm.camera.preprocess_mnist()")
+
+local t_pre = slm.uptime()
+local bytes, rc = slm.camera.preprocess_mnist(frame_id, width, height,
+                                              bayer, cam_name)
+if bytes == nil then
+    note(string.format("preprocess_mnist failed: rc=%d", rc or 0))
+    cam:close()
+    return
+end
+note(string.format("preprocess:  %d ms  (%d bytes = %d fp32 samples)",
+                   slm.uptime() - t_pre, #bytes, #bytes / 4))
+
+-- ------------------------------------------------------------------
+-- Step 3: load the built-in MNIST model
+-- ------------------------------------------------------------------
+header("3. Model — slm.model_load_mnist()")
+
+local t_load = slm.uptime()
+local mid = slm.model_load_mnist()
+if mid == nil or mid < 0 then
+    note("model_load_mnist failed — MNIST not embedded in this build.")
+    cam:close()
+    return
+end
+note(string.format("model_load:  %d ms  (model_id=%d)",
+                   slm.uptime() - t_load, mid))
+
+-- ------------------------------------------------------------------
+-- Step 4: inference
+-- ------------------------------------------------------------------
+header("4. Inference — slm.model_infer_bytes()")
+
+local t_inf = slm.uptime()
+local logits, argmax = slm.model_infer_bytes(mid, bytes)
+if logits == nil then
+    note(string.format("model_infer_bytes failed: rc=%d", argmax or 0))
+    cam:close()
+    return
+end
+note(string.format("inference:   %d ms", slm.uptime() - t_inf))
+note("")
+note("Logits (class -> score):")
+for i = 0, 9 do
+    local f = string.unpack("<f", logits, 1 + i * 4)
+    local marker = (i == argmax) and "  <-- argmax" or ""
+    note(string.format("  %d: %8.4f%s", i, f, marker))
+end
+note("")
+note(string.format("Predicted digit: %d", argmax))
+
+cam:close()
+
+-- ------------------------------------------------------------------
+-- Footer
+-- ------------------------------------------------------------------
+header("Demo Complete")
+note("Pipeline:  IMX219 sensor -> NVCSI -> VI -> kernel carveout")
+note("           -> MNIST preprocess -> CPU inference -> argmax")
+note("")
+note("The argmax is only meaningful if the sensor is pointed at a")
+note("hand-drawn digit on a uniform background. The demo's purpose")
+note("is to show every stage running end-to-end through Lua.")
+P("")


### PR DESCRIPTION
## Summary

End-to-end capstone walkthrough as a single Lua script. Captures one
IMX219 frame on Jetson Orin Nano, runs it through `slm.camera.preprocess_mnist`,
loads the built-in MNIST model, and prints the 10-class logits + argmax.

- New script: `scripts/demo_imx219_mnist.lua`
- Embedded in the kernel image via `demo_scripts.S` + `demo_init.c`, installed at `/mnt/files/demo_imx219_mnist.lua` on boot
- Degrades cleanly on non-Jetson platforms (camera-open fails fast)
- Must be invoked under `lua-admin` — `model_load_mnist` and `model_infer_bytes` are admin-only

## Hardware verification (jetson-nano-1, 2026-05-14)

```
camera.open: 390 ms
capture:     188 ms  (frame_id=0, 1640x1232, bayer=0)
preprocess:  191 ms  (3136 bytes = 784 fp32 samples)
model_load:    0 ms  (preloaded slot 0)
inference:     4 ms
Predicted digit: 5
```

Logits printed cleanly with `%8.4f` (kernel printf doesn't accept the
space flag — that's why an earlier draft showed literal `% .4f`).

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` clean build
- [x] `lua-admin /mnt/files/demo_imx219_mnist.lua` over serial after kexec on jetson-nano-1 — full pipeline runs and prints argmax
- [ ] Reviewer spot-check on `scripts/demo_imx219_mnist.lua` text + the three build wiring sites (admin.lua wiring is the pattern)

Closes the demo half of #396 (capture + Lua surface complete). The
composable Rust-side preprocess refactor remains tracked in #815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)