### PR TITLE
hailo-re-driver: relax corpus.load seq invariant to allow region gaps

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
@@ -365,7 +365,14 @@ def init(path: os.PathLike | str, header: Header) -> Corpus:
 
 
 def append_op(corpus: Corpus, op: OpEntry) -> None:
-    """Append a new op, enforcing strict monotonic seq."""
+    """Append a new op, enforcing strict +1 seq.
+
+    Unlike ``load``, which accepts gaps (region-served accesses don't
+    produce op entries), this function is only ever called to record
+    the immediately-next captured read — the seq the QEMU stub halted
+    at, one past its own most-recent C-side auto-append. So +1 is the
+    right invariant here, and a non-+1 seq indicates a caller bug.
+    """
     if corpus.trailer is not None:
         raise CorpusError(
             f"{corpus.path}: cannot append after trailer is written"

--- a/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
@@ -318,10 +318,17 @@ def load(path: os.PathLike | str) -> Corpus:
         kind = obj.get("type")
         if kind == "op":
             op = _validate_op(obj)
-            if op.seq != prev_seq + 1:
+            # Op entries must be strictly increasing in seq, but NOT
+            # necessarily contiguous. Phase 4 region rules cover a
+            # contiguous BAR range with a single entry; the seq counter
+            # still ticks for every region-served access inside that
+            # range, so the next captured op naturally has a seq several
+            # hundred (or thousand) past the prior one. The +1 invariant
+            # held pre-Phase 4 only because every access generated an op.
+            if op.seq <= prev_seq:
                 raise CorpusError(
-                    f"{p}:{i}: seq jumped {prev_seq} -> {op.seq} "
-                    "(must be strictly monotonic +1)"
+                    f"{p}:{i}: seq went backwards {prev_seq} -> {op.seq} "
+                    "(must be strictly increasing)"
                 )
             ops.append(op)
             prev_seq = op.seq

--- a/host-tools/hailo-re-driver/tests/test_corpus.py
+++ b/host-tools/hailo-re-driver/tests/test_corpus.py
@@ -117,14 +117,42 @@ class CorpusValidationTests(unittest.TestCase):
             with self.assertRaises(CorpusError):
                 corpus_mod.append_op(corpus, bad)
 
-    def test_load_rejects_seq_gap(self) -> None:
+    def test_load_accepts_seq_gap(self) -> None:
+        # Phase 4 region rules cover a contiguous range with a single
+        # entry; the stub's seq counter still ticks for every covered
+        # access, so the next captured op has a seq far past the prior
+        # one. Gaps are legitimate.
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "corpus.jsonl"
             with p.open("w") as f:
                 f.write(json.dumps(make_header().to_json_obj()) + "\n")
                 f.write(json.dumps(make_write(1).to_json_obj()) + "\n")
-                # skip seq=2 — should be rejected on load
-                f.write(json.dumps(make_write(3).to_json_obj()) + "\n")
+                # Seq 2..99 served by an implicit region — no entries.
+                f.write(json.dumps(make_write(100).to_json_obj()) + "\n")
+            corpus = corpus_mod.load(p)
+            self.assertEqual(len(corpus.ops), 2)
+            self.assertEqual(corpus.ops[0].seq, 1)
+            self.assertEqual(corpus.ops[1].seq, 100)
+
+    def test_load_rejects_seq_decrease(self) -> None:
+        # Strictly-increasing is still enforced — seqs that go backwards
+        # or repeat indicate file corruption / concurrent-writer bugs.
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            with p.open("w") as f:
+                f.write(json.dumps(make_header().to_json_obj()) + "\n")
+                f.write(json.dumps(make_write(5).to_json_obj()) + "\n")
+                f.write(json.dumps(make_write(3).to_json_obj()) + "\n")  # backwards
+            with self.assertRaises(CorpusError):
+                corpus_mod.load(p)
+
+    def test_load_rejects_seq_duplicate(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            with p.open("w") as f:
+                f.write(json.dumps(make_header().to_json_obj()) + "\n")
+                f.write(json.dumps(make_write(5).to_json_obj()) + "\n")
+                f.write(json.dumps(make_write(5).to_json_obj()) + "\n")  # duplicate
             with self.assertRaises(CorpusError):
                 corpus_mod.load(p)
 


### PR DESCRIPTION
## Summary

Follow-up to #817. After Phase 4 region rules landed, the post-region grind iteration appends an op at a seq far past the prior one (~2108 vs 1744 — the QEMU stub's seq counter ticks for every region-served BAR4 firmware-byte access). The Python loader's strict-+1 monotonicity check (originally correct because pre-Phase 4 every access generated an op entry) now wrongly rejects this. Surfaced as:

\`\`\`
CorpusError: ...:1747: seq jumped 1744 -> 2108 (must be strictly monotonic +1)
\`\`\`

Relax the rule to **strictly increasing** without requiring +1 contiguity. Duplicate and backwards seqs are still rejected — those still indicate file corruption or concurrent-writer bugs. \`append_op\`'s \`next_seq\` check is unchanged; that path captures the immediately-next-seq read after the stub's auto-appends, so +1 remains the correct invariant there.

## Test plan

- [x] Replace \`test_load_rejects_seq_gap\` with three tests:
      \`test_load_accepts_seq_gap\`, \`test_load_rejects_seq_decrease\`, \`test_load_rejects_seq_duplicate\`
- [x] Full \`hailo_re_driver.tests.test_corpus\` suite — 15/15 pass
- [x] Real working corpus (post-region-injection, with the seq-2108 entry) loads cleanly: \`ops=1745, regions=1, next_seq=2109\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)