### PR TITLE
demo: camera_heatmap.lua — debug aid for OOD MNIST inputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1206,8 +1206,8 @@ if(EMBED_DEMO_SCRIPTS)
     set_source_files_properties(
         kernel/src/demo_scripts.S
         PROPERTIES
-        COMPILE_DEFINITIONS "DEMO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo.lua;DEMO_MENU_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;DEMO_AUTO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;DEMO_MULTIPROC_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;DEMO_HAILO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;DEMO_ADMIN_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/admin.lua;DEMO_IMX219_MNIST_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua"
-        OBJECT_DEPENDS "${CMAKE_SOURCE_DIR}/scripts/demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua"
+        COMPILE_DEFINITIONS "DEMO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo.lua;DEMO_MENU_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;DEMO_AUTO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;DEMO_MULTIPROC_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;DEMO_HAILO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;DEMO_ADMIN_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/admin.lua;DEMO_IMX219_MNIST_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua;DEMO_CAMERA_HEATMAP_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/camera_heatmap.lua"
+        OBJECT_DEPENDS "${CMAKE_SOURCE_DIR}/scripts/demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua;${CMAKE_SOURCE_DIR}/scripts/camera_heatmap.lua"
     )
 endif()
 

--- a/kernel/src/demo_init.c
+++ b/kernel/src/demo_init.c
@@ -39,6 +39,8 @@ extern const unsigned char demo_admin_lua_start[];
 extern const unsigned char demo_admin_lua_end[];
 extern const unsigned char demo_imx219_mnist_lua_start[];
 extern const unsigned char demo_imx219_mnist_lua_end[];
+extern const unsigned char demo_camera_heatmap_lua_start[];
+extern const unsigned char demo_camera_heatmap_lua_end[];
 
 int demo_init(void)
 {
@@ -120,6 +122,18 @@ int demo_init(void)
                             (size_t)(demo_imx219_mnist_lua_end -
                                      demo_imx219_mnist_lua_start));
         littlefs_file_close(mnt, fim);
+    }
+
+    /* IMX219 debug aid: ASCII heatmap of the post-preprocess
+     * 28x28 tensor. Useful when the MNIST demo collapses to a
+     * single class regardless of scene. */
+    int fch = littlefs_file_open(mnt, "/camera_heatmap.lua",
+                                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fch >= 0) {
+        littlefs_file_write(mnt, fch, demo_camera_heatmap_lua_start,
+                            (size_t)(demo_camera_heatmap_lua_end -
+                                     demo_camera_heatmap_lua_start));
+        littlefs_file_close(mnt, fch);
     }
 
     /* #64: boot-time model preload config. One model name per line.

--- a/kernel/src/demo_scripts.S
+++ b/kernel/src/demo_scripts.S
@@ -18,11 +18,12 @@
 #if !defined(DEMO_LUA_PATH) || !defined(DEMO_MENU_LUA_PATH) || \
     !defined(DEMO_AUTO_LUA_PATH) || !defined(DEMO_MULTIPROC_LUA_PATH) || \
     !defined(DEMO_HAILO_LUA_PATH) || !defined(DEMO_ADMIN_LUA_PATH) || \
-    !defined(DEMO_IMX219_MNIST_LUA_PATH)
+    !defined(DEMO_IMX219_MNIST_LUA_PATH) || \
+    !defined(DEMO_CAMERA_HEATMAP_LUA_PATH)
 # error "DEMO_LUA_PATH, DEMO_MENU_LUA_PATH, DEMO_AUTO_LUA_PATH, "\
         "DEMO_MULTIPROC_LUA_PATH, DEMO_HAILO_LUA_PATH, "\
-        "DEMO_ADMIN_LUA_PATH, and DEMO_IMX219_MNIST_LUA_PATH "\
-        "must be supplied by the build system"
+        "DEMO_ADMIN_LUA_PATH, DEMO_IMX219_MNIST_LUA_PATH, and "\
+        "DEMO_CAMERA_HEATMAP_LUA_PATH must be supplied by the build system"
 #endif
 
 #define xstr(s) str(s)
@@ -96,6 +97,16 @@ demo_admin_lua_end:
 demo_imx219_mnist_lua_start:
     .incbin xstr(DEMO_IMX219_MNIST_LUA_PATH)
 demo_imx219_mnist_lua_end:
+
+    /* IMX219 debug aid: renders the post-preprocess 28x28 tensor as
+     * an ASCII heatmap so the operator can see what the model
+     * actually receives. Optional admin-side inference summary. */
+    .global demo_camera_heatmap_lua_start
+    .global demo_camera_heatmap_lua_end
+    .align 4
+demo_camera_heatmap_lua_start:
+    .incbin xstr(DEMO_CAMERA_HEATMAP_LUA_PATH)
+demo_camera_heatmap_lua_end:
 
 #if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__))
     .section .note.GNU-stack, "", @progbits

--- a/scripts/camera_heatmap.lua
+++ b/scripts/camera_heatmap.lua
@@ -1,0 +1,133 @@
+-- camera_heatmap.lua — show what the model actually sees.
+--
+-- Captures one frame, runs it through the MNIST preprocess pipeline,
+-- and renders the resulting 28x28 fp32 tensor as an ASCII heatmap.
+-- Then (under lua-admin) runs the MNIST classifier and prints the
+-- top-3 logits side-by-side with the image.
+--
+-- Purpose: when the MNIST demo returns the same class for every
+-- scene, the heatmap is the fastest way to tell whether the bug is
+-- in capture/preprocess (image is mostly uniform regardless of
+-- scene) or whether the model is just out-of-distribution on real
+-- photos (image looks correct, but logit magnitudes are tiny and
+-- argmax collapses to whichever class the network biases toward
+-- with near-uniform input).
+--
+-- Usage:  lua-admin /mnt/files/camera_heatmap.lua [camera-name]
+--   or:   lua       /mnt/files/camera_heatmap.lua [camera-name]
+--
+-- Under plain `lua` the heatmap renders but inference is skipped
+-- (model_load_mnist / model_infer_bytes are admin-only).
+
+local P = slm.print
+local cam_name = (arg and arg[1]) or "imx219-0"
+
+-- ------------------------------------------------------------------
+-- Capture + preprocess
+-- ------------------------------------------------------------------
+local cam = slm.camera.open(cam_name)
+if cam == nil then
+    P("camera.open failed for '" .. cam_name .. "'")
+    return
+end
+
+local t0 = slm.uptime()
+local frame_id, w, h, bayer = cam:capture()
+local t_cap = slm.uptime() - t0
+if frame_id == nil then
+    P("cam:capture failed")
+    cam:close()
+    return
+end
+
+t0 = slm.uptime()
+local bytes, rc = slm.camera.preprocess_mnist(frame_id, w, h, bayer, cam_name)
+local t_pre = slm.uptime() - t0
+if bytes == nil then
+    P(string.format("preprocess_mnist failed: rc=%d", rc or 0))
+    cam:close()
+    return
+end
+
+-- ------------------------------------------------------------------
+-- Decode the 784 fp32 samples + collect range stats
+-- ------------------------------------------------------------------
+local N = 28 * 28
+local px = {}
+local pmin, pmax, psum = math.huge, -math.huge, 0.0
+for i = 0, N - 1 do
+    local v = string.unpack("<f", bytes, 1 + i * 4)
+    px[i + 1] = v
+    if v < pmin then pmin = v end
+    if v > pmax then pmax = v end
+    psum = psum + v
+end
+local pmean = psum / N
+
+P(string.format("Camera: %s   capture: %dms   preprocess: %dms",
+                cam_name, t_cap, t_pre))
+P(string.format("Pixel range: min=%.4f  max=%.4f  mean=%.4f",
+                pmin, pmax, pmean))
+P("")
+
+-- ------------------------------------------------------------------
+-- Render heatmap. Each pixel is doubled horizontally so the 28x28
+-- image isn't squashed by the terminal's ~2:1 character cell
+-- aspect ratio. Normalise to the data's own (min, max) so a tightly
+-- clustered input still shows internal structure rather than a flat
+-- grey square.
+-- ------------------------------------------------------------------
+local ramp = " .:-=+*#%@"  -- 10 levels, dark to bright
+local span = pmax - pmin
+if span < 1e-6 then span = 1.0 end  -- guard against a perfectly flat frame
+
+local border = "  +" .. string.rep("-", 56) .. "+"
+P(border)
+for row = 0, 27 do
+    local line = "  |"
+    for col = 0, 27 do
+        local v = px[1 + row * 28 + col]
+        local lvl = math.floor((v - pmin) / span * 9 + 0.5)
+        if lvl < 0 then lvl = 0 end
+        if lvl > 9 then lvl = 9 end
+        local ch = string.sub(ramp, lvl + 1, lvl + 1)
+        line = line .. ch .. ch
+    end
+    P(line .. "|")
+end
+P(border)
+
+cam:close()
+
+-- ------------------------------------------------------------------
+-- Optional MNIST inference (admin-only bindings)
+-- ------------------------------------------------------------------
+if slm.model_load_mnist == nil or slm.model_infer_bytes == nil then
+    P("")
+    P("(Run under `lua-admin` to also see MNIST logits.)")
+    return
+end
+
+local mid = slm.model_load_mnist()
+if mid == nil or mid < 0 then return end
+local logits, argmax = slm.model_infer_bytes(mid, bytes)
+if logits == nil then return end
+
+local scored = {}
+for i = 0, 9 do
+    scored[i + 1] = { i, string.unpack("<f", logits, 1 + i * 4) }
+end
+table.sort(scored, function(a, b) return a[2] > b[2] end)
+
+P("")
+P(string.format("Inference: argmax=%d", argmax))
+P(string.format("  top-3:  %d=%.4f   %d=%.4f   %d=%.4f",
+                scored[1][1], scored[1][2],
+                scored[2][1], scored[2][2],
+                scored[3][1], scored[3][2]))
+P(string.format("  range:  max=%.4f  min=%.4f  spread=%.4f",
+                scored[1][2], scored[10][2], scored[1][2] - scored[10][2]))
+P("")
+P("If the heatmap clearly shows your subject but spread is small")
+P("(< ~1.0), the bug is OOD input — MNIST is trained on centered")
+P("black-on-white handwritten digits and won't classify photos.")


### PR DESCRIPTION
## Summary

Adds `scripts/camera_heatmap.lua`, a debug aid for diagnosing the "MNIST demo always returns the same class" failure mode of #818. The script captures one frame, runs it through `slm.camera.preprocess_mnist`, and renders the resulting 28×28 fp32 tensor as an ASCII heatmap so the operator can see what the model actually receives. Under `lua-admin` it also runs inference and prints the top-3 logits + spread.

## Why

The IMX219 demo predicts `5` for every scene with logit magnitudes ~0.15. Two competing hypotheses:

1. Preprocess is broken — the 28×28 input is mostly uniform regardless of scene.
2. The model is fine but the input is out-of-distribution — MNIST is trained on centred black-on-white handwritten digits in a tight 20×20 region; real photos of anything look nothing like that.

The heatmap distinguishes these in one shell command: if it shows the subject clearly but spread is small (~< 1.0), it's (2); if the heatmap is a flat grey square regardless of scene, it's (1).

## Wiring

Same pattern as `demo_imx219_mnist.lua` — `.incbin` in `demo_scripts.S`, file-write in `demo_init.c`, paths fed through `set_source_files_properties` in the top-level CMakeLists. Lands at `/mnt/files/camera_heatmap.lua` at boot.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` clean build
- [x] Deployed to jetson-nano-1 via `slmos-kexec`; script lands at `/mnt/files/camera_heatmap.lua`
- [ ] Operator runs `lua-admin /mnt/files/camera_heatmap.lua` over serial / telnet and reports which failure-mode hypothesis the heatmap reveals

🤖 Generated with [Claude Code](https://claude.com/claude-code)