### PR TITLE
GR ctx reservation: 17% → 60% kexec-handoff PASS rate (#788 investigation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,6 +556,11 @@ set(KERNEL_SOURCES
     # channel; no CPU-side phys arithmetic required, sidesteps the
     # GMMU walk-discovery failure observed post-kexec.
     $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/ga10b_ce.c>
+    # Jetson: register the kexec'd channel's inst block as a PMM
+    # user-reserve before PMM init publishes pages, so nvgpu state
+    # surviving in DRAM doesn't get clobbered by SLM-OS kernel
+    # allocations. #788 root-cause fix.
+    $<$<STREQUAL:${PLATFORM},JETSON_ORIN_NANO>:kernel/gpu/nvidia/ga10b_handoff_reserve.c>
     # Jetson: full GSP platform shim — MMIO at GPU_BASE, unified memory
     # DMA, cache maintenance, firmware via .incbin. Replaces the old
     # nvidia_gsp_platform_stub.c now that CBB firewall is bypassed.

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1250,12 +1250,18 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
      *      accept the W1 handoff; oplib_pool consumers still
      *      check `version >= 8u` before reading the trailing
      *      weights_pool_* fields.
-     * Phase 6 inherit accepts all seven; launch_kernel version-gates
+     * v9: + weights-pool per-page extents (weights_extents_phys +
+     *      weights_n_extents). Lets SLM-OS map the full 1.5 GB
+     *      IOVMM-stitched weights pool post-kexec instead of just
+     *      the first 4 KB. Helpers that don't allocate a weights
+     *      pool leave these at zero; SLM-OS rebuild path falls
+     *      back to the Stage 3 single-page mapping. #788 Stage 4.
+     * Phase 6 inherit accepts all eight; launch_kernel version-gates
      * at dispatch time (v3 minimum for single-shot, v5 for pipelines,
      * v7 for the QMD-pool path, v8 for the weights pool). */
     if (h->version != 2 && h->version != 3 &&
         h->version != 4 && h->version != 5 && h->version != 6 &&
-        h->version != 7 && h->version != 8) return -1;
+        h->version != 7 && h->version != 8 && h->version != 9) return -1;
     if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
         h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
     if (h->work_submit_token == 0) return -1;
@@ -1443,6 +1449,14 @@ int ga10b_bringup_channel_kind(struct ga10b_bringup *b, uint32_t wanted_kind)
     g_handoff.weights_pool_phys       = hoff->weights_pool_phys;
     g_handoff.weights_pool_gpu_va     = hoff->weights_pool_gpu_va;
     g_handoff.weights_pool_size_bytes = hoff->weights_pool_size_bytes;
+
+    /* v9 extension: weights-pool per-page extents. Same
+     * "unconditional read is safe" argument as v7/v8 — the
+     * `_Static_assert` pins the offsets so a v8 helper leaves
+     * these as zero and SLM-OS's rebuild path falls back to the
+     * single-page mapping. #788 Stage 4. */
+    g_handoff.weights_extents_phys = hoff->weights_extents_phys;
+    g_handoff.weights_n_extents    = hoff->weights_n_extents;
 
     /* Validate the handoff block (pure-logic, host-testable). */
     if (ga10b_validate_handoff((const struct ga10b_channel_handoff *)

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1847,6 +1847,29 @@ static void dump_fecs_state(const char *tag)
                 (unsigned long)bar0_r32(0x00409814u),
                 (unsigned long)bar0_r32(0x00409818u),
                 (unsigned long)bar0_r32(0x0040981cu));
+    /* ctxsw_status_0/1 — additional FECS state the official NVIDIA
+     * `ctxsw_err_info` struct records alongside mailbox_value (see
+     * `mon_ctxsw.c::nvgpu_report_ctxsw_err` + the struct's three
+     * fields `ctxsw_status0`, `ctxsw_status1`, `mailbox_value` in
+     * `nvgpu_err.h:373-388`). Without these two, mb6 alone is hard
+     * to interpret because the FECS ucode error code is opaque —
+     * NVIDIA doesn't publish a value→meaning table for mb6 in any
+     * source I can access. Status0 (FE_0 register) shows what
+     * stage of ctxsw FE was in; status1 includes the arb_busy bit
+     * and other state. Register offsets per
+     * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_gr_ga10b.h`:
+     *   gr_fecs_ctxsw_status_1_r()    = 0x00409400
+     *   gr_fecs_ctxsw_status_fe_0_r() = 0x00409c00
+     * Plus the GPCCS-side mirror (some errors originate on GPCCS):
+     *   gr_gpc0_gpccs_ctxsw_status_1_r() = 0x00502400
+     *   gr_gpc0_gpccs_ctxsw_status_gpc_0_r() = 0x00502c04 */
+    uart_printf("[%s]   ctxsw_status fecs_fe_0=0x%08lx fecs_1=0x%08lx "
+                "gpccs_gpc_0=0x%08lx gpccs_1=0x%08lx\n",
+                tag,
+                (unsigned long)bar0_r32(0x00409c00u),
+                (unsigned long)bar0_r32(0x00409400u),
+                (unsigned long)bar0_r32(0x00502c04u),
+                (unsigned long)bar0_r32(0x00502400u));
 }
 
 /* Layer 2c: FB MMU fault info. `fault_during_ctxsw` (#788 working

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2076,9 +2076,100 @@ void ga10b_dump_inst_blocks_atomic(const char *tag)
     dump_one_inst_block("GA10B-INST-FAULT", fault_inst_phys);
 }
 
+/* Layer 1b: GPC / TPC / SM drill-down for when top-level
+ * `gr_exception` has bit 24 set (GPC exception). Decodes the
+ * GPC0 exception register; if a TPC or SM bit is set, reads
+ * the corresponding TPC + SM ESRs.
+ *
+ * Register offsets per
+ *   `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_gr_ga10b.h`:
+ *     gr_pri_gpc0_gpccs_gpc_exception_r   = 0x00502c90
+ *     gr_gpc0_gpccs_hww_esr_r             = 0x00502c98
+ *     gr_pri_gpc0_tpc0_tpccs_tpc_exception_r = 0x00504508
+ *     gr_gpc0_tpc0_sm0_hww_global_esr_r   = 0x00504734
+ *     gr_gpc0_tpc0_sm0_hww_warp_esr_r     = 0x00504730
+ *     gr_gpc0_tpc0_sm0_hww_warp_esr_pc_hi = 0x0050473c
+ *
+ * GPC exception bit layout (low bits only — see header for
+ * full list):
+ *   bit 0  = prop, 1 = zcull, 2 = gcc, 3 = setup,
+ *   bit 4  = pes0, 5 = pes1, 13 = gpcmmu0, 14 = gpccs,
+ *   bits[23:16] = TPC0..TPC7 pending masks
+ *
+ * Only TPC0/SM0 are sampled here. Orin Nano has 1 GPC × 8 TPCs
+ * but most GR exceptions in the wild surface on TPC0/SM0; if a
+ * future regression points elsewhere, expand to iterate. */
+static void dump_gpc_tpc_sm(const char *tag, uint32_t gr_exception)
+{
+    /* Bit 24 of gr_exception = GPC exception per
+     * gr_exception_gpc_m() = (1U << 24). Skip the drill-down if
+     * the GPC bit isn't set — the fault is upstream of any GPC. */
+    if ((gr_exception & 0x01000000u) == 0u) {
+        return;
+    }
+
+    uint32_t gpc_exc       = bar0_r32(0x00502c90u);
+    uint32_t gpccs_hww_esr = bar0_r32(0x00502c98u);
+    uart_printf("[%s]   gpc0_exception=0x%08lx (prop=%u zcull=%u gcc=%u "
+                "setup=%u pes0=%u pes1=%u gpcmmu0=%u gpccs=%u tpc_mask=0x%02x "
+                "crop=%u%u zrop=%u%u rrh=%u%u) gpccs_hww_esr=0x%08lx\n",
+                tag, (unsigned long)gpc_exc,
+                (unsigned)(gpc_exc & 0x1u),
+                (unsigned)((gpc_exc >> 1) & 0x1u),
+                (unsigned)((gpc_exc >> 2) & 0x1u),
+                (unsigned)((gpc_exc >> 3) & 0x1u),
+                (unsigned)((gpc_exc >> 4) & 0x1u),
+                (unsigned)((gpc_exc >> 5) & 0x1u),
+                (unsigned)((gpc_exc >> 13) & 0x1u),
+                (unsigned)((gpc_exc >> 14) & 0x1u),
+                (unsigned)((gpc_exc >> 16) & 0xffu),
+                (unsigned)((gpc_exc >> 26) & 0x1u),
+                (unsigned)((gpc_exc >> 29) & 0x1u),
+                (unsigned)((gpc_exc >> 27) & 0x1u),
+                (unsigned)((gpc_exc >> 30) & 0x1u),
+                (unsigned)((gpc_exc >> 28) & 0x1u),
+                (unsigned)((gpc_exc >> 31) & 0x1u),
+                (unsigned long)gpccs_hww_esr);
+
+    /* If any TPC bit is set, sample TPC0's exception register.
+     * Drills into SM/MPC/PE pending bits. */
+    if ((gpc_exc & 0x00ff0000u) != 0u) {
+        uint32_t tpc0_exc = bar0_r32(0x00504508u);
+        uart_printf("[%s]   gpc0_tpc0_exception=0x%08lx "
+                    "(sm=%u pe=%u mpc=%u)\n",
+                    tag, (unsigned long)tpc0_exc,
+                    (unsigned)((tpc0_exc >> 1) & 0x1u),
+                    (unsigned)((tpc0_exc >> 2) & 0x1u),
+                    (unsigned)((tpc0_exc >> 4) & 0x1u));
+
+        /* SM bit set → dump SM-level error state. The
+         * `global_esr` carries the bp/poison/error_in_trap
+         * class; `warp_esr` carries the actual fault code
+         * (misaligned_pc, mmu_fault, oor_addr, ...) and
+         * `warp_esr_pc_hi` pairs with `warp_esr_pc_lo` (4 B
+         * below the hi register at 0x00504738) to identify
+         * which SASS PC triggered the fault. */
+        if (((tpc0_exc >> 1) & 0x1u) != 0u) {
+            uint32_t sm_global = bar0_r32(0x00504734u);
+            uint32_t sm_warp   = bar0_r32(0x00504730u);
+            uint32_t pc_lo     = bar0_r32(0x00504738u);
+            uint32_t pc_hi     = bar0_r32(0x0050473cu);
+            uart_printf("[%s]   sm0_global_esr=0x%08lx sm0_warp_esr=0x%08lx "
+                        "warp_pc=0x%08lx_%08lx (error_code=0x%02x)\n",
+                        tag, (unsigned long)sm_global,
+                        (unsigned long)sm_warp,
+                        (unsigned long)pc_hi, (unsigned long)pc_lo,
+                        (unsigned)(sm_warp & 0xffu));
+        }
+    }
+}
+
 static void ga10b_dump_gr_state(const char *tag)
 {
     dump_gr_top_level(tag);
+    /* GR exception register again — re-read so the GPC drill-down
+     * sees the same snapshot the top-level dump just printed. */
+    dump_gpc_tpc_sm(tag, bar0_r32(0x00400108u));
     dump_fecs_state(tag);
     dump_mmu_fault(tag);
     dump_pbdma_state(tag);
@@ -2578,6 +2669,27 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
               (unsigned long)gp_put_start,
               (unsigned long)pushbuf_phys,
               (unsigned long)g_handoff.qmd_pool_phys);
+
+    /* #788 Stage 9 instrumentation — dump each op's shader/cbuf
+     * GPU VAs to confirm whether the v7 ops the helper published
+     * point at the right SASS pool. The bisect-E SM fault at PC =
+     * pushbuf_gpu_va + 0x10000 suggests op[i].shader_gpu_va is
+     * being mis-set. */
+    uart_printf("[GA10B-P8-v7-DBG] ops_v7 array @0x%lx, n=%lu\n",
+                (unsigned long)g_handoff.pipeline_ops_phys,
+                (unsigned long)n);
+    for (uint32_t i = 0; i < n; i++) {
+        const struct ga10b_pipeline_op_v7 *opdbg = &ops_v7[i];
+        uart_printf("[GA10B-P8-v7-DBG]   op[%lu] shader_gpu_va=0x%lx "
+                    "cbuf_gpu_va=0x%lx qmd_gpu_va=0x%lx output_phys=0x%lx "
+                    "reg_v=%lu\n",
+                    (unsigned long)i,
+                    (unsigned long)opdbg->shader_gpu_va,
+                    (unsigned long)opdbg->cbuf_gpu_va,
+                    (unsigned long)opdbg->qmd_gpu_va,
+                    (unsigned long)opdbg->output_phys,
+                    (unsigned long)opdbg->register_count_v);
+    }
 
     /* Phase 1: queue all N kernel-dispatch entries. */
     for (uint32_t i = 0; i < n; i++) {

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -273,7 +273,80 @@ struct ga10b_channel_handoff {
     uint64_t weights_pool_phys;
     uint64_t weights_pool_gpu_va;
     uint64_t weights_pool_size_bytes;
+
+    /* --- v9 extension: weights-pool per-page physical layout. ---
+     * Zero on v2..v8. Populated by the helper when it walks the
+     * weights pool's pages via /proc/self/pagemap and coalesces
+     * consecutive physical pages into extents.
+     *
+     * The 1.5 GB IOVMM weights pool is SMMU-stitched from
+     * physically-scattered pages — `weights_pool_phys` records
+     * only the FIRST page's CPU phys (the rest can't be derived
+     * by `phys + offset` arithmetic). For SLM-OS to install GMMU
+     * PTEs covering the entire pool post-kexec (#788 Stage 4),
+     * the helper publishes a list of `(phys, n_pages)` extents
+     * describing the contiguous physical runs that make up the
+     * IO-virtually-contiguous 1.5 GB region.
+     *
+     * `weights_extents_phys` is the CPU physical address of a
+     * separate dmabuf containing an array of
+     * `struct ga10b_phys_extent` entries. The dmabuf is
+     * page-aligned (4 KB) and sized to hold at most
+     * GA10B_WEIGHTS_EXTENTS_MAX entries (see below). The phys
+     * is in DRAM and identity-mapped, so SLM-OS can read it
+     * directly without re-walking GMMU.
+     *
+     * `weights_n_extents` is the actual count of valid entries.
+     * If the helper finds more physical runs than the dmabuf
+     * can hold, it warns and truncates — SLM-OS only maps the
+     * extents that fit; the tail of the weights pool will
+     * trigger MMU faults if a CE memcpy writes there. The
+     * helper's warning gives a fix-by-resizing path.
+     *
+     * SLM-OS PMM also reserves every extent's pages via the
+     * `pmm_user_reserve_add` API (PR #801), so the kernel
+     * doesn't allocate from physical pages that the GPU is
+     * about to receive weight data into.
+     *
+     * Backward compatible: a v8-or-earlier helper writes zero
+     * here; SLM-OS sees `weights_n_extents == 0` and falls back
+     * to mapping the single first-page run from
+     * `weights_pool_phys` (the Stage 3 behaviour).
+     *
+     * Note: this field only applies when `weights_pool_size_bytes`
+     * is non-zero. A helper that didn't allocate a weights pool
+     * leaves both at zero. */
+    uint64_t weights_extents_phys;
+    uint32_t weights_n_extents;
+    uint32_t _pad_v9;
 };
+
+/* One entry in the v9 weights-pool extents array. Represents a
+ * contiguous run of physical pages within the IOVMM-stitched
+ * weights pool. Walking the entries in order from GPU-VA
+ * `weights_pool_gpu_va`, each extent covers `n_pages * 4 KB` of
+ * virtual address space starting at the cursor (which advances
+ * by `n_pages * 4 KB` after each extent).
+ *
+ * Wire-format-locked to 16 bytes — pinned by static_assert
+ * below. */
+struct ga10b_phys_extent {
+    uint64_t phys;        /* run's base physical address (4 KB aligned) */
+    uint32_t n_pages;     /* number of consecutive 4 KB pages */
+    uint32_t reserved;    /* zero; reserved for future flags */
+};
+
+/* Cap on extents the helper publishes. With 1.5 GB at 4 KB pages
+ * = 393,216 pages, the worst case is one extent per page (most
+ * scattered allocation) → too many to inline. In practice nvmap's
+ * IOVMM allocator returns sequences of contiguous runs (often
+ * dozens to low thousands of extents for a 1.5 GB CMA-backed
+ * region on Tegra), so 8192 caps the dmabuf at 128 KB (8192 × 16
+ * bytes) — generous for empirically-observed L4T behaviour, leaves
+ * headroom for fragmentation as the system ages. If a future
+ * helper logs `extents truncated`, bump this cap on both sides
+ * in lock-step and re-publish the handoff. */
+#define GA10B_WEIGHTS_EXTENTS_MAX 8192u
 
 /* Pipeline-kind discriminator values stored in
  * `struct ga10b_channel_handoff::pipeline_kind`. Numbered to keep
@@ -364,12 +437,17 @@ struct ga10b_pipeline_op_v7 {
  * (qmd_pool_phys + qmd_pool_gpu_va + qmd_pool_size_bytes +
  * qmd_pool_n_slots) → 232 + 24 = 256. v8 grows it by another 24
  * (weights_pool_phys + weights_pool_gpu_va +
- * weights_pool_size_bytes) → 256 + 24 = 280. */
-_Static_assert(sizeof(struct ga10b_channel_handoff) == 280,
+ * weights_pool_size_bytes) → 256 + 24 = 280. v9 grows it by 16
+ * (weights_extents_phys + weights_n_extents + _pad_v9) → 280 + 16
+ * = 296. */
+_Static_assert(sizeof(struct ga10b_channel_handoff) == 296,
                "ga10b_channel_handoff layout changed — update Linux "
                "helper (scripts/gpu-channel-helper.c, "
                "scripts/gpu-kernel-launch.c, scripts/gpu-launch-common.c) "
                "and bump version");
+_Static_assert(sizeof(struct ga10b_phys_extent) == 16,
+               "ga10b_phys_extent layout changed — Linux helper and "
+               "SLM-OS must agree on the v9 extents-array entry size");
 _Static_assert(sizeof(struct ga10b_pipeline_op) == 24,
                "ga10b_pipeline_op layout changed — Linux + SLM-OS "
                "must agree on the per-op size");
@@ -440,6 +518,15 @@ _Static_assert(offsetof(struct ga10b_channel_handoff, weights_pool_gpu_va) == 26
                "v8 weights_pool_gpu_va offset drifted");
 _Static_assert(offsetof(struct ga10b_channel_handoff, weights_pool_size_bytes) == 272,
                "v8 weights_pool_size_bytes offset drifted");
+
+/* v9 extents descriptor — appended after weights_pool_size_bytes.
+ * `weights_n_extents == 0` lets a v9-aware reader detect a v8-
+ * built handoff (where these bytes are zero) and fall back to
+ * mapping just `weights_pool_phys` as a single 4 KB run. */
+_Static_assert(offsetof(struct ga10b_channel_handoff, weights_extents_phys) == 280,
+               "v9 weights_extents_phys offset drifted");
+_Static_assert(offsetof(struct ga10b_channel_handoff, weights_n_extents) == 288,
+               "v9 weights_n_extents offset drifted");
 
 _Static_assert(offsetof(struct ga10b_pipeline_op, qmd_gpu_va) == 0,
                "pipeline_op.qmd_gpu_va must be at offset 0");

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -413,6 +413,28 @@ struct ga10b_pipeline_op_v7 {
     uint32_t smem_size_bytes;   /* shared memory per block */
     uint32_t slm_size_bytes;    /* shader local memory per thread */
     uint32_t barrier_count;     /* num_control_barriers */
+
+    /* v7.1 additions (#788 Mode B fix): per-op shader phys + size
+     * for SLM-OS's PMM reservation. Without these, SLM-OS would
+     * have to GMMU-walk shader_gpu_va from h->inst_block_phys to
+     * find the phys — which fails when h->inst_block_phys was
+     * read from FECS at a moment FECS happened to be on another
+     * channel (Xorg, nvgpu's GR-internal). The helper has these
+     * values directly from `gpu_virt_to_phys` at allocation time;
+     * publishing them bypasses the walk entirely.
+     *
+     * `shader_size_bytes` is the dmabuf size (≥ SASS_len, page-
+     * rounded up). SLM-OS reserves the full dmabuf phys range so
+     * multi-page shaders are covered. Zero means "helper didn't
+     * populate" (older builds) — SLM-OS falls back to walk-based
+     * discovery.
+     *
+     * Adding 16 B bumps sizeof to 96 B per op, lowers v7 cap
+     * from 51 → 42 ops per 4 KB array page. mnist uses 8 ops;
+     * still ample headroom. */
+    uint64_t shader_phys;       /* CPU-phys of op's SASS dmabuf, 0 if unset */
+    uint32_t shader_size_bytes; /* dmabuf size in bytes, 0 if unset */
+    uint32_t _pad_v71;          /* explicit pad → keeps 8 B alignment */
 };
 
 /* Upper bound on pipeline length, enforced by the kernel-side runner.
@@ -421,14 +443,14 @@ struct ga10b_pipeline_op_v7 {
  * Anything past that would dereference into adjacent memory.
  *
  *   v6 ops (24 B): 4096 / 24 = 170 max
- *   v7 ops (80 B): 4096 / 80 = 51  max
+ *   v7 ops (96 B): 4096 / 96 = 42  max (#788 Mode B v7.1 fields)
  *
  * MNIST uses 8 ops on either layout. Larger SLMs (Qwen 2.5 1.5B has
  * ~370 ops/token) need either the launcher to allocate >1 page or
  * a different ops-array structure entirely — tracked separately
  * (#573 covers the dispatch architecture rework). */
 #define GA10B_PIPELINE_MAX_OPS    170u   /* v6 cap (existing) */
-#define GA10B_PIPELINE_V7_MAX_OPS 51u    /* v7 cap (4096 / 80) */
+#define GA10B_PIPELINE_V7_MAX_OPS 42u    /* v7 cap (4096 / 96) */
 
 /* Wire-format size is locked: both the Linux helper and SLM-OS
  * depend on this exact layout. Any struct reorder or field addition
@@ -451,7 +473,7 @@ _Static_assert(sizeof(struct ga10b_phys_extent) == 16,
 _Static_assert(sizeof(struct ga10b_pipeline_op) == 24,
                "ga10b_pipeline_op layout changed — Linux + SLM-OS "
                "must agree on the per-op size");
-_Static_assert(sizeof(struct ga10b_pipeline_op_v7) == 80,
+_Static_assert(sizeof(struct ga10b_pipeline_op_v7) == 96,
                "ga10b_pipeline_op_v7 layout changed — Linux helper "
                "and SLM-OS must agree on the v7 per-op size");
 

--- a/kernel/gpu/nvidia/ga10b_channel_handoff.h
+++ b/kernel/gpu/nvidia/ga10b_channel_handoff.h
@@ -319,6 +319,36 @@ struct ga10b_channel_handoff {
     uint64_t weights_extents_phys;
     uint32_t weights_n_extents;
     uint32_t _pad_v9;
+
+    /* --- v10 extension (#788 Mode C fix): per-channel GR context
+     * buffer physical ranges. Zero on v2..v9. ---
+     *
+     * The helper reads /sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys
+     * (a debugfs file exported by a patched nvgpu.ko — see
+     * `tools/nvgpu-patches/0001-expose-gr-ctx-phys-via-debugfs.patch`)
+     * which lists every active channel's GR context buffers
+     * (`NVGPU_GR_CTX_CTX` at ~513 KB, `NVGPU_GR_CTX_PATCH_CTX` at
+     * 4 KB, etc.). Without this protection, SLM-OS's PMM allocates
+     * from those physical pages and FECS's next context-load reads
+     * garbage — surfaces as the `mb6=0x5a` watchdog failure that
+     * dominates the N=30 stress test (50% of iterations).
+     *
+     * `gr_ctx_extents_phys` is the CPU physical address of a
+     * dmabuf containing an array of `struct ga10b_phys_extent`
+     * entries (same layout as the v9 weights extents). Each entry
+     * covers one of the channel-internal GR buffers. SLM-OS
+     * reserves every extent in `ga10b_kexec_handoff_register_-
+     * reserves`.
+     *
+     * The helper publishes ALL active channels' GR contexts, not
+     * just its own — Xorg / nvgpu-internal channels also leave
+     * GR ctx state in DRAM that FECS may try to load post-kexec
+     * during context-switch. Conservatively protecting all of
+     * them is cheap (each phys_extent = 16 B; 16 channels × 8
+     * buffers × 16 B = 2 KB max). */
+    uint64_t gr_ctx_extents_phys;
+    uint32_t gr_ctx_n_extents;
+    uint32_t _pad_v10;
 };
 
 /* One entry in the v9 weights-pool extents array. Represents a
@@ -462,11 +492,11 @@ struct ga10b_pipeline_op_v7 {
  * weights_pool_size_bytes) → 256 + 24 = 280. v9 grows it by 16
  * (weights_extents_phys + weights_n_extents + _pad_v9) → 280 + 16
  * = 296. */
-_Static_assert(sizeof(struct ga10b_channel_handoff) == 296,
+_Static_assert(sizeof(struct ga10b_channel_handoff) == 312,
                "ga10b_channel_handoff layout changed — update Linux "
                "helper (scripts/gpu-channel-helper.c, "
                "scripts/gpu-kernel-launch.c, scripts/gpu-launch-common.c) "
-               "and bump version");
+               "and bump version. v10 adds gr_ctx_extents (+16 B).");
 _Static_assert(sizeof(struct ga10b_phys_extent) == 16,
                "ga10b_phys_extent layout changed — Linux helper and "
                "SLM-OS must agree on the v9 extents-array entry size");

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -489,10 +489,37 @@ static inline uint64_t encode_pte(uint64_t phys, uint32_t flags)
  * thing so the GPU sees an all-zero (= all-invalid) table when
  * we point a parent PDE at it. Returns kernel VA (== phys on
  * Jetson via identity map) or NULL on PMM exhaustion. */
+
+/* uart_printf forward decl — file-scope `extern` further down
+ * covers later sites; the trace path below needs it earlier. */
+extern int uart_printf(const char *fmt, ...);
+
+/* #788 Stage 6: trace every alloc_zero_table_page call when the
+ * flag is on. Set by the rebuild path before its mapping loop;
+ * cleared at the end. Lets the operator see which physes the
+ * rebuild's intermediate PT pages landed on — needed to identify
+ * the colliding-with-FW-state phys that breaks `nvgpu submit` in
+ * Stage 4 bisect E/F (pushbuf/sem reservation regression). */
+static bool g_table_alloc_trace = false;
+static int  g_table_alloc_count = 0;
+
+void ga10b_gmmu_table_alloc_trace_set(bool on)
+{
+    g_table_alloc_trace = on;
+    if (on) {
+        g_table_alloc_count = 0;
+    }
+}
+
 static void *alloc_zero_table_page(void)
 {
     void *p = pmm_alloc_page();
     if (p == NULL) return NULL;
+    if (g_table_alloc_trace) {
+        uart_printf("[rebuild-pt] alloc[%d] phys=0x%lx\n",
+                    g_table_alloc_count++,
+                    (unsigned long)(uintptr_t)p);
+    }
     volatile uint64_t *q = (volatile uint64_t *)p;
     for (int i = 0; i < 512; i++) {
         q[i] = 0;
@@ -1161,6 +1188,12 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
         return -1;
     }
 
+    /* #788 Stage 6: trace every PMM page the rebuild allocates so
+     * the operator can spot which one might be colliding with an
+     * unknown FW range. Tail of the function disables tracing
+     * once mapping is done. */
+    ga10b_gmmu_table_alloc_trace_set(true);
+
     /* 1. Allocate a fresh PDB page from SLM-OS PMM. Zero it so
      *    every PDE3 entry reads as invalid until `map_one_page`
      *    populates the ones it needs. */
@@ -1412,7 +1445,10 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
      *    PTEs from the tree we just built. */
     int rc = ga10b_gmmu_tlb_invalidate(pdb_phys);
     uart_printf("[rebuild-gmmu] TLB invalidate rc=%d, %d buffer(s) "
-                "mapped\n", rc, mapped);
+                "mapped (%d PT pages allocated)\n",
+                rc, mapped, g_table_alloc_count);
+
+    ga10b_gmmu_table_alloc_trace_set(false);
     return (rc == 0) ? 0 : -1;
 }
 

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1049,6 +1049,88 @@ int ga10b_gmmu_free(uint64_t inst_block_phys,
 #define GA10B_RAM_IN_USE_VER2_PT_FORMAT   0x400u
 #define GA10B_RAM_IN_BIG_PAGE_SIZE_64KB   0x800u
 
+/* RAMFC field word offsets per
+ * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_ram_ga10b.h:118-140`.
+ * RAMFC starts at word 0 of the inst block and ends at word 127;
+ * PDB lives at words 128/129. All offsets here are word indices
+ * (multiply by 4 for the byte offset into the inst block). */
+#define GA10B_RAMFC_W_SIGNATURE            4u
+#define GA10B_RAMFC_W_ACQUIRE              12u
+#define GA10B_RAMFC_W_GP_BASE              18u
+#define GA10B_RAMFC_W_GP_BASE_HI           19u
+#define GA10B_RAMFC_W_PB_HEADER            33u
+#define GA10B_RAMFC_W_SUBDEVICE            37u
+#define GA10B_RAMFC_W_TARGET               43u
+#define GA10B_RAMFC_W_CONFIG               61u
+#define GA10B_RAMFC_W_INTR_NOTIFY          62u
+#define GA10B_RAMFC_W_SET_CHANNEL_INFO     63u
+/* engine_wfi block (post-PDB), word 134 for the VEID field. */
+#define GA10B_RAMIN_W_ENGINE_WFI_VEID      134u
+
+/* PBDMA-encoded field values for a default Tegra GA10B channel
+ * (chid=0, subctx=1 ASYNC veid, engine=GR rleng_id=0, intr_vec=0,
+ * privileged-config=no, long acquire timeout saturated). Derived
+ * by mechanically following the L4T r36.4.4 nvgpu HAL ops chain:
+ *
+ *   .signature   = gp10b_pbdma_get_signature
+ *                  → litter(GPFIFO_CLASS) = AMPERE_CHANNEL_GPFIFO_B
+ *   .pb_header   = gv11b_pbdma_get_fc_pb_header
+ *                  → method_zero | subch_zero | level_main |
+ *                    first_true | type_inc
+ *   .subdevice   = gm20b_pbdma_get_fc_subdevice
+ *                  → subdevice_id(1) | status_active | channel_dma_enable
+ *   .target      = ga10b_pbdma_get_fc_target
+ *                  → engine_f(rleng=0) | eng_ctx_valid_true | ce_ctx_valid_true
+ *   .acquire     = gm20b_pbdma_acquire_val (2 s scaled saturates)
+ *                  → retry_man_2 | retry_exp_2 |
+ *                    timeout_man_max | timeout_exp_max | timeout_en_enable
+ *   .intr_notify = ga10b_pbdma_set_intr_notify(0)
+ *                  → vector_f(0) | ctrl_cpu_enable | ctrl_gsp_disable
+ *   .config      = gv11b_pbdma_config_userd_writeback_enable(0)
+ *                  → userd_writeback_enable bit (12)
+ *
+ * Documented offsets keyed back to the L4T header so a future
+ * investigator can re-derive these from the nvgpu source if the
+ * Tegra HAL chain ever changes. */
+#define GA10B_RAMFC_VAL_SIGNATURE          0x0000C76Fu  /* AMPERE_CHANNEL_GPFIFO_B */
+#define GA10B_RAMFC_VAL_PB_HEADER          0x20400000u  /* first | type_inc */
+#define GA10B_RAMFC_VAL_SUBDEVICE          0x30000001u  /* id=1 | active | dma_enable */
+#define GA10B_RAMFC_VAL_TARGET_GR          0x00030000u  /* rleng=0 | eng+ce_ctx_valid */
+#define GA10B_RAMFC_VAL_ACQUIRE_LONG       0xFFFF7902u  /* saturated 2 s acquire */
+#define GA10B_RAMFC_VAL_INTR_NOTIFY        0x80000000u  /* vec=0 | cpu_enable */
+#define GA10B_RAMFC_VAL_CONFIG_USERD_WB    0x00001000u  /* userd_writeback bit */
+
+/* `set_channel_info` is read-modify-write on a 32-bit value with
+ * `chid` at bits[27:16] and `veid` at bits[13:8]. We start from 0
+ * (the inst block was just zeroed) and OR in the encoded fields. */
+#define GA10B_RAMFC_SET_CHANNEL_INFO(chid, veid) \
+    ((((uint32_t)(chid) & 0xfffu) << 16) | (((uint32_t)(veid) & 0x3fu) << 8))
+
+/* The helper's CREATE_SUBCONTEXT call publishes subctx_id=1 (ASYNC
+ * veid=1). The handoff doesn't carry this explicitly today
+ * (channel_id and tsg_id are u32 fields but veid is implicit);
+ * hardcoded here matching the helper's invariant. If a future
+ * helper revision uses a different subctx_id, both this constant
+ * AND the helper need updating in lock-step — fortunately the
+ * runlist + USERD config flow through SLM-OS only handles single-
+ * subctx channels today, so the hardcode is the simplest safe
+ * choice. Document in `ga10b_channel_handoff.h` if a veid field
+ * is ever added to the handoff struct. */
+#define GA10B_HELPER_SUBCTX_ID             1u
+
+/* Compute log2 of `n` for n that's a non-zero power of two. Used
+ * for the gpfifo `limit2` field in gp_base_hi which encodes
+ * log2(num_entries). Returns 0 for n=0 (defensive — caller should
+ * have validated). The handoff always carries
+ * GPU_LAUNCH_GPFIFO_ENTRIES (currently 512 → log2 = 9), but the
+ * computation generalises so a future helper change doesn't bake
+ * the magic 9 in. */
+static inline uint32_t log2_pow2(uint32_t n)
+{
+    if (n == 0) return 0;
+    return (uint32_t)__builtin_ctz(n);
+}
+
 /* Map `n_pages` of contiguous physical memory at the given GPU
  * VA. Helper for the rebuild path — calls into the existing
  * `map_one_page` so it benefits from the auto-allocated
@@ -1114,12 +1196,76 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
 
     inst[128] = pdb_lo_word;
     inst[129] = pdb_hi_word;
+
+    /* 2b. Populate RAMFC fields PBDMA reads when fetching submits
+     *    for this channel. Without these, PBDMA finds gpfifo_phys
+     *    = 0 in the inst block and silently does nothing — the
+     *    Stage 2 PR's known limitation. Mirrors
+     *    `ga10b_ramfc_setup` from
+     *    `~/slmos-ref/nvidia/nvgpu-hal-fifo-ramfc_ga10b_fusa.c`,
+     *    with the PBDMA-HAL-computed values inlined as constants
+     *    above (the HAL chain dispatches through 4 chip-version
+     *    HAL ops to produce them on Linux; we replicate the
+     *    Tegra GA10B output values directly). */
+
+    /* `gp_base_offset_f` shifts the gpfifo phys's bits[31:3] into
+     * word bits[31:3]. We just need to mask off the bottom 3 bits;
+     * gpfifo phys is page-aligned (4 KB) so the bottom 12 bits are
+     * already zero, but the mask keeps the encoding explicit. */
+    uint32_t gp_base_lo_val =
+        (uint32_t)(h->gpfifo_phys & 0xfffffff8u);
+    /* `gp_base_hi` carries phys bits[39:32] in bits[7:0], and the
+     * gpfifo size in entries-log2 at bits[20:16]. Tegra GA10B
+     * gpfifo phys is 40-bit so the high byte is at most 0xFF. */
+    uint32_t gp_base_hi_val =
+        ((uint32_t)(h->gpfifo_phys >> 32) & 0xffu) |
+        (log2_pow2(h->gpfifo_entries) << 16);
+
+    inst[GA10B_RAMFC_W_GP_BASE]       = gp_base_lo_val;
+    inst[GA10B_RAMFC_W_GP_BASE_HI]    = gp_base_hi_val;
+    inst[GA10B_RAMFC_W_SIGNATURE]     = GA10B_RAMFC_VAL_SIGNATURE;
+    inst[GA10B_RAMFC_W_PB_HEADER]     = GA10B_RAMFC_VAL_PB_HEADER;
+    inst[GA10B_RAMFC_W_SUBDEVICE]     = GA10B_RAMFC_VAL_SUBDEVICE;
+    inst[GA10B_RAMFC_W_TARGET]        = GA10B_RAMFC_VAL_TARGET_GR;
+    inst[GA10B_RAMFC_W_ACQUIRE]       = GA10B_RAMFC_VAL_ACQUIRE_LONG;
+    inst[GA10B_RAMFC_W_INTR_NOTIFY]   = GA10B_RAMFC_VAL_INTR_NOTIFY;
+    inst[GA10B_RAMFC_W_CONFIG]        = GA10B_RAMFC_VAL_CONFIG_USERD_WB;
+    inst[GA10B_RAMFC_W_SET_CHANNEL_INFO] =
+        GA10B_RAMFC_SET_CHANNEL_INFO(h->channel_id,
+                                      GA10B_HELPER_SUBCTX_ID);
+
+    /* engine_wfi block (post-RAMFC, pre-PDB region for the
+     * engine-wait-for-idle save pointer). Only the VEID is written
+     * by `ga10b_ramfc_setup`; ptr_lo/ptr_hi/target stay zero in
+     * the inherited channel because the helper doesn't allocate a
+     * GR ctxsw save buffer (Tegra's nvgpu lazy-allocates it on
+     * first GR engagement, and the helper never engages GR — only
+     * does host-family sema releases on subch 0). */
+    inst[GA10B_RAMIN_W_ENGINE_WFI_VEID] = GA10B_HELPER_SUBCTX_ID;
+
     cache_clean_range((void *)(uintptr_t)inst_block_phys, 4096);
 
-    uart_printf("[rebuild-gmmu] inst_block@0x%lx written: "
-                "PDB_lo=0x%08x PDB_hi=0x%08x\n",
-                (unsigned long)inst_block_phys,
+    uart_printf("[rebuild-gmmu] inst_block@0x%lx written:\n",
+                (unsigned long)inst_block_phys);
+    uart_printf("[rebuild-gmmu]   PDB_lo=0x%08x PDB_hi=0x%08x\n",
                 (unsigned)pdb_lo_word, (unsigned)pdb_hi_word);
+    uart_printf("[rebuild-gmmu]   gp_base=0x%08x gp_base_hi=0x%08x "
+                "(entries=%u → log2=%u)\n",
+                (unsigned)gp_base_lo_val, (unsigned)gp_base_hi_val,
+                (unsigned)h->gpfifo_entries,
+                (unsigned)log2_pow2(h->gpfifo_entries));
+    uart_printf("[rebuild-gmmu]   signature=0x%08x pb_header=0x%08x "
+                "subdevice=0x%08x target=0x%08x\n",
+                GA10B_RAMFC_VAL_SIGNATURE, GA10B_RAMFC_VAL_PB_HEADER,
+                GA10B_RAMFC_VAL_SUBDEVICE, GA10B_RAMFC_VAL_TARGET_GR);
+    uart_printf("[rebuild-gmmu]   acquire=0x%08x intr_notify=0x%08x "
+                "config=0x%08x set_channel_info=0x%08x veid=%u\n",
+                GA10B_RAMFC_VAL_ACQUIRE_LONG,
+                GA10B_RAMFC_VAL_INTR_NOTIFY,
+                GA10B_RAMFC_VAL_CONFIG_USERD_WB,
+                GA10B_RAMFC_SET_CHANNEL_INFO(h->channel_id,
+                                              GA10B_HELPER_SUBCTX_ID),
+                (unsigned)GA10B_HELPER_SUBCTX_ID);
 
     /* 3. Map each preserved buffer at its original GPU VA. The
      *    handoff publishes (phys, gpu_va, size) for every dmabuf

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -24,6 +24,7 @@
 
 #include "../../include/cache.h"
 #include "../../include/pmm.h"
+#include "../../include/string.h"
 #include "../../include/timer.h"
 
 #include <stdint.h>
@@ -209,13 +210,8 @@ int ga10b_gmmu_walk(uint64_t inst_block_phys, uint64_t gpu_va,
         return -1;
     }
 
-    /* Zero the result struct so partial walks have well-defined
-     * fields. Use a small loop because the kernel's freestanding
-     * environment doesn't have memset declared in this TU. */
-    {
-        uint8_t *p = (uint8_t *)result;
-        for (size_t i = 0; i < sizeof(*result); i++) p[i] = 0;
-    }
+    /* Zero the result struct so partial walks have well-defined fields. */
+    memset(result, 0, sizeof(*result));
     result->inst_block_phys = inst_block_phys;
     result->gpu_va = gpu_va;
     result->status = GA10B_GMMU_WALK_BAD_INST;
@@ -520,10 +516,7 @@ static void *alloc_zero_table_page(void)
                     g_table_alloc_count++,
                     (unsigned long)(uintptr_t)p);
     }
-    volatile uint64_t *q = (volatile uint64_t *)p;
-    for (int i = 0; i < 512; i++) {
-        q[i] = 0;
-    }
+    memset(p, 0, 4096);
     cache_clean_range(p, 4096);
     return p;
 }
@@ -933,8 +926,8 @@ int ga10b_gmmu_alloc(uint64_t inst_block_phys,
         if (data == NULL) {
             /* Partial alloc — the pages we mapped before this
              * stay mapped and the PTEs stay set. The PMM pages
-             * we already alloc'd leak (no phys-tracker yet,
-             * Milestone D). Caller treats this as fatal. */
+             * we already alloc'd leak (no rollback yet; tracked
+             * in #825). Caller treats this as fatal. */
             return -1;
         }
         if (i == 0) {

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1298,12 +1298,17 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
           (uint64_t)h->cbuf_size },
         { "qmd_pool", h->qmd_pool_phys, h->qmd_pool_gpu_va,
           (uint64_t)h->qmd_pool_size_bytes },
-        /* Weights pool: only the first physical page's phys is
-         * known. The 1.5 GB region is SMMU-stitched from
-         * scattered pages so a single (phys, size) reserve
-         * doesn't cover the rest. Map the first page so the
-         * caller can at least chunk-0-test W3 staging; further
-         * pages will MMU-fault and the wedge handler will dump. */
+        /* Weights pool: when the helper publishes a v9 extents
+         * list, we walk it below (after this fixed-list loop)
+         * and map every extent. The single-page first-run entry
+         * stays here as a fallback for v8 helpers — SLM-OS sees
+         * `weights_n_extents == 0` and maps only this 4 KB run,
+         * mirroring the Stage 3 behaviour. v9 helpers leave
+         * `weights_pool_phys` populated (matches the first
+         * extent's phys) so the entry is harmlessly redundant
+         * with extent[0] — the GMMU's PTE write is idempotent
+         * since both writes encode the same `phys → gpu_va`
+         * mapping for the first page. */
         { "weights_first", h->weights_pool_phys, h->weights_pool_gpu_va,
           (h->weights_pool_size_bytes != 0) ? 4096ull : 0ull },
     };
@@ -1330,6 +1335,70 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
                     b->tag, (unsigned long)b->gpu_va,
                     (unsigned long)b->phys, (unsigned)n_pages);
         mapped++;
+    }
+
+    /* v9 weights-pool extents — the helper walks
+     * /proc/self/pagemap over the 1.5 GB IOVMM-stitched pool
+     * pre-kexec and publishes a list of (phys, n_pages) extents
+     * in a separate dmabuf. Walk them and install PTEs covering
+     * the entire pool. Without this, only the first 4 KB above
+     * is mapped and CE memcpy writes past that fault.
+     *
+     * The cursor advances by `n_pages * 4 KB` per extent because
+     * the pool is IO-virtually contiguous at `weights_pool_gpu_va`
+     * — the SMMU stitches scattered phys into one IOVA range —
+     * but the underlying physical pages aren't contiguous. Each
+     * extent maps a contiguous physical run to its corresponding
+     * stretch of GPU VA. */
+    if (h->version >= 9u && h->weights_n_extents > 0u &&
+        h->weights_extents_phys != 0u &&
+        h->weights_pool_gpu_va != 0u) {
+        if (!phys_in_dram(h->weights_extents_phys,
+                          (size_t)h->weights_n_extents *
+                          sizeof(struct ga10b_phys_extent))) {
+            uart_printf("[rebuild-gmmu] weights_extents_phys=0x%lx "
+                        "(n=%u) outside DRAM — skipping extent map\n",
+                        (unsigned long)h->weights_extents_phys,
+                        (unsigned)h->weights_n_extents);
+        } else {
+            const struct ga10b_phys_extent *exts =
+                (const struct ga10b_phys_extent *)
+                (uintptr_t)h->weights_extents_phys;
+            uint64_t cursor_va = h->weights_pool_gpu_va;
+            uint32_t total_pages_mapped = 0;
+            uint32_t failed_at = 0;
+            bool extent_fail = false;
+            for (uint32_t i = 0; i < h->weights_n_extents; i++) {
+                if (exts[i].n_pages == 0u) {
+                    continue;
+                }
+                if (rebuild_map_range(pdb_phys, cursor_va,
+                                       exts[i].phys,
+                                       exts[i].n_pages) < 0) {
+                    failed_at = i;
+                    extent_fail = true;
+                    break;
+                }
+                cursor_va += (uint64_t)exts[i].n_pages * 4096ull;
+                total_pages_mapped += exts[i].n_pages;
+            }
+            if (extent_fail) {
+                uart_printf("[rebuild-gmmu] weights extents FAIL at "
+                            "index %u of %u (mapped %u pages before "
+                            "failure)\n",
+                            (unsigned)failed_at,
+                            (unsigned)h->weights_n_extents,
+                            (unsigned)total_pages_mapped);
+                return -1;
+            }
+            uart_printf("[rebuild-gmmu]  ok   weights_extents  "
+                        "n=%u total_pages=%u (~%u MB) end_va=0x%lx\n",
+                        (unsigned)h->weights_n_extents,
+                        (unsigned)total_pages_mapped,
+                        (unsigned)(total_pages_mapped / 256u),
+                        (unsigned long)cursor_va);
+            mapped++;
+        }
     }
 
     /* Amortized dsb sy so all PTE writes are visible to the GPU

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1191,8 +1191,10 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
     /* #788 Stage 6: trace every PMM page the rebuild allocates so
      * the operator can spot which one might be colliding with an
      * unknown FW range. Tail of the function disables tracing
-     * once mapping is done. */
-    ga10b_gmmu_table_alloc_trace_set(true);
+     * once mapping is done. Currently OFF — the 4000+-line trace
+     * is overwhelming when not specifically investigating.
+     * Toggle on for diagnostic captures. */
+    /* ga10b_gmmu_table_alloc_trace_set(true); */
 
     /* 1. Allocate a fresh PDB page from SLM-OS PMM. Zero it so
      *    every PDE3 entry reads as invalid until `map_one_page`

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -997,6 +997,210 @@ int ga10b_gmmu_free(uint64_t inst_block_phys,
     return 0;
 }
 
+/* ============================================================
+ * #788 Stage 2: rebuild GMMU state for an inherited channel.
+ *
+ * After kexec, Linux's nvgpu has freed the channel's inst block,
+ * page-directory base (PDB), and intermediate page tables —
+ * verified by `nvgpu instdump` (PR #797) showing inst-block
+ * contents as ARM64 kernel code (mid-boot allocations) or random
+ * weight bytes (mid-xload). The Stage 1 reservation in
+ * `pmm_user_reserve_add` (PR #801) keeps SLM-OS from overwriting
+ * the inst-block page itself, but the PDB and page tables stay
+ * gone — they were freed before SLM-OS could see them.
+ *
+ * What survives: the helper's user-allocated dmabufs (USERD,
+ * GPFIFO, pushbuffer, semaphore, SASS pool, cbuf, QMD pool,
+ * weights pool first-page, handoff dmabuf). These are tied to
+ * the helper's open file descriptors, so Linux's reference
+ * counting keeps them alive across kexec. The handoff struct
+ * publishes (phys, gpu_va, size) for each.
+ *
+ * Strategy: build a fresh PDB tree in SLM-OS and re-install PTEs
+ * mapping every preserved dmabuf at its original GPU VA. Write
+ * the inst-block's PDB pointer to point at the new tree. The
+ * GPU's runlist still references the old inst-block physical
+ * address (because that's what nvgpu wrote pre-kexec), but we're
+ * filling THAT physical page with a fresh inst block — so the
+ * runlist's pointer becomes meaningful again. TLB-invalidate
+ * after the rebuild so any cached PDB-walks from before-kexec
+ * are flushed.
+ *
+ * **Scope:** maps fixed-size buffers from the handoff at their
+ * recorded GPU VAs. Skips the weights pool beyond its first
+ * page — the 1.5 GB region is SMMU-stitched from scattered
+ * physical pages, and the handoff only publishes the first
+ * page's phys. A future enhancement (Helper Stage 2.1?) could
+ * enumerate per-page phys via /proc/self/pagemap pre-kexec and
+ * publish a longer reserve list, enabling full weights-pool
+ * mapping. Until then, slm xload's W3 staging will succeed for
+ * the first 4 KB chunk only.
+ * ============================================================ */
+
+#include "ga10b_channel_handoff.h"
+#include "../../include/uart.h"
+
+/* Inst-block PDB-pointer encoding per
+ * `~/slmos-ref/nvidia/nvgpu-l4t-r36.4.4-hw_ram_ga10b.h:62-71`.
+ * Replicates `ga10b_ramin_init_pdb` from the nvgpu source — keeps
+ * the encoding correct without dragging the full HW reg header in. */
+#define GA10B_RAM_IN_PDB_TARGET_SYS_NCOH  0x3u
+#define GA10B_RAM_IN_PDB_VOL_TRUE         0x4u
+#define GA10B_RAM_IN_USE_VER2_PT_FORMAT   0x400u
+#define GA10B_RAM_IN_BIG_PAGE_SIZE_64KB   0x800u
+
+/* Map `n_pages` of contiguous physical memory at the given GPU
+ * VA. Helper for the rebuild path — calls into the existing
+ * `map_one_page` so it benefits from the auto-allocated
+ * intermediate-table code. Returns 0 on success, -1 on PMM
+ * exhaustion or invalid range; on partial failure, the pages
+ * mapped before the failure stay mapped (the caller treats this
+ * as fatal). */
+static int rebuild_map_range(uint64_t pdb_phys, uint64_t gpu_va_base,
+                             uint64_t phys_base, uint32_t n_pages)
+{
+    for (uint32_t i = 0; i < n_pages; i++) {
+        uint64_t va_i   = gpu_va_base + (uint64_t)i * 4096ull;
+        uint64_t phys_i = phys_base   + (uint64_t)i * 4096ull;
+        if (map_one_page(pdb_phys, va_i, phys_i, 0) < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
+                                   const struct ga10b_channel_handoff *h)
+{
+    if (h == NULL) {
+        return -1;
+    }
+    if (!phys_in_dram(inst_block_phys, 4096)) {
+        return -1;
+    }
+
+    /* 1. Allocate a fresh PDB page from SLM-OS PMM. Zero it so
+     *    every PDE3 entry reads as invalid until `map_one_page`
+     *    populates the ones it needs. */
+    void *pdb_page = alloc_zero_table_page();
+    if (pdb_page == NULL) {
+        uart_puts("[rebuild-gmmu] PMM exhausted allocating PDB\n");
+        return -1;
+    }
+    uint64_t pdb_phys = (uint64_t)(uintptr_t)pdb_page;
+    uart_printf("[rebuild-gmmu] fresh PDB at phys=0x%lx\n",
+                (unsigned long)pdb_phys);
+
+    /* 2. Zero the inst block (Stage 1 reservation kept the page
+     *    around but Linux may have left non-zero residue) and
+     *    write the PDB pointer at words 128-129 (byte offsets
+     *    512/516) per `ram_in_page_dir_base_lo_w()`/`_hi_w()`. */
+    volatile uint32_t *inst = (volatile uint32_t *)(uintptr_t)inst_block_phys;
+    for (int i = 0; i < 1024; i++) {
+        inst[i] = 0;
+    }
+
+    /* Encode PDB-lo word: aperture (sys_mem_ncoh on Tegra),
+     * volatile bit, ver2 page-table format, 64 KB big-page size,
+     * and phys[31:12] in bits [31:12] (the bottom 12 bits of phys
+     * are zero by page alignment). */
+    uint32_t pdb_lo_word =
+        GA10B_RAM_IN_PDB_TARGET_SYS_NCOH |
+        GA10B_RAM_IN_PDB_VOL_TRUE |
+        GA10B_RAM_IN_USE_VER2_PT_FORMAT |
+        GA10B_RAM_IN_BIG_PAGE_SIZE_64KB |
+        (uint32_t)(pdb_phys & 0xfffff000u);
+    uint32_t pdb_hi_word = (uint32_t)(pdb_phys >> 32);
+
+    inst[128] = pdb_lo_word;
+    inst[129] = pdb_hi_word;
+    cache_clean_range((void *)(uintptr_t)inst_block_phys, 4096);
+
+    uart_printf("[rebuild-gmmu] inst_block@0x%lx written: "
+                "PDB_lo=0x%08x PDB_hi=0x%08x\n",
+                (unsigned long)inst_block_phys,
+                (unsigned)pdb_lo_word, (unsigned)pdb_hi_word);
+
+    /* 3. Map each preserved buffer at its original GPU VA. The
+     *    handoff publishes (phys, gpu_va, size) for every dmabuf
+     *    the helper allocated; we replay those mappings into the
+     *    fresh PDB tree.
+     *
+     *    USERD and GPFIFO are accessed by PBDMA via physical
+     *    addresses (not GPU VAs), so they don't need GMMU
+     *    mappings — skip them.
+     *
+     *    Buffers that DO need GMMU mappings (Pushbuffer +
+     *    Semaphore + SASS pool + cbuf + QMD pool + weights pool
+     *    first-page) are mapped below. Anything with size=0 or
+     *    gpu_va=0 is skipped — that means the helper didn't
+     *    allocate that buffer for this channel. */
+    struct rebuild_buf {
+        const char *tag;
+        uint64_t phys;
+        uint64_t gpu_va;
+        uint64_t size_bytes;
+    };
+
+    struct rebuild_buf bufs[] = {
+        { "pushbuf", h->pushbuf_phys, h->pushbuf_gpu_va,
+          (uint64_t)h->pushbuf_size },
+        { "sem", h->semaphore_phys, h->semaphore_gpu_va, 4096 },
+        { "shader", h->shader_phys, h->shader_gpu_va,
+          (uint64_t)h->shader_size },
+        { "cbuf", h->cbuf_phys, h->cbuf_gpu_va,
+          (uint64_t)h->cbuf_size },
+        { "qmd_pool", h->qmd_pool_phys, h->qmd_pool_gpu_va,
+          (uint64_t)h->qmd_pool_size_bytes },
+        /* Weights pool: only the first physical page's phys is
+         * known. The 1.5 GB region is SMMU-stitched from
+         * scattered pages so a single (phys, size) reserve
+         * doesn't cover the rest. Map the first page so the
+         * caller can at least chunk-0-test W3 staging; further
+         * pages will MMU-fault and the wedge handler will dump. */
+        { "weights_first", h->weights_pool_phys, h->weights_pool_gpu_va,
+          (h->weights_pool_size_bytes != 0) ? 4096ull : 0ull },
+    };
+
+    int mapped = 0;
+    for (size_t i = 0; i < sizeof(bufs) / sizeof(bufs[0]); i++) {
+        const struct rebuild_buf *b = &bufs[i];
+        if (b->size_bytes == 0 || b->phys == 0 || b->gpu_va == 0) {
+            uart_printf("[rebuild-gmmu]  skip %-14s (not allocated)\n",
+                        b->tag);
+            continue;
+        }
+        uint32_t n_pages = (uint32_t)((b->size_bytes + 4095u) / 4096u);
+        if (rebuild_map_range(pdb_phys, b->gpu_va, b->phys,
+                               n_pages) < 0) {
+            uart_printf("[rebuild-gmmu]  FAIL %-14s gpu_va=0x%lx "
+                        "phys=0x%lx pages=%u\n",
+                        b->tag, (unsigned long)b->gpu_va,
+                        (unsigned long)b->phys, (unsigned)n_pages);
+            return -1;
+        }
+        uart_printf("[rebuild-gmmu]  ok   %-14s gpu_va=0x%lx "
+                    "phys=0x%lx pages=%u\n",
+                    b->tag, (unsigned long)b->gpu_va,
+                    (unsigned long)b->phys, (unsigned)n_pages);
+        mapped++;
+    }
+
+    /* Amortized dsb sy so all PTE writes are visible to the GPU
+     * before TLB invalidate fires (matches the `dsb sy` at the
+     * tail of `ga10b_gmmu_alloc` for the same reason). */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    /* 4. Flush any TLB entries the GPU might have cached against
+     *    the old PDB-tree state. `ga10b_gmmu_tlb_invalidate`
+     *    targets the new PDB phys so the next walk loads fresh
+     *    PTEs from the tree we just built. */
+    int rc = ga10b_gmmu_tlb_invalidate(pdb_phys);
+    uart_printf("[rebuild-gmmu] TLB invalidate rc=%d, %d buffer(s) "
+                "mapped\n", rc, mapped);
+    return (rc == 0) ? 0 : -1;
+}
+
 /* Try to satisfy an allocation of `n_pages` from the free-extent
  * tracker (exact-fit). Returns the freed VA on success, removing
  * its slot; returns 0 on miss (caller falls through to the bump

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -356,6 +356,68 @@ uint64_t ga10b_gmmu_discover_inst_block_phys(void);
  * and does not intersect the OP-TEE carveout. */
 bool ga10b_phys_in_dram(uint64_t phys, size_t bytes);
 
+/* Forward decl — full struct is in `ga10b_channel_handoff.h`,
+ * pulled in by the rebuild path's translation unit. Declaring here
+ * lets callers of `ga10b_gmmu_rebuild_for_handoff` work with an
+ * opaque pointer if they only need the function signature. */
+struct ga10b_channel_handoff;
+
+/* #788 Stage 2 — rebuild a fresh GMMU page-table tree for a kexec'd
+ * channel and write the inst block to point at it.
+ *
+ * Use case: after Linux kexecs, nvgpu's module .shutdown handler
+ * frees the channel's PDB + page tables. The inst-block page
+ * survives via the Stage 1 `pmm_user_reserve_add` reservation, but
+ * its contents (PDB pointer, ramfc state) are gone. The helper's
+ * USER-allocated buffers (pushbuffer, semaphore, SASS pool, etc.)
+ * survive intact because the helper's open file descriptors keep
+ * Linux from reclaiming them.
+ *
+ * This function rebuilds:
+ *
+ *   1. A fresh PDB page allocated from SLM-OS PMM, zeroed so every
+ *      PDE3 entry reads invalid until mapped.
+ *   2. The inst block at `inst_block_phys` — overwritten with a
+ *      valid PDB pointer (sys_mem_ncoh aperture, volatile, ver2
+ *      page-table format, 64 KB big-page size) and zeroed
+ *      elsewhere.
+ *   3. PTEs in the new tree mapping each preserved dmabuf from the
+ *      handoff at its original GPU VA: pushbuf, semaphore, SASS
+ *      pool (shader_*), cbuf, QMD pool, and the first 4 KB of the
+ *      weights pool. USERD and GPFIFO are PBDMA-accessed via phys
+ *      and don't need GMMU entries.
+ *   4. TLB invalidate against the new PDB so the GPU loads fresh
+ *      PTEs on the next walk.
+ *
+ * **Limitations:**
+ *
+ *   - Weights pool beyond its first page is NOT mapped. The 1.5 GB
+ *     IOVMM allocation is SMMU-stitched from physically-scattered
+ *     pages; the handoff publishes only the first page's phys.
+ *     `slm xload qwen`'s W3 staging will succeed for the first 4
+ *     KB chunk only; further chunks MMU-fault. A future helper
+ *     enhancement could enumerate per-page phys via
+ *     /proc/self/pagemap pre-kexec.
+ *
+ *   - GR engine ctxsw save buffer is NOT rebuilt. nvgpu allocates
+ *     this lazily on first GR engagement; if FECS tries to save a
+ *     context during the rebuilt channel's life, the save will
+ *     fault. The MVP doesn't attempt to recreate it; if hardware
+ *     testing shows it's needed, a future revision will allocate a
+ *     save buffer and patch the inst block's engine_wfi fields.
+ *
+ *   - The runlist on the GPU still references the OLD inst-block
+ *     physical address (because that's where nvgpu wrote it
+ *     pre-kexec). The Stage 1 reservation keeps that page intact;
+ *     this function fills it with valid contents so the runlist's
+ *     reference becomes meaningful again. No runlist edit needed.
+ *
+ * Returns 0 on success, -1 on PMM exhaustion / invalid inst_phys /
+ * mapping failure / TLB-invalidate timeout. All UART-logged so the
+ * caller can correlate failures with the boot-time trace. */
+int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
+                                   const struct ga10b_channel_handoff *h);
+
 /* Discover the inherited channel's inst block by walking DRAM and
  * cross-checking each candidate against a known (gpu_va, leaf_phys)
  * pair from the channel handoff. Used as a fallback when

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -1,0 +1,160 @@
+/*
+ * ga10b_handoff_reserve.c — implementation of
+ * `ga10b_kexec_handoff_register_reserves`. See the header for the
+ * #788 problem statement.
+ *
+ * The function reads FECS_CURRENT_CTX (BAR0 + 0x409b00), decodes the
+ * inst-block physical address per `gr_fecs_current_ctx_*`
+ * (bits[27:0] = inst_phys >> 12, bits[29:28] = aperture target),
+ * bounds-checks it against the DRAM aperture via `ga10b_phys_in_dram`,
+ * and registers a single 4 KB reserve via `pmm_user_reserve_add`.
+ *
+ * Why read FECS_CURRENT_CTX directly here instead of going through
+ * `ga10b_gmmu_discover_inst_block_phys`?
+ *
+ * The MMU is up at the call site (vmm_init has run, identity-maps
+ * cover all DRAM + the GPU BAR0 aperture), but the higher-level
+ * GPU bringup infrastructure (`ga10b_bringup` state machine, PMM-
+ * dependent allocations inside `ga10b_gmmu_*`) has not been
+ * initialised — `pmm_init` itself is the next call after us. Reading
+ * the raw MMIO directly keeps the dependency footprint to the
+ * identity mapping plus `pmm_user_reserve_add`, both of which are
+ * known-safe to use this early.
+ *
+ * **Limitations of the MVP:**
+ *
+ *   - Reserves only the inst block. The PDB and page-table pages
+ *     pointed to from the inst block also need protection but the
+ *     walk requires reading those pages too — adding correctness
+ *     gates that aren't worth shipping until the inst-block-only
+ *     reservation is hardware-verified to fix the wedge or proves
+ *     insufficient.
+ *
+ *   - Reads `FECS_CURRENT_CTX` from BAR0 directly. The Tegra GA10B
+ *     GPU MMIO can return poisoned values (`0xbadfXXXX` family) when
+ *     the GPU is power-gated. Those decode to a non-DRAM `inst_phys`
+ *     and are filtered out by the `ga10b_phys_in_dram` check; the
+ *     function logs the skip and returns cleanly.
+ *
+ *   - Assumes the helper kept the channel loaded on the GR engine
+ *     through kexec — i.e. FECS still has a meaningful current ctx
+ *     to report. A `--gpu-suspend` kexec breaks this assumption;
+ *     the function early-returns on `target == 0` (and on poisoned
+ *     reads) so suspended-GPU boots cost only a single MMIO read.
+ */
+
+#include "ga10b_handoff_reserve.h"
+
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+
+#include "ga10b_gmmu.h"
+#include "../../include/pmm.h"
+#include "../../include/uart.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* MMIO offsets — same as `ga10b_gmmu.c` and `ga10b_bringup.c` use,
+ * duplicated here so this TU has no compile-time dependency on the
+ * larger bringup module (which itself pulls in `pmm.h` transitively
+ * and could create cycles in early-boot ordering). */
+#define GA10B_BAR0_BASE                  0x17000000ull
+#define GA10B_GR_FECS_CURRENT_CTX_OFFSET 0x00409b00u
+
+/* `gr_fecs_current_ctx_*` field encoding per L4T nvgpu
+ * `~/slmos-ref/nvidia/nvgpu-include-nvgpu-hw-gv11b-hw_gr_gv11b.h`:
+ *   bits [27:0]  = `ptr` = inst_block_phys >> 12
+ *   bits [29:28] = `target` (0=vid_mem, 2=sys_mem_coh, 3=sys_mem_ncoh)
+ * target == 0 on Tegra means "no current ctx" (no vidmem) or stale
+ * post-kexec garbage; skip the reservation in either case. */
+#define GA10B_FECS_CTX_PTR_MASK     0x0FFFFFFFu
+#define GA10B_FECS_CTX_TARGET_SHIFT 28u
+#define GA10B_FECS_CTX_TARGET_MASK  0x3u
+
+/* GA10B inst block is 4 KB. Hardcoded constant duplicated from
+ * `ga10b_bringup.c`'s `GA10B_INST_BLOCK_BYTES` so this TU stays
+ * self-contained — the larger bringup header has the
+ * compile-time-pinned definition; if the size ever changes on
+ * Ampere, both sites need updating in lock-step. */
+#define GA10B_INST_BLOCK_BYTES 4096u
+
+void ga10b_kexec_handoff_register_reserves(void)
+{
+    /* Read FECS_CURRENT_CTX directly via the identity mapping that
+     * vmm_init has just established. Volatile so the compiler can't
+     * elide or reorder; `bar0_r32` from ga10b_bringup.c would route
+     * through the GSP platform vtable which is still NULL this
+     * early in boot. */
+    uint32_t reg = *(volatile uint32_t *)(uintptr_t)
+        (GA10B_BAR0_BASE + GA10B_GR_FECS_CURRENT_CTX_OFFSET);
+
+    /* GA10B GPU MMIO returns the `0xbadfXXXX` family of poison
+     * patterns when the GPU is power-gated or off (PRI bad-access
+     * response). Filter those out specifically — the `target` check
+     * below would catch most by coincidence (poison patterns
+     * typically decode to target=2 or 3 with a garbage ptr field,
+     * which then fails the DRAM bounds check), but the explicit
+     * filter logs the cause clearly instead of "outside DRAM" for
+     * the case the operator hits most often (fresh boot, no
+     * helper). */
+    if ((reg & 0xFFFF0000u) == 0xbadf0000u) {
+        uart_printf("[ga10b-reserve] FECS_CURRENT_CTX=0x%08x (priv-bad "
+                    "poison — GPU likely power-gated). Skipping "
+                    "inst-block reservation.\n",
+                    (unsigned)reg);
+        return;
+    }
+
+    uint32_t target = (reg >> GA10B_FECS_CTX_TARGET_SHIFT) &
+                      GA10B_FECS_CTX_TARGET_MASK;
+    if (target == 0u) {
+        uart_printf("[ga10b-reserve] FECS_CURRENT_CTX=0x%08x (target=0 "
+                    "— no current ctx, or fresh boot). Skipping.\n",
+                    (unsigned)reg);
+        return;
+    }
+
+    uint64_t inst_phys =
+        ((uint64_t)(reg & GA10B_FECS_CTX_PTR_MASK)) << 12;
+
+    if (!ga10b_phys_in_dram(inst_phys, GA10B_INST_BLOCK_BYTES)) {
+        uart_printf("[ga10b-reserve] decoded inst_phys=0x%lx outside "
+                    "DRAM (FECS_CURRENT_CTX=0x%08x, target=%u). "
+                    "Skipping reservation.\n",
+                    (unsigned long)inst_phys, (unsigned)reg,
+                    (unsigned)target);
+        return;
+    }
+
+    int rc = pmm_user_reserve_add(inst_phys,
+                                  (uint64_t)GA10B_INST_BLOCK_BYTES);
+    if (rc != 0) {
+        uart_printf("[ga10b-reserve] pmm_user_reserve_add(0x%lx, %u) "
+                    "rc=%d — reservation NOT registered. PMM will hand "
+                    "out the inst-block page; expect a #788-style "
+                    "wedge on the first GPU submit.\n",
+                    (unsigned long)inst_phys,
+                    (unsigned)GA10B_INST_BLOCK_BYTES, rc);
+        return;
+    }
+
+    uart_printf("[ga10b-reserve] reserved kexec'd channel inst block "
+                "at phys=0x%lx (size=%u, FECS_CURRENT_CTX=0x%08x, "
+                "target=%u)\n",
+                (unsigned long)inst_phys,
+                (unsigned)GA10B_INST_BLOCK_BYTES,
+                (unsigned)reg, (unsigned)target);
+}
+
+#else  /* !PLATFORM_JETSON_ORIN_NANO */
+
+/* No-op stub for non-Jetson platforms. The header's documentation
+ * notes the function is safe to call from a platform-guarded call
+ * site; this empty body lets non-Jetson builds still link if a
+ * future caller forgets the `#if`. Compiler will inline-eliminate
+ * the call entirely at LTO time. */
+void ga10b_kexec_handoff_register_reserves(void)
+{
+}
+
+#endif

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -147,6 +147,97 @@ void ga10b_kexec_handoff_register_reserves(void)
                 (unsigned)GA10B_INST_BLOCK_BYTES,
                 (unsigned)reg, (unsigned)target);
 
+    /* #788 Stage 7: read the GR engine's runlist submit_base register
+     * and reserve the runlist's pages.
+     *
+     * The runlist is a per-engine DRAM buffer that PBDMA reads to
+     * find which channels to schedule. Linux's nvgpu allocates it
+     * via `gk20a_gmmu_alloc_sys` (sys mem, page-aligned) and writes
+     * the address into `runlist_submit_base_lo/hi`. The handoff
+     * struct doesn't publish the runlist phys, so without this
+     * step SLM-OS's PMM may hand out the runlist's pages to its
+     * own allocations — Stage 6 trace proves intermediate PT-page
+     * allocations during the GMMU rebuild land on physical pages
+     * adjacent to / overlapping the runlist when pushbuf or sem
+     * is reserved.
+     *
+     * GA10B Tegra has a single GR runlist with empirically-observed
+     * pri_base at BAR0 + 0xC000 (per the PTOP device-info table
+     * walk in L4T nvgpu's `ga10b_top_parse_next_dev`). So
+     * `runlist_submit_base_lo` is at BAR0 + 0xC080, `_hi` at
+     * BAR0 + 0xC084.
+     *
+     * Register encoding per `~/slmos-ref/nvidia/nvgpu-hw-ga10b-hw_runlist_ga10b.h`:
+     *   lo bits[31:10] = runlist_iova >> 10 (1 KB-aligned ptr)
+     *   lo bits[1:0]   = target aperture
+     *   hi bits[7:0]   = runlist_iova bits[39:32]
+     *
+     * Runlist size: 32 KiB per buffer × 2 buffers (double-buffered)
+     * = 64 KiB total, page-aligned.
+     *
+     * If the empirical 0xC000 offset is wrong on a future chip
+     * revision, the read will return a value outside DRAM and
+     * the `ga10b_phys_in_dram` check will skip the reservation
+     * cleanly — Stage 4+5 regression behavior worsens but the
+     * boot continues. */
+    {
+        const uint64_t runlist_lo_addr = GA10B_BAR0_BASE + 0xC080u;
+        const uint64_t runlist_hi_addr = GA10B_BAR0_BASE + 0xC084u;
+        uint32_t rl_lo = *(volatile uint32_t *)(uintptr_t)runlist_lo_addr;
+        uint32_t rl_hi = *(volatile uint32_t *)(uintptr_t)runlist_hi_addr;
+
+        if ((rl_lo & 0xFFFF0000u) == 0xbadf0000u ||
+            (rl_hi & 0xFFFF0000u) == 0xbadf0000u) {
+            uart_printf("[ga10b-reserve] runlist submit_base reads "
+                        "poison (lo=0x%08x hi=0x%08x) — wrong "
+                        "pri_base offset or GPU power-gated. Skipping.\n",
+                        (unsigned)rl_lo, (unsigned)rl_hi);
+        } else {
+            /* Decode: lo bits[31:10] are ptr bits[31:10] (1 KB-aligned).
+             * Mask off the low 10 bits, those carry target + flags. */
+            uint64_t runlist_phys =
+                ((uint64_t)(rl_lo & 0xfffffc00u)) |
+                ((uint64_t)(rl_hi & 0xffu) << 32);
+            uint32_t aperture = rl_lo & 0x3u;
+
+            /* Double-buffered 32 KiB → 64 KiB total. Page-round
+             * the size to ensure we cover both buffers even if
+             * the base isn't 64 KiB-aligned. */
+            const uint64_t runlist_bytes = 64u * 1024u;
+
+            if (!ga10b_phys_in_dram(runlist_phys, (size_t)runlist_bytes)) {
+                uart_printf("[ga10b-reserve] runlist phys=0x%lx (size=%llu, "
+                            "lo=0x%08x hi=0x%08x ap=%u) outside DRAM — "
+                            "skipping reservation. Either the pri_base "
+                            "offset is wrong or Linux's nvgpu hadn't "
+                            "programmed the runlist yet.\n",
+                            (unsigned long)runlist_phys,
+                            (unsigned long long)runlist_bytes,
+                            (unsigned)rl_lo, (unsigned)rl_hi,
+                            (unsigned)aperture);
+            } else {
+                uint64_t runlist_page_base = runlist_phys & ~4095ull;
+                uint64_t runlist_page_end =
+                    (runlist_phys + runlist_bytes + 4095ull) & ~4095ull;
+                uint64_t runlist_reserve_bytes =
+                    runlist_page_end - runlist_page_base;
+                if (pmm_user_reserve_add(runlist_page_base,
+                                          runlist_reserve_bytes) != 0) {
+                    uart_printf("[ga10b-reserve] pmm_user_reserve_add "
+                                "for runlist @0x%lx failed (table full)\n",
+                                (unsigned long)runlist_page_base);
+                } else {
+                    uart_printf("[ga10b-reserve] reserved GR runlist "
+                                "@0x%lx (%llu B, lo=0x%08x hi=0x%08x ap=%u)\n",
+                                (unsigned long)runlist_page_base,
+                                (unsigned long long)runlist_reserve_bytes,
+                                (unsigned)rl_lo, (unsigned)rl_hi,
+                                (unsigned)aperture);
+                }
+            }
+        }
+    }
+
     /* #788 Stage 4 — scan DRAM for the handoff and reserve every
      * weights-pool extent it lists. The IOVMM-stitched 1.5 GB
      * weights pool is physically scattered across hundreds-to-
@@ -224,19 +315,28 @@ void ga10b_kexec_handoff_register_reserves(void)
         uint64_t sem_p     = h->semaphore_phys;
         uint64_t shader_p  = h->shader_phys;
         uint32_t shader_s  = h->shader_size;
+        uint64_t cbuf_p    = h->cbuf_phys;
+        uint32_t cbuf_s    = h->cbuf_size;
+        uint64_t qmd_p     = h->qmd_pool_phys;
+        uint32_t qmd_s     = h->qmd_pool_size_bytes;
 
         struct {
             const char *tag;
             uint64_t phys;
             uint64_t size;
         } refs[] = {
+            /* Stage 7: full helper-buf reservation. Stage 4 was
+             * broken by pushbuf/sem reservation (bisect E/F);
+             * Stage 7 adds the runlist reservation above which
+             * should make the rebuild's PT-page allocations safe. */
             { "userd",    userd_p,   4096 },
             { "gpfifo",   gpfifo_p,  (uint64_t)gpfifo_e * (uint64_t)gpfifo_es },
-            /* Stage 6: USERD + GPFIFO + pushbuf (bisect E config —
-             * the failing case we want to instrument). */
             { "pushbuf",  pushbuf_p, (uint64_t)pushbuf_s },
+            { "sem",      sem_p,     4096 },
+            { "shader",   shader_p,  (uint64_t)shader_s },
+            { "cbuf",     cbuf_p,    (uint64_t)cbuf_s },
+            { "qmd_pool", qmd_p,     (uint64_t)qmd_s },
         };
-        (void)sem_p; (void)shader_p; (void)shader_s;
         for (size_t i = 0; i < sizeof(refs) / sizeof(refs[0]); i++) {
             if (refs[i].phys == 0 || refs[i].size == 0) {
                 continue;

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -232,10 +232,11 @@ void ga10b_kexec_handoff_register_reserves(void)
         } refs[] = {
             { "userd",    userd_p,   4096 },
             { "gpfifo",   gpfifo_p,  (uint64_t)gpfifo_e * (uint64_t)gpfifo_es },
-            /* Stage 5 bisect F: USERD + GPFIFO + sem only. */
-            { "sem",      sem_p,     4096 },
+            /* Stage 6: USERD + GPFIFO + pushbuf (bisect E config —
+             * the failing case we want to instrument). */
+            { "pushbuf",  pushbuf_p, (uint64_t)pushbuf_s },
         };
-        (void)pushbuf_p; (void)pushbuf_s; (void)shader_p; (void)shader_s;
+        (void)sem_p; (void)shader_p; (void)shader_s;
         for (size_t i = 0; i < sizeof(refs) / sizeof(refs[0]); i++) {
             if (refs[i].phys == 0 || refs[i].size == 0) {
                 continue;

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -192,6 +192,13 @@ void ga10b_kexec_handoff_register_reserves(void)
     uint32_t n_extents = h->weights_n_extents;
     uint64_t extents_phys = h->weights_extents_phys;
 
+#if 1  /* Stage 5 bisect B: only USERD + GPFIFO reserved */
+#define BISECT_B_USERD_GPFIFO_ONLY 1
+#else
+#define BISECT_B_USERD_GPFIFO_ONLY 0
+#endif
+
+#if BISECT_B_USERD_GPFIFO_ONLY  /* Stage 5 bisect B: only USERD + GPFIFO */
     /* Reserve every helper-allocated buffer the channel needs
      * (USERD, GPFIFO, pushbuf, sem, SASS pool, cbuf, QMD pool).
      * Without these, SLM-OS PMM can hand them out to its own
@@ -217,10 +224,6 @@ void ga10b_kexec_handoff_register_reserves(void)
         uint64_t sem_p     = h->semaphore_phys;
         uint64_t shader_p  = h->shader_phys;
         uint32_t shader_s  = h->shader_size;
-        uint64_t cbuf_p    = h->cbuf_phys;
-        uint32_t cbuf_s    = h->cbuf_size;
-        uint64_t qmd_p     = h->qmd_pool_phys;
-        uint32_t qmd_s     = h->qmd_pool_size_bytes;
 
         struct {
             const char *tag;
@@ -229,12 +232,10 @@ void ga10b_kexec_handoff_register_reserves(void)
         } refs[] = {
             { "userd",    userd_p,   4096 },
             { "gpfifo",   gpfifo_p,  (uint64_t)gpfifo_e * (uint64_t)gpfifo_es },
-            { "pushbuf",  pushbuf_p, (uint64_t)pushbuf_s },
+            /* Stage 5 bisect F: USERD + GPFIFO + sem only. */
             { "sem",      sem_p,     4096 },
-            { "shader",   shader_p,  (uint64_t)shader_s },
-            { "cbuf",     cbuf_p,    (uint64_t)cbuf_s },
-            { "qmd_pool", qmd_p,     (uint64_t)qmd_s },
         };
+        (void)pushbuf_p; (void)pushbuf_s; (void)shader_p; (void)shader_s;
         for (size_t i = 0; i < sizeof(refs) / sizeof(refs[0]); i++) {
             if (refs[i].phys == 0 || refs[i].size == 0) {
                 continue;
@@ -255,6 +256,9 @@ void ga10b_kexec_handoff_register_reserves(void)
             }
         }
     }
+#else
+    uart_puts("[ga10b-reserve]   STAGE5-BISECT: helper-buffer reservations SKIPPED\n");
+#endif
     if (version < 9u || n_extents == 0u || extents_phys == 0u) {
         uart_printf("[ga10b-reserve]   handoff@0x%lx v=%u no v9 "
                     "extents (n=%u extents_phys=0x%lx) — skipping\n",

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -527,6 +527,80 @@ void ga10b_kexec_handoff_register_reserves(void)
                     (unsigned long)h->inst_block_phys);
     }
 
+    /* v10 (#788 Mode C fix): per-channel GR context buffer reservation.
+     *
+     * The helper read /sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys
+     * (exposed by a patched nvgpu.ko) and published every active
+     * channel's GR context buffer phys ranges in an extents array.
+     * Each entry covers one channel-internal GR buffer (main ctx,
+     * patch ctx, etc.). Without this, SLM-OS PMM clobbers the
+     * buffers and FECS hits mb6=0x5a on context-load. */
+    {
+        uint64_t gr_ctx_extents_phys = h->gr_ctx_extents_phys;
+        uint32_t gr_ctx_n_extents    = h->gr_ctx_n_extents;
+        if (gr_ctx_extents_phys != 0 && gr_ctx_n_extents > 0) {
+            uint64_t gr_extents_bytes =
+                (uint64_t)gr_ctx_n_extents *
+                sizeof(struct ga10b_phys_extent);
+            if (!ga10b_phys_in_dram(gr_ctx_extents_phys,
+                                    (size_t)gr_extents_bytes)) {
+                uart_printf("[ga10b-reserve]   gr_ctx_extents_phys=0x%lx "
+                            "(n=%u) outside DRAM — skipping gr_ctx "
+                            "reservation\n",
+                            (unsigned long)gr_ctx_extents_phys,
+                            (unsigned)gr_ctx_n_extents);
+            } else {
+                /* Reserve the extents-array dmabuf itself */
+                uint64_t arr_page_base = gr_ctx_extents_phys & ~4095ull;
+                uint64_t arr_page_end  =
+                    (gr_ctx_extents_phys + gr_extents_bytes + 4095ull) &
+                    ~4095ull;
+                if (pmm_user_reserve_add(arr_page_base,
+                                          arr_page_end - arr_page_base) == 0) {
+                    uart_printf("[ga10b-reserve]   reserved gr_ctx_extents "
+                                "array @0x%lx\n",
+                                (unsigned long)arr_page_base);
+                }
+
+                /* Reserve every entry. */
+                const struct ga10b_phys_extent *gr_exts =
+                    (const struct ga10b_phys_extent *)(uintptr_t)
+                    gr_ctx_extents_phys;
+                int gr_reserved = 0, gr_skipped = 0;
+                uint64_t gr_total_bytes = 0;
+                for (uint32_t i = 0; i < gr_ctx_n_extents; i++) {
+                    uint64_t ph = gr_exts[i].phys;
+                    uint32_t np = gr_exts[i].n_pages;
+                    if (np == 0u) continue;
+                    uint64_t sz = (uint64_t)np * 4096ull;
+                    if (!ga10b_phys_in_dram(ph, sz)) {
+                        gr_skipped++;
+                        continue;
+                    }
+                    if (pmm_user_reserve_add(ph, sz) != 0) {
+                        uart_printf("[ga10b-reserve]   gr_ctx reserve "
+                                    "table full at extent %u/%u\n",
+                                    (unsigned)i, (unsigned)gr_ctx_n_extents);
+                        break;
+                    }
+                    gr_reserved++;
+                    gr_total_bytes += sz;
+                }
+                uart_printf("[ga10b-reserve]   gr_ctx: %u extents reserved "
+                            "(%llu KB total), %u skipped\n",
+                            (unsigned)gr_reserved,
+                            (unsigned long long)(gr_total_bytes / 1024ull),
+                            (unsigned)gr_skipped);
+            }
+        } else {
+            uart_printf("[ga10b-reserve]   gr_ctx reservation skipped "
+                        "(extents_phys=0x%lx n=%u — helper didn't publish, "
+                        "older or non-patched nvgpu)\n",
+                        (unsigned long)gr_ctx_extents_phys,
+                        (unsigned)gr_ctx_n_extents);
+        }
+    }
+
     if (version < 9u || n_extents == 0u || extents_phys == 0u) {
         uart_printf("[ga10b-reserve]   handoff@0x%lx v=%u no v9 "
                     "extents (n=%u extents_phys=0x%lx) — skipping\n",

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -417,7 +417,9 @@ static void reserve_per_op_shaders(const volatile struct ga10b_channel_handoff *
                     (unsigned)GA10B_PIPELINE_V7_MAX_OPS);
         return;
     }
-    if (!ga10b_phys_in_dram(ops_phys, (size_t)n_ops * 80u)) {
+    if (!ga10b_phys_in_dram(ops_phys,
+                            (size_t)n_ops *
+                            sizeof(struct ga10b_pipeline_op_v7))) {
         uart_printf("[ga10b-reserve]   pipeline_ops_phys=0x%lx "
                     "(n=%u) outside DRAM — skipping per-op "
                     "shader reservation\n",
@@ -430,7 +432,8 @@ static void reserve_per_op_shaders(const volatile struct ga10b_channel_handoff *
      * Without this, SLM-OS PMM could clobber the ops array between
      * boot and the launch-kernel command reading it. */
     uint64_t ops_page_base = ops_phys & ~4095ull;
-    uint64_t ops_bytes     = (uint64_t)n_ops * 80ull;
+    uint64_t ops_bytes     = (uint64_t)n_ops *
+                             sizeof(struct ga10b_pipeline_op_v7);
     uint64_t ops_page_end  =
         (ops_phys + ops_bytes + 4095ull) & ~4095ull;
     if (pmm_user_reserve_add(ops_page_base,

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -41,6 +41,16 @@
  *     to report. A `--gpu-suspend` kexec breaks this assumption;
  *     the function early-returns on `target == 0` (and on poisoned
  *     reads) so suspended-GPU boots cost only a single MMIO read.
+ *
+ * **Patched-`nvgpu.ko` dependency** (#788 v10/v11 fix path).
+ * `reserve_gr_ctx_extents` consumes `h->gr_ctx_extents_phys` /
+ * `gr_ctx_n_extents` which are populated only when the Linux-side
+ * `nvgpu.ko` is built from the patch at
+ * `tools/nvgpu-patches/0001-expose-gr-ctx-phys-via-debugfs.patch`.
+ * Without the patched module installed, those fields stay zero,
+ * the function logs the `gr_ctx reservation skipped (...)` line,
+ * and per-attempt PASS regresses from ~60% to the v6-equivalent
+ * ~17%. See PR #823 §Dependencies for the build/install steps.
  */
 
 #include "ga10b_handoff_reserve.h"
@@ -81,21 +91,35 @@
 #define GA10B_INST_BLOCK_BYTES 4096u
 
 /* Boot-time capture of the kexec'd channel's inst-block phys. Read
- * from FECS_CURRENT_CTX in `ga10b_kexec_handoff_register_reserves`
- * BEFORE any other SLM-OS GPU MMIO touches FECS. The live
- * FECS_CURRENT_CTX register drifts after kexec — SLM-OS's own
- * subsequent GPU probes (nvgpu inherit / channel / submit) trigger
- * FECS context switches to other channels Linux had loaded, and
- * the helper-published handoff doesn't carry an inst_block_phys
- * field. So this is the single authoritative copy of "which inst
- * block did Linux just leave on the GR engine when we kexec'd."
+ * from FECS_CURRENT_CTX in `reserve_inst_block` BEFORE any other
+ * SLM-OS GPU MMIO touches FECS. The live FECS_CURRENT_CTX register
+ * drifts after kexec — SLM-OS's own subsequent GPU probes
+ * (nvgpu inherit / channel / submit) trigger FECS context switches
+ * to other channels Linux had loaded, and the helper-published
+ * handoff doesn't carry an inst_block_phys field. So this is the
+ * single authoritative copy of "which inst block did Linux just
+ * leave on the GR engine when we kexec'd."
  *
  * Exposed via `ga10b_kexec_inherited_inst_block_phys()` for the
  * `nvgpu oplib stage` shell verb (and any future caller that needs
  * to dereference the inherited channel's GMMU after FECS has drifted). */
 static uint64_t g_boot_inst_block_phys = 0;
 
-void ga10b_kexec_handoff_register_reserves(void)
+/* ---------------------------------------------------------------
+ * Sub-functions, one per reservation class. Called in order by
+ * `ga10b_kexec_handoff_register_reserves` below; the orchestrator
+ * threads the inst-block early-out and the handoff scan.
+ * --------------------------------------------------------------- */
+
+/* Read FECS_CURRENT_CTX, decode the inst-block phys, validate it
+ * lives in DRAM, and register a 4 KB reserve. Stashes the verified
+ * phys in `g_boot_inst_block_phys` for later access.
+ *
+ * Returns true iff a valid inst block was reserved (caller should
+ * continue with downstream reservations). Returns false on any skip
+ * path: poison MMIO, target=0 fresh boot, outside-DRAM phys, or
+ * PMM table full. */
+static bool reserve_inst_block(void)
 {
     /* Read FECS_CURRENT_CTX directly via the identity mapping that
      * vmm_init has just established. Volatile so the compiler can't
@@ -119,7 +143,7 @@ void ga10b_kexec_handoff_register_reserves(void)
                     "poison — GPU likely power-gated). Skipping "
                     "inst-block reservation.\n",
                     (unsigned)reg);
-        return;
+        return false;
     }
 
     uint32_t target = (reg >> GA10B_FECS_CTX_TARGET_SHIFT) &
@@ -128,7 +152,7 @@ void ga10b_kexec_handoff_register_reserves(void)
         uart_printf("[ga10b-reserve] FECS_CURRENT_CTX=0x%08x (target=0 "
                     "— no current ctx, or fresh boot). Skipping.\n",
                     (unsigned)reg);
-        return;
+        return false;
     }
 
     uint64_t inst_phys =
@@ -140,7 +164,7 @@ void ga10b_kexec_handoff_register_reserves(void)
                     "Skipping reservation.\n",
                     (unsigned long)inst_phys, (unsigned)reg,
                     (unsigned)target);
-        return;
+        return false;
     }
 
     int rc = pmm_user_reserve_add(inst_phys,
@@ -152,7 +176,7 @@ void ga10b_kexec_handoff_register_reserves(void)
                     "wedge on the first GPU submit.\n",
                     (unsigned long)inst_phys,
                     (unsigned)GA10B_INST_BLOCK_BYTES, rc);
-        return;
+        return false;
     }
 
     /* Save the verified inst_phys for the inherited-inst-block
@@ -170,127 +194,108 @@ void ga10b_kexec_handoff_register_reserves(void)
                 (unsigned long)inst_phys,
                 (unsigned)GA10B_INST_BLOCK_BYTES,
                 (unsigned)reg, (unsigned)target);
+    return true;
+}
 
-    /* #788 Stage 7: read the GR engine's runlist submit_base register
-     * and reserve the runlist's pages.
-     *
-     * The runlist is a per-engine DRAM buffer that PBDMA reads to
-     * find which channels to schedule. Linux's nvgpu allocates it
-     * via `gk20a_gmmu_alloc_sys` (sys mem, page-aligned) and writes
-     * the address into `runlist_submit_base_lo/hi`. The handoff
-     * struct doesn't publish the runlist phys, so without this
-     * step SLM-OS's PMM may hand out the runlist's pages to its
-     * own allocations — Stage 6 trace proves intermediate PT-page
-     * allocations during the GMMU rebuild land on physical pages
-     * adjacent to / overlapping the runlist when pushbuf or sem
-     * is reserved.
-     *
-     * GA10B Tegra has a single GR runlist with empirically-observed
-     * pri_base at BAR0 + 0xC000 (per the PTOP device-info table
-     * walk in L4T nvgpu's `ga10b_top_parse_next_dev`). So
-     * `runlist_submit_base_lo` is at BAR0 + 0xC080, `_hi` at
-     * BAR0 + 0xC084.
-     *
-     * Register encoding per `~/slmos-ref/nvidia/nvgpu-hw-ga10b-hw_runlist_ga10b.h`:
-     *   lo bits[31:10] = runlist_iova >> 10 (1 KB-aligned ptr)
-     *   lo bits[1:0]   = target aperture
-     *   hi bits[7:0]   = runlist_iova bits[39:32]
-     *
-     * Runlist size: 32 KiB per buffer × 2 buffers (double-buffered)
-     * = 64 KiB total, page-aligned.
-     *
-     * If the empirical 0xC000 offset is wrong on a future chip
-     * revision, the read will return a value outside DRAM and
-     * the `ga10b_phys_in_dram` check will skip the reservation
-     * cleanly — Stage 4+5 regression behavior worsens but the
-     * boot continues. */
-    {
-        const uint64_t runlist_lo_addr = GA10B_BAR0_BASE + 0xC080u;
-        const uint64_t runlist_hi_addr = GA10B_BAR0_BASE + 0xC084u;
-        uint32_t rl_lo = *(volatile uint32_t *)(uintptr_t)runlist_lo_addr;
-        uint32_t rl_hi = *(volatile uint32_t *)(uintptr_t)runlist_hi_addr;
+/* #788 Stage 7 — read the GR engine's runlist submit_base register
+ * and reserve the runlist's pages.
+ *
+ * The runlist is a per-engine DRAM buffer that PBDMA reads to
+ * find which channels to schedule. Linux's nvgpu allocates it
+ * via `gk20a_gmmu_alloc_sys` (sys mem, page-aligned) and writes
+ * the address into `runlist_submit_base_lo/hi`. The handoff
+ * struct doesn't publish the runlist phys, so without this
+ * step SLM-OS's PMM may hand out the runlist's pages to its
+ * own allocations — Stage 6 trace proves intermediate PT-page
+ * allocations during the GMMU rebuild land on physical pages
+ * adjacent to / overlapping the runlist when pushbuf or sem
+ * is reserved.
+ *
+ * GA10B Tegra has a single GR runlist with empirically-observed
+ * pri_base at BAR0 + 0xC000 (per the PTOP device-info table
+ * walk in L4T nvgpu's `ga10b_top_parse_next_dev`). So
+ * `runlist_submit_base_lo` is at BAR0 + 0xC080, `_hi` at
+ * BAR0 + 0xC084.
+ *
+ * Register encoding per `~/slmos-ref/nvidia/nvgpu-hw-ga10b-hw_runlist_ga10b.h`:
+ *   lo bits[31:10] = runlist_iova >> 10 (1 KB-aligned ptr)
+ *   lo bits[1:0]   = target aperture
+ *   hi bits[7:0]   = runlist_iova bits[39:32]
+ *
+ * Runlist size: 32 KiB per buffer × 2 buffers (double-buffered)
+ * = 64 KiB total, page-aligned.
+ *
+ * If the empirical 0xC000 offset is wrong on a future chip
+ * revision, the read will return a value outside DRAM and
+ * the `ga10b_phys_in_dram` check will skip the reservation
+ * cleanly — Stage 4+5 regression behavior worsens but the
+ * boot continues. */
+static void reserve_runlist(void)
+{
+    const uint64_t runlist_lo_addr = GA10B_BAR0_BASE + 0xC080u;
+    const uint64_t runlist_hi_addr = GA10B_BAR0_BASE + 0xC084u;
+    uint32_t rl_lo = *(volatile uint32_t *)(uintptr_t)runlist_lo_addr;
+    uint32_t rl_hi = *(volatile uint32_t *)(uintptr_t)runlist_hi_addr;
 
-        if ((rl_lo & 0xFFFF0000u) == 0xbadf0000u ||
-            (rl_hi & 0xFFFF0000u) == 0xbadf0000u) {
-            uart_printf("[ga10b-reserve] runlist submit_base reads "
-                        "poison (lo=0x%08x hi=0x%08x) — wrong "
-                        "pri_base offset or GPU power-gated. Skipping.\n",
-                        (unsigned)rl_lo, (unsigned)rl_hi);
-        } else {
-            /* Decode: lo bits[31:10] are ptr bits[31:10] (1 KB-aligned).
-             * Mask off the low 10 bits, those carry target + flags. */
-            uint64_t runlist_phys =
-                ((uint64_t)(rl_lo & 0xfffffc00u)) |
-                ((uint64_t)(rl_hi & 0xffu) << 32);
-            uint32_t aperture = rl_lo & 0x3u;
-
-            /* Double-buffered 32 KiB → 64 KiB total. Page-round
-             * the size to ensure we cover both buffers even if
-             * the base isn't 64 KiB-aligned. */
-            const uint64_t runlist_bytes = 64u * 1024u;
-
-            if (!ga10b_phys_in_dram(runlist_phys, (size_t)runlist_bytes)) {
-                uart_printf("[ga10b-reserve] runlist phys=0x%lx (size=%llu, "
-                            "lo=0x%08x hi=0x%08x ap=%u) outside DRAM — "
-                            "skipping reservation. Either the pri_base "
-                            "offset is wrong or Linux's nvgpu hadn't "
-                            "programmed the runlist yet.\n",
-                            (unsigned long)runlist_phys,
-                            (unsigned long long)runlist_bytes,
-                            (unsigned)rl_lo, (unsigned)rl_hi,
-                            (unsigned)aperture);
-            } else {
-                uint64_t runlist_page_base = runlist_phys & ~4095ull;
-                uint64_t runlist_page_end =
-                    (runlist_phys + runlist_bytes + 4095ull) & ~4095ull;
-                uint64_t runlist_reserve_bytes =
-                    runlist_page_end - runlist_page_base;
-                if (pmm_user_reserve_add(runlist_page_base,
-                                          runlist_reserve_bytes) != 0) {
-                    uart_printf("[ga10b-reserve] pmm_user_reserve_add "
-                                "for runlist @0x%lx failed (table full)\n",
-                                (unsigned long)runlist_page_base);
-                } else {
-                    uart_printf("[ga10b-reserve] reserved GR runlist "
-                                "@0x%lx (%llu B, lo=0x%08x hi=0x%08x ap=%u)\n",
-                                (unsigned long)runlist_page_base,
-                                (unsigned long long)runlist_reserve_bytes,
-                                (unsigned)rl_lo, (unsigned)rl_hi,
-                                (unsigned)aperture);
-                }
-            }
-        }
-    }
-
-    /* #788 Stage 4 — scan DRAM for the handoff and reserve every
-     * weights-pool extent it lists. The IOVMM-stitched 1.5 GB
-     * weights pool is physically scattered across hundreds-to-
-     * thousands of contiguous runs; without reserving each run's
-     * pages, SLM-OS PMM allocates from those pages and the CE
-     * memcpy writes during W3 staging clobber whatever kernel
-     * data SLM-OS put there.
-     *
-     * The handoff itself lives somewhere in the 4-8 GB DRAM
-     * range (the helper's nvmap allocation lands wherever the
-     * IOVMM heap has room). Scanning at 4 KB stride is ~50 ms
-     * one-time-only at boot; acceptable cost for the protection.
-     *
-     * If the scan fails (no handoff found) we still finished the
-     * inst-block reservation above — a fresh-boot or no-helper
-     * test path that doesn't have a kexec'd channel works
-     * normally without the extents protection. */
-    uart_puts("[ga10b-reserve] scanning DRAM for handoff magic + "
-              "weights-pool extents...\n");
-    uint64_t handoff_phys =
-        ga10b_find_handoff_in_range(0x100000000ull, 0x200000000ull,
-                                     4096ull);
-    if (handoff_phys == 0) {
-        uart_puts("[ga10b-reserve]   handoff not found — skipping "
-                  "weights-pool extent reservation\n");
+    if ((rl_lo & 0xFFFF0000u) == 0xbadf0000u ||
+        (rl_hi & 0xFFFF0000u) == 0xbadf0000u) {
+        uart_printf("[ga10b-reserve] runlist submit_base reads "
+                    "poison (lo=0x%08x hi=0x%08x) — wrong "
+                    "pri_base offset or GPU power-gated. Skipping.\n",
+                    (unsigned)rl_lo, (unsigned)rl_hi);
         return;
     }
 
-    /* Reserve the handoff dmabuf page itself first (cheap + small). */
+    /* Decode: lo bits[31:10] are ptr bits[31:10] (1 KB-aligned).
+     * Mask off the low 10 bits, those carry target + flags. */
+    uint64_t runlist_phys =
+        ((uint64_t)(rl_lo & 0xfffffc00u)) |
+        ((uint64_t)(rl_hi & 0xffu) << 32);
+    uint32_t aperture = rl_lo & 0x3u;
+
+    /* Double-buffered 32 KiB → 64 KiB total. Page-round
+     * the size to ensure we cover both buffers even if
+     * the base isn't 64 KiB-aligned. */
+    const uint64_t runlist_bytes = 64u * 1024u;
+
+    if (!ga10b_phys_in_dram(runlist_phys, (size_t)runlist_bytes)) {
+        uart_printf("[ga10b-reserve] runlist phys=0x%lx (size=%llu, "
+                    "lo=0x%08x hi=0x%08x ap=%u) outside DRAM — "
+                    "skipping reservation. Either the pri_base "
+                    "offset is wrong or Linux's nvgpu hadn't "
+                    "programmed the runlist yet.\n",
+                    (unsigned long)runlist_phys,
+                    (unsigned long long)runlist_bytes,
+                    (unsigned)rl_lo, (unsigned)rl_hi,
+                    (unsigned)aperture);
+        return;
+    }
+
+    uint64_t runlist_page_base = runlist_phys & ~4095ull;
+    uint64_t runlist_page_end =
+        (runlist_phys + runlist_bytes + 4095ull) & ~4095ull;
+    uint64_t runlist_reserve_bytes =
+        runlist_page_end - runlist_page_base;
+    if (pmm_user_reserve_add(runlist_page_base,
+                              runlist_reserve_bytes) != 0) {
+        uart_printf("[ga10b-reserve] pmm_user_reserve_add "
+                    "for runlist @0x%lx failed (table full)\n",
+                    (unsigned long)runlist_page_base);
+    } else {
+        uart_printf("[ga10b-reserve] reserved GR runlist "
+                    "@0x%lx (%llu B, lo=0x%08x hi=0x%08x ap=%u)\n",
+                    (unsigned long)runlist_page_base,
+                    (unsigned long long)runlist_reserve_bytes,
+                    (unsigned)rl_lo, (unsigned)rl_hi,
+                    (unsigned)aperture);
+    }
+}
+
+/* Reserve the handoff dmabuf page itself — cheap + small (one 4 KB
+ * page), but without it PMM can clobber the handoff between boot
+ * and the first reader. */
+static void reserve_handoff_dmabuf(uint64_t handoff_phys)
+{
     if (pmm_user_reserve_add(handoff_phys & ~4095ull, 4096ull) != 0) {
         uart_printf("[ga10b-reserve]   pmm_user_reserve_add for "
                     "handoff page @0x%lx failed (table full?)\n",
@@ -300,311 +305,324 @@ void ga10b_kexec_handoff_register_reserves(void)
                     "@0x%lx (4 KB)\n",
                     (unsigned long)(handoff_phys & ~4095ull));
     }
-    const volatile struct ga10b_channel_handoff *h =
-        (const volatile struct ga10b_channel_handoff *)
-        (uintptr_t)handoff_phys;
-    uint32_t version = h->version;
-    uint32_t n_extents = h->weights_n_extents;
-    uint64_t extents_phys = h->weights_extents_phys;
+}
 
-#if 1  /* Stage 5 bisect B: only USERD + GPFIFO reserved */
-#define BISECT_B_USERD_GPFIFO_ONLY 1
-#else
-#define BISECT_B_USERD_GPFIFO_ONLY 0
-#endif
+/* Reserve every helper-allocated buffer the channel needs
+ * (USERD, GPFIFO, pushbuf, sem, SASS pool, cbuf, QMD pool).
+ * Without these, SLM-OS PMM can hand them out to its own
+ * allocations (e.g. the GMMU rebuild's page-table pages —
+ * Stage 4 maps a 1.5 GB weights pool which requires ~3 MB of
+ * PTE tables, way more PMM activity than the Stage 3
+ * single-page case), and the channel state gets clobbered.
+ * Stage 3 worked without these because the PTE-table footprint
+ * was tiny (a few pages); Stage 4's larger PTE footprint
+ * surfaced the latent collision.
+ *
+ * Each buffer is small + finite (max ~1 MB for SASS pool);
+ * collectively well under the PMM user-reserve table cap.
+ * Read the (volatile) handoff fields into locals first so the
+ * struct-initializer fits a static helper table cleanly. */
+static void reserve_helper_buffers(const volatile struct ga10b_channel_handoff *h)
+{
+    uint64_t userd_p   = h->userd_phys;
+    uint64_t gpfifo_p  = h->gpfifo_phys;
+    uint32_t gpfifo_e  = h->gpfifo_entries;
+    uint32_t gpfifo_es = h->gpfifo_entry_size;
+    uint64_t pushbuf_p = h->pushbuf_phys;
+    uint32_t pushbuf_s = h->pushbuf_size;
+    uint64_t sem_p     = h->semaphore_phys;
+    uint64_t shader_p  = h->shader_phys;
+    uint32_t shader_s  = h->shader_size;
+    uint64_t cbuf_p    = h->cbuf_phys;
+    uint32_t cbuf_s    = h->cbuf_size;
+    uint64_t qmd_p     = h->qmd_pool_phys;
+    uint32_t qmd_s     = h->qmd_pool_size_bytes;
 
-#if BISECT_B_USERD_GPFIFO_ONLY  /* Stage 5 bisect B: only USERD + GPFIFO */
-    /* Reserve every helper-allocated buffer the channel needs
-     * (USERD, GPFIFO, pushbuf, sem, SASS pool, cbuf, QMD pool).
-     * Without these, SLM-OS PMM can hand them out to its own
-     * allocations (e.g. the GMMU rebuild's page-table pages —
-     * Stage 4 maps a 1.5 GB weights pool which requires ~3 MB of
-     * PTE tables, way more PMM activity than the Stage 3
-     * single-page case), and the channel state gets clobbered.
-     * Stage 3 worked without these because the PTE-table footprint
-     * was tiny (a few pages); Stage 4's larger PTE footprint
-     * surfaced the latent collision.
-     *
-     * Each buffer is small + finite (max ~1 MB for SASS pool);
-     * collectively well under the PMM user-reserve table cap.
-     * Read the (volatile) handoff fields into locals first so the
-     * struct-initializer fits a static helper table cleanly. */
-    {
-        uint64_t userd_p   = h->userd_phys;
-        uint64_t gpfifo_p  = h->gpfifo_phys;
-        uint32_t gpfifo_e  = h->gpfifo_entries;
-        uint32_t gpfifo_es = h->gpfifo_entry_size;
-        uint64_t pushbuf_p = h->pushbuf_phys;
-        uint32_t pushbuf_s = h->pushbuf_size;
-        uint64_t sem_p     = h->semaphore_phys;
-        uint64_t shader_p  = h->shader_phys;
-        uint32_t shader_s  = h->shader_size;
-        uint64_t cbuf_p    = h->cbuf_phys;
-        uint32_t cbuf_s    = h->cbuf_size;
-        uint64_t qmd_p     = h->qmd_pool_phys;
-        uint32_t qmd_s     = h->qmd_pool_size_bytes;
-
-        struct {
-            const char *tag;
-            uint64_t phys;
-            uint64_t size;
-        } refs[] = {
-            /* Stage 7: full helper-buf reservation. Stage 4 was
-             * broken by pushbuf/sem reservation (bisect E/F);
-             * Stage 7 adds the runlist reservation above which
-             * should make the rebuild's PT-page allocations safe. */
-            { "userd",    userd_p,   4096 },
-            { "gpfifo",   gpfifo_p,  (uint64_t)gpfifo_e * (uint64_t)gpfifo_es },
-            { "pushbuf",  pushbuf_p, (uint64_t)pushbuf_s },
-            { "sem",      sem_p,     4096 },
-            { "shader",   shader_p,  (uint64_t)shader_s },
-            { "cbuf",     cbuf_p,    (uint64_t)cbuf_s },
-            { "qmd_pool", qmd_p,     (uint64_t)qmd_s },
-        };
-        for (size_t i = 0; i < sizeof(refs) / sizeof(refs[0]); i++) {
-            if (refs[i].phys == 0 || refs[i].size == 0) {
-                continue;
-            }
-            uint64_t base = refs[i].phys & ~4095ull;
-            uint64_t end  = (refs[i].phys + refs[i].size + 4095ull) &
-                            ~4095ull;
-            uint64_t sz   = end - base;
-            if (pmm_user_reserve_add(base, sz) != 0) {
-                uart_printf("[ga10b-reserve]   pmm_user_reserve_add "
-                            "for %s @0x%lx failed (table full?)\n",
-                            refs[i].tag, (unsigned long)base);
-            } else {
-                uart_printf("[ga10b-reserve]   reserved %s @0x%lx "
-                            "(%llu B)\n",
-                            refs[i].tag, (unsigned long)base,
-                            (unsigned long long)sz);
-            }
+    struct {
+        const char *tag;
+        uint64_t phys;
+        uint64_t size;
+    } refs[] = {
+        { "userd",    userd_p,   4096 },
+        { "gpfifo",   gpfifo_p,  (uint64_t)gpfifo_e * (uint64_t)gpfifo_es },
+        { "pushbuf",  pushbuf_p, (uint64_t)pushbuf_s },
+        { "sem",      sem_p,     4096 },
+        { "shader",   shader_p,  (uint64_t)shader_s },
+        { "cbuf",     cbuf_p,    (uint64_t)cbuf_s },
+        { "qmd_pool", qmd_p,     (uint64_t)qmd_s },
+    };
+    for (size_t i = 0; i < sizeof(refs) / sizeof(refs[0]); i++) {
+        if (refs[i].phys == 0 || refs[i].size == 0) {
+            continue;
+        }
+        uint64_t base = refs[i].phys & ~4095ull;
+        uint64_t end  = (refs[i].phys + refs[i].size + 4095ull) &
+                        ~4095ull;
+        uint64_t sz   = end - base;
+        if (pmm_user_reserve_add(base, sz) != 0) {
+            uart_printf("[ga10b-reserve]   pmm_user_reserve_add "
+                        "for %s @0x%lx failed (table full?)\n",
+                        refs[i].tag, (unsigned long)base);
+        } else {
+            uart_printf("[ga10b-reserve]   reserved %s @0x%lx "
+                        "(%llu B)\n",
+                        refs[i].tag, (unsigned long)base,
+                        (unsigned long long)sz);
         }
     }
-#else
-    uart_puts("[ga10b-reserve]   STAGE5-BISECT: helper-buffer reservations SKIPPED\n");
-#endif
+}
 
-    /* #788 Mode B fix — per-op shader reservation via GMMU walk.
-     *
-     * In v7+ mode the helper allocates each pipeline op's SASS as a
-     * separate nvmap dmabuf and publishes only the GPU VA in
-     * `pipeline_ops_phys[i].shader_gpu_va`. The single `h->shader_phys`
-     * is either 0 (v6/v7 publish path in gpu-launch-common.c) or
-     * covers only one shader buffer, so the existing helper-buf
-     * reservation block above doesn't protect the other shader pages.
-     *
-     * Stress-test Mode B (4/10 fails on post-Mode-A-fix run) is
-     * empty-SASS at op[0].shader_gpu_va — SLM-OS PMM clobbered the
-     * helper's shader pages before launch-kernel could fetch them.
-     *
-     * Fix: walk the GMMU starting from the inherited channel's inst
-     * block (h->inst_block_phys, populated by the Stage 9 helper-side
-     * fix) for each op[i].shader_gpu_va. Reserve the resulting leaf
-     * phys. Reads-only walk — no PMM allocations involved, so safe
-     * to run before `pmm_init`.
-     *
-     * Bounded by GA10B_PIPELINE_V7_MAX_OPS (51) — well under
-     * pmm_user_reserve_add table cap of 2048. */
-    if (h->pipeline_n_ops > 0u && h->pipeline_ops_phys != 0u &&
-        h->inst_block_phys != 0u) {
-        uint64_t ops_phys = h->pipeline_ops_phys;
-        uint32_t n_ops    = h->pipeline_n_ops;
-        uint64_t inst_phys_for_walk = h->inst_block_phys;
-
-        /* Bound check: cap at GA10B_PIPELINE_V7_MAX_OPS to match the
-         * dispatch path's enforced max. A bigger value in the handoff
-         * is a corruption signal, not a real op count. */
-        if (n_ops > 51u) {
-            uart_printf("[ga10b-reserve]   pipeline_n_ops=%u exceeds "
-                        "cap 51 — likely corrupt handoff; skipping "
-                        "per-op shader reservation\n",
-                        (unsigned)n_ops);
-        } else if (!ga10b_phys_in_dram(ops_phys,
-                                       (size_t)n_ops * 80u)) {
-            uart_printf("[ga10b-reserve]   pipeline_ops_phys=0x%lx "
-                        "(n=%u) outside DRAM — skipping per-op "
-                        "shader reservation\n",
-                        (unsigned long)ops_phys, (unsigned)n_ops);
-        } else {
-            /* Reserve the ops array page itself (cheap + small —
-             * single 4 KB page for ≤51 v7 ops × 80 B). Without this,
-             * SLM-OS PMM could clobber the ops array between boot
-             * and the launch-kernel command reading it. */
-            uint64_t ops_page_base = ops_phys & ~4095ull;
-            uint64_t ops_bytes     = (uint64_t)n_ops * 80ull;
-            uint64_t ops_page_end  =
-                (ops_phys + ops_bytes + 4095ull) & ~4095ull;
-            if (pmm_user_reserve_add(ops_page_base,
-                                      ops_page_end - ops_page_base) == 0) {
-                uart_printf("[ga10b-reserve]   reserved pipeline_ops "
-                            "@0x%lx (%llu B)\n",
-                            (unsigned long)ops_page_base,
-                            (unsigned long long)(ops_page_end - ops_page_base));
-            }
-
-            /* v7.1 path (commit b2b6c2dc+): the helper now publishes
-             * shader_phys + shader_size_bytes per op directly. No
-             * GMMU walking needed — read the values and reserve.
-             *
-             * Falls back to GMMU walk for older helpers (shader_phys=0)
-             * if h->inst_block_phys is available. The walk path is
-             * less reliable because the helper-side FECS read can
-             * catch a wrong channel (Xorg / nvgpu-internal) — but
-             * better than no per-op reservation at all.
-             *
-             * Dedup: mnist reuses 4 shaders across 8 ops, dedup by
-             * phys. Simple O(n²) linear scan, n ≤ 42 (v7.1 cap). */
-            const struct ga10b_pipeline_op_v7 *ops_v7 =
-                (const struct ga10b_pipeline_op_v7 *)(uintptr_t)ops_phys;
-            uint64_t reserved_phys[42];
-            uint32_t n_reserved = 0;
-            uint32_t n_direct = 0, n_walked = 0, n_walk_ok = 0;
-            for (uint32_t i = 0; i < n_ops; i++) {
-                uint64_t phys = 0;
-                uint64_t size_b = 0;
-
-                /* Prefer the explicit fields. Falls back to walk if
-                 * helper didn't populate them. */
-                if (ops_v7[i].shader_phys != 0 &&
-                    ops_v7[i].shader_size_bytes > 0) {
-                    phys   = ops_v7[i].shader_phys;
-                    size_b = (uint64_t)ops_v7[i].shader_size_bytes;
-                    n_direct++;
-                } else if (ops_v7[i].shader_gpu_va != 0) {
-                    n_walked++;
-                    struct ga10b_gmmu_walk_result wr;
-                    ga10b_gmmu_walk(inst_phys_for_walk,
-                                    ops_v7[i].shader_gpu_va, &wr);
-                    if (wr.status != GA10B_GMMU_WALK_OK) continue;
-                    n_walk_ok++;
-                    phys   = wr.leaf_phys;
-                    size_b = 4096u;  /* walk gives one page */
-                } else {
-                    continue;
-                }
-
-                uint64_t page_base = phys & ~4095ull;
-                uint64_t page_end  = (phys + size_b + 4095ull) & ~4095ull;
-                uint64_t reserve_bytes = page_end - page_base;
-                if (!ga10b_phys_in_dram(page_base, (size_t)reserve_bytes)) {
-                    continue;
-                }
-
-                /* Dedup */
-                bool seen = false;
-                for (uint32_t j = 0; j < n_reserved; j++) {
-                    if (reserved_phys[j] == page_base) {
-                        seen = true;
-                        break;
-                    }
-                }
-                if (seen) continue;
-
-                if (pmm_user_reserve_add(page_base,
-                                         reserve_bytes) != 0) {
-                    uart_printf("[ga10b-reserve]   per-op shader: "
-                                "pmm_user_reserve_add(0x%lx, %llu) failed — "
-                                "table full, op %u/%u uncovered\n",
-                                (unsigned long)page_base,
-                                (unsigned long long)reserve_bytes,
-                                (unsigned)i, (unsigned)n_ops);
-                    break;
-                }
-                reserved_phys[n_reserved++] = page_base;
-            }
-            uart_printf("[ga10b-reserve]   per-op shader (v7.1): "
-                        "%u direct, %u walked (%u ok), %u unique "
-                        "reservations\n",
-                        (unsigned)n_direct, (unsigned)n_walked,
-                        (unsigned)n_walk_ok, (unsigned)n_reserved);
-        }
-    } else {
+/* #788 Mode B fix — per-op shader reservation.
+ *
+ * In v7+ mode the helper allocates each pipeline op's SASS as a
+ * separate nvmap dmabuf and publishes only the GPU VA in
+ * `pipeline_ops_phys[i].shader_gpu_va`. The single `h->shader_phys`
+ * is either 0 (v6/v7 publish path in gpu-launch-common.c) or
+ * covers only one shader buffer, so the existing helper-buf
+ * reservation block above doesn't protect the other shader pages.
+ *
+ * Stress-test Mode B (4/10 fails on post-Mode-A-fix run) is
+ * empty-SASS at op[0].shader_gpu_va — SLM-OS PMM clobbered the
+ * helper's shader pages before launch-kernel could fetch them.
+ *
+ * Prefers `ops_v7[i].shader_phys` (helper publishes since b2b6c2dc);
+ * falls back to GMMU walk via `h->inst_block_phys` for older helpers.
+ *
+ * Bounded by GA10B_PIPELINE_V7_MAX_OPS — well under
+ * pmm_user_reserve_add table cap of 2048. */
+static void reserve_per_op_shaders(const volatile struct ga10b_channel_handoff *h)
+{
+    if (!(h->pipeline_n_ops > 0u && h->pipeline_ops_phys != 0u &&
+        h->inst_block_phys != 0u)) {
         uart_printf("[ga10b-reserve]   per-op shader reservation skipped "
                     "(n_ops=%u ops_phys=0x%lx inst_block_phys=0x%lx)\n",
                     (unsigned)h->pipeline_n_ops,
                     (unsigned long)h->pipeline_ops_phys,
                     (unsigned long)h->inst_block_phys);
+        return;
     }
 
-    /* v10 (#788 Mode C fix): per-channel GR context buffer reservation.
+    uint64_t ops_phys = h->pipeline_ops_phys;
+    uint32_t n_ops    = h->pipeline_n_ops;
+    uint64_t inst_phys_for_walk = h->inst_block_phys;
+
+    /* Bound check: cap at GA10B_PIPELINE_V7_MAX_OPS to match the
+     * dispatch path's enforced max. A bigger value in the handoff
+     * is a corruption signal, not a real op count. */
+    if (n_ops > GA10B_PIPELINE_V7_MAX_OPS) {
+        uart_printf("[ga10b-reserve]   pipeline_n_ops=%u exceeds "
+                    "cap %u — likely corrupt handoff; skipping "
+                    "per-op shader reservation\n",
+                    (unsigned)n_ops,
+                    (unsigned)GA10B_PIPELINE_V7_MAX_OPS);
+        return;
+    }
+    if (!ga10b_phys_in_dram(ops_phys, (size_t)n_ops * 80u)) {
+        uart_printf("[ga10b-reserve]   pipeline_ops_phys=0x%lx "
+                    "(n=%u) outside DRAM — skipping per-op "
+                    "shader reservation\n",
+                    (unsigned long)ops_phys, (unsigned)n_ops);
+        return;
+    }
+
+    /* Reserve the ops array page itself (cheap + small — single
+     * 4 KB page for ≤GA10B_PIPELINE_V7_MAX_OPS v7 ops × 80 B).
+     * Without this, SLM-OS PMM could clobber the ops array between
+     * boot and the launch-kernel command reading it. */
+    uint64_t ops_page_base = ops_phys & ~4095ull;
+    uint64_t ops_bytes     = (uint64_t)n_ops * 80ull;
+    uint64_t ops_page_end  =
+        (ops_phys + ops_bytes + 4095ull) & ~4095ull;
+    if (pmm_user_reserve_add(ops_page_base,
+                              ops_page_end - ops_page_base) == 0) {
+        uart_printf("[ga10b-reserve]   reserved pipeline_ops "
+                    "@0x%lx (%llu B)\n",
+                    (unsigned long)ops_page_base,
+                    (unsigned long long)(ops_page_end - ops_page_base));
+    }
+
+    /* v7.1 path (commit b2b6c2dc+): the helper now publishes
+     * shader_phys + shader_size_bytes per op directly. No
+     * GMMU walking needed — read the values and reserve.
      *
-     * The helper read /sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys
-     * (exposed by a patched nvgpu.ko) and published every active
-     * channel's GR context buffer phys ranges in an extents array.
-     * Each entry covers one channel-internal GR buffer (main ctx,
-     * patch ctx, etc.). Without this, SLM-OS PMM clobbers the
-     * buffers and FECS hits mb6=0x5a on context-load. */
-    {
-        uint64_t gr_ctx_extents_phys = h->gr_ctx_extents_phys;
-        uint32_t gr_ctx_n_extents    = h->gr_ctx_n_extents;
-        if (gr_ctx_extents_phys != 0 && gr_ctx_n_extents > 0) {
-            uint64_t gr_extents_bytes =
-                (uint64_t)gr_ctx_n_extents *
-                sizeof(struct ga10b_phys_extent);
-            if (!ga10b_phys_in_dram(gr_ctx_extents_phys,
-                                    (size_t)gr_extents_bytes)) {
-                uart_printf("[ga10b-reserve]   gr_ctx_extents_phys=0x%lx "
-                            "(n=%u) outside DRAM — skipping gr_ctx "
-                            "reservation\n",
-                            (unsigned long)gr_ctx_extents_phys,
-                            (unsigned)gr_ctx_n_extents);
-            } else {
-                /* Reserve the extents-array dmabuf itself */
-                uint64_t arr_page_base = gr_ctx_extents_phys & ~4095ull;
-                uint64_t arr_page_end  =
-                    (gr_ctx_extents_phys + gr_extents_bytes + 4095ull) &
-                    ~4095ull;
-                if (pmm_user_reserve_add(arr_page_base,
-                                          arr_page_end - arr_page_base) == 0) {
-                    uart_printf("[ga10b-reserve]   reserved gr_ctx_extents "
-                                "array @0x%lx\n",
-                                (unsigned long)arr_page_base);
-                }
+     * Falls back to GMMU walk for older helpers (shader_phys=0)
+     * if h->inst_block_phys is available. The walk path is
+     * less reliable because the helper-side FECS read can
+     * catch a wrong channel (Xorg / nvgpu-internal) — but
+     * better than no per-op reservation at all.
+     *
+     * Dedup: mnist reuses 4 shaders across 8 ops, dedup by
+     * phys. Simple O(n²) linear scan, n ≤ GA10B_PIPELINE_V7_MAX_OPS. */
+    const struct ga10b_pipeline_op_v7 *ops_v7 =
+        (const struct ga10b_pipeline_op_v7 *)(uintptr_t)ops_phys;
+    uint64_t reserved_phys[GA10B_PIPELINE_V7_MAX_OPS];
+    uint32_t n_reserved = 0;
+    uint32_t n_direct = 0, n_walked = 0, n_walk_ok = 0;
+    for (uint32_t i = 0; i < n_ops; i++) {
+        uint64_t phys = 0;
+        uint64_t size_b = 0;
 
-                /* Reserve every entry. */
-                const struct ga10b_phys_extent *gr_exts =
-                    (const struct ga10b_phys_extent *)(uintptr_t)
-                    gr_ctx_extents_phys;
-                int gr_reserved = 0, gr_skipped = 0;
-                uint64_t gr_total_bytes = 0;
-                for (uint32_t i = 0; i < gr_ctx_n_extents; i++) {
-                    uint64_t ph = gr_exts[i].phys;
-                    uint32_t np = gr_exts[i].n_pages;
-                    if (np == 0u) continue;
-                    uint64_t sz = (uint64_t)np * 4096ull;
-                    if (!ga10b_phys_in_dram(ph, sz)) {
-                        gr_skipped++;
-                        continue;
-                    }
-                    if (pmm_user_reserve_add(ph, sz) != 0) {
-                        uart_printf("[ga10b-reserve]   gr_ctx reserve "
-                                    "table full at extent %u/%u\n",
-                                    (unsigned)i, (unsigned)gr_ctx_n_extents);
-                        break;
-                    }
-                    gr_reserved++;
-                    gr_total_bytes += sz;
-                }
-                uart_printf("[ga10b-reserve]   gr_ctx: %u extents reserved "
-                            "(%llu KB total), %u skipped\n",
-                            (unsigned)gr_reserved,
-                            (unsigned long long)(gr_total_bytes / 1024ull),
-                            (unsigned)gr_skipped);
-            }
+        /* Prefer the explicit fields. Falls back to walk if
+         * helper didn't populate them. */
+        if (ops_v7[i].shader_phys != 0 &&
+            ops_v7[i].shader_size_bytes > 0) {
+            phys   = ops_v7[i].shader_phys;
+            size_b = (uint64_t)ops_v7[i].shader_size_bytes;
+            n_direct++;
+        } else if (ops_v7[i].shader_gpu_va != 0) {
+            n_walked++;
+            struct ga10b_gmmu_walk_result wr;
+            ga10b_gmmu_walk(inst_phys_for_walk,
+                            ops_v7[i].shader_gpu_va, &wr);
+            if (wr.status != GA10B_GMMU_WALK_OK) continue;
+            n_walk_ok++;
+            phys   = wr.leaf_phys;
+            size_b = 4096u;  /* walk gives one page */
         } else {
-            uart_printf("[ga10b-reserve]   gr_ctx reservation skipped "
-                        "(extents_phys=0x%lx n=%u — helper didn't publish, "
-                        "older or non-patched nvgpu)\n",
-                        (unsigned long)gr_ctx_extents_phys,
-                        (unsigned)gr_ctx_n_extents);
+            continue;
         }
+
+        uint64_t page_base = phys & ~4095ull;
+        uint64_t page_end  = (phys + size_b + 4095ull) & ~4095ull;
+        uint64_t reserve_bytes = page_end - page_base;
+        if (!ga10b_phys_in_dram(page_base, (size_t)reserve_bytes)) {
+            continue;
+        }
+
+        /* Dedup */
+        bool seen = false;
+        for (uint32_t j = 0; j < n_reserved; j++) {
+            if (reserved_phys[j] == page_base) {
+                seen = true;
+                break;
+            }
+        }
+        if (seen) continue;
+
+        if (pmm_user_reserve_add(page_base,
+                                 reserve_bytes) != 0) {
+            uart_printf("[ga10b-reserve]   per-op shader: "
+                        "pmm_user_reserve_add(0x%lx, %llu) failed — "
+                        "table full, op %u/%u uncovered\n",
+                        (unsigned long)page_base,
+                        (unsigned long long)reserve_bytes,
+                        (unsigned)i, (unsigned)n_ops);
+            break;
+        }
+        reserved_phys[n_reserved++] = page_base;
     }
+    uart_printf("[ga10b-reserve]   per-op shader (v7.1): "
+                "%u direct, %u walked (%u ok), %u unique "
+                "reservations\n",
+                (unsigned)n_direct, (unsigned)n_walked,
+                (unsigned)n_walk_ok, (unsigned)n_reserved);
+}
+
+/* v10 (#788 Mode C fix): per-channel GR context buffer reservation.
+ *
+ * The helper reads /sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys
+ * (exposed by the patched nvgpu.ko — see file header) and publishes
+ * every active channel's GR context buffer phys ranges in an
+ * extents array. Each entry covers one channel-internal GR buffer
+ * (main ctx, patch ctx, etc.). Without this, SLM-OS PMM clobbers
+ * the buffers and FECS hits mb6=0x5a on context-load. */
+static void reserve_gr_ctx_extents(const volatile struct ga10b_channel_handoff *h)
+{
+    uint64_t gr_ctx_extents_phys = h->gr_ctx_extents_phys;
+    uint32_t gr_ctx_n_extents    = h->gr_ctx_n_extents;
+    if (gr_ctx_extents_phys == 0 || gr_ctx_n_extents == 0) {
+        uart_printf("[ga10b-reserve]   gr_ctx reservation skipped "
+                    "(extents_phys=0x%lx n=%u — helper didn't publish, "
+                    "older or non-patched nvgpu)\n",
+                    (unsigned long)gr_ctx_extents_phys,
+                    (unsigned)gr_ctx_n_extents);
+        return;
+    }
+
+    uint64_t gr_extents_bytes =
+        (uint64_t)gr_ctx_n_extents *
+        sizeof(struct ga10b_phys_extent);
+    if (!ga10b_phys_in_dram(gr_ctx_extents_phys,
+                            (size_t)gr_extents_bytes)) {
+        uart_printf("[ga10b-reserve]   gr_ctx_extents_phys=0x%lx "
+                    "(n=%u) outside DRAM — skipping gr_ctx "
+                    "reservation\n",
+                    (unsigned long)gr_ctx_extents_phys,
+                    (unsigned)gr_ctx_n_extents);
+        return;
+    }
+
+    /* Reserve the extents-array dmabuf itself */
+    uint64_t arr_page_base = gr_ctx_extents_phys & ~4095ull;
+    uint64_t arr_page_end  =
+        (gr_ctx_extents_phys + gr_extents_bytes + 4095ull) &
+        ~4095ull;
+    if (pmm_user_reserve_add(arr_page_base,
+                              arr_page_end - arr_page_base) == 0) {
+        uart_printf("[ga10b-reserve]   reserved gr_ctx_extents "
+                    "array @0x%lx\n",
+                    (unsigned long)arr_page_base);
+    }
+
+    /* Reserve every entry. */
+    const struct ga10b_phys_extent *gr_exts =
+        (const struct ga10b_phys_extent *)(uintptr_t)
+        gr_ctx_extents_phys;
+    int gr_reserved = 0, gr_skipped = 0;
+    uint64_t gr_total_bytes = 0;
+    for (uint32_t i = 0; i < gr_ctx_n_extents; i++) {
+        uint64_t ph = gr_exts[i].phys;
+        uint32_t np = gr_exts[i].n_pages;
+        if (np == 0u) continue;
+        uint64_t sz = (uint64_t)np * 4096ull;
+        if (!ga10b_phys_in_dram(ph, sz)) {
+            gr_skipped++;
+            continue;
+        }
+        if (pmm_user_reserve_add(ph, sz) != 0) {
+            uart_printf("[ga10b-reserve]   gr_ctx reserve "
+                        "table full at extent %u/%u\n",
+                        (unsigned)i, (unsigned)gr_ctx_n_extents);
+            break;
+        }
+        gr_reserved++;
+        gr_total_bytes += sz;
+    }
+    uart_printf("[ga10b-reserve]   gr_ctx: %u extents reserved "
+                "(%llu KB total), %u skipped\n",
+                (unsigned)gr_reserved,
+                (unsigned long long)(gr_total_bytes / 1024ull),
+                (unsigned)gr_skipped);
+}
+
+/* #788 Stage 4 — reserve every weights-pool extent the handoff lists.
+ *
+ * The IOVMM-stitched 1.5 GB weights pool is physically scattered
+ * across hundreds-to-thousands of contiguous runs; without
+ * reserving each run's pages, SLM-OS PMM allocates from those
+ * pages and the CE memcpy writes during W3 staging clobber
+ * whatever kernel data SLM-OS put there.
+ *
+ * Also reserves the extents dmabuf itself (can be 100s of KB for
+ * a fragmented IOVMM allocation; up to 128 KB at
+ * GA10B_WEIGHTS_EXTENTS_MAX × 16 B). Without that, SLM-OS PMM
+ * easily hands those pages to ramdisk allocations or model
+ * preload buffers, and by rebuild-time the extents array reads
+ * as random bytes.
+ *
+ * `handoff_phys_for_log` is the dmabuf phys carried through only
+ * for the trailing log line — no functional dependence. */
+static void reserve_weights_extents(const volatile struct ga10b_channel_handoff *h,
+                                    uint64_t handoff_phys_for_log)
+{
+    uint32_t version = h->version;
+    uint32_t n_extents = h->weights_n_extents;
+    uint64_t extents_phys = h->weights_extents_phys;
 
     if (version < 9u || n_extents == 0u || extents_phys == 0u) {
         uart_printf("[ga10b-reserve]   handoff@0x%lx v=%u no v9 "
                     "extents (n=%u extents_phys=0x%lx) — skipping\n",
-                    (unsigned long)handoff_phys, (unsigned)version,
+                    (unsigned long)handoff_phys_for_log, (unsigned)version,
                     (unsigned)n_extents, (unsigned long)extents_phys);
         return;
     }
@@ -617,32 +635,24 @@ void ga10b_kexec_handoff_register_reserves(void)
         return;
     }
 
-    /* Reserve the extents dmabuf itself so PMM doesn't allocate
-     * from it before the rebuild path reads it. The dmabuf can
-     * be 100s of KB for a fragmented IOVMM allocation (1033
-     * extents × 16 B = 16 KB; capped at GA10B_WEIGHTS_EXTENTS_MAX
-     * × 16 B = 128 KB), much larger than the inst-block page or
-     * handoff dmabuf — without explicit reservation, SLM-OS PMM
-     * easily hands those pages to ramdisk allocations or model
-     * preload buffers, and by rebuild-time the extents array
-     * reads as random bytes. */
-    {
-        uint64_t extents_page_base = extents_phys & ~4095ull;
-        uint64_t extents_page_end =
-            (extents_phys + extents_bytes + 4095ull) & ~4095ull;
-        uint64_t extents_reserve_bytes =
-            extents_page_end - extents_page_base;
-        if (pmm_user_reserve_add(extents_page_base,
-                                  extents_reserve_bytes) != 0) {
-            uart_printf("[ga10b-reserve]   pmm_user_reserve_add for "
-                        "extents dmabuf failed — array will be at "
-                        "risk of clobber between boot and rebuild\n");
-        } else {
-            uart_printf("[ga10b-reserve]   reserved extents dmabuf "
-                        "@0x%lx (%llu B)\n",
-                        (unsigned long)extents_page_base,
-                        (unsigned long long)extents_reserve_bytes);
-        }
+    /* Reserve the extents dmabuf itself first so the array doesn't
+     * get clobbered between this boot stage and the rebuild path
+     * that reads it later. */
+    uint64_t extents_page_base = extents_phys & ~4095ull;
+    uint64_t extents_page_end =
+        (extents_phys + extents_bytes + 4095ull) & ~4095ull;
+    uint64_t extents_reserve_bytes =
+        extents_page_end - extents_page_base;
+    if (pmm_user_reserve_add(extents_page_base,
+                              extents_reserve_bytes) != 0) {
+        uart_printf("[ga10b-reserve]   pmm_user_reserve_add for "
+                    "extents dmabuf failed — array will be at "
+                    "risk of clobber between boot and rebuild\n");
+    } else {
+        uart_printf("[ga10b-reserve]   reserved extents dmabuf "
+                    "@0x%lx (%llu B)\n",
+                    (unsigned long)extents_page_base,
+                    (unsigned long long)extents_reserve_bytes);
     }
 
     const struct ga10b_phys_extent *exts =
@@ -678,7 +688,52 @@ void ga10b_kexec_handoff_register_reserves(void)
                 (unsigned long long)total_pages,
                 (unsigned long long)(total_pages / 256ull),
                 (unsigned)skipped_count,
-                (unsigned long)handoff_phys);
+                (unsigned long)handoff_phys_for_log);
+}
+
+/* ---------------------------------------------------------------
+ * Orchestrator.
+ * --------------------------------------------------------------- */
+
+void ga10b_kexec_handoff_register_reserves(void)
+{
+    /* Always-on phase: read FECS_CURRENT_CTX and reserve the
+     * channel's inst block. If this skip-returns (poison MMIO,
+     * target=0 fresh boot, outside-DRAM, PMM table full), the rest
+     * of the handoff machinery is meaningless — no kexec'd channel
+     * to protect. */
+    if (!reserve_inst_block()) {
+        return;
+    }
+
+    reserve_runlist();
+
+    /* Handoff-dependent phase: locate the helper-published handoff
+     * dmabuf in DRAM by scanning for its magic. ~50 ms one-time-only
+     * boot cost. A fresh-boot or no-helper test path that doesn't
+     * have a kexec'd channel works fine without these reservations —
+     * just leaves PMM with more pages to allocate from. */
+    uart_puts("[ga10b-reserve] scanning DRAM for handoff magic + "
+              "weights-pool extents...\n");
+    uint64_t handoff_phys =
+        ga10b_find_handoff_in_range(0x100000000ull, 0x200000000ull,
+                                     4096ull);
+    if (handoff_phys == 0) {
+        uart_puts("[ga10b-reserve]   handoff not found — skipping "
+                  "weights-pool extent reservation\n");
+        return;
+    }
+
+    reserve_handoff_dmabuf(handoff_phys);
+
+    const volatile struct ga10b_channel_handoff *h =
+        (const volatile struct ga10b_channel_handoff *)
+        (uintptr_t)handoff_phys;
+
+    reserve_helper_buffers(h);
+    reserve_per_op_shaders(h);
+    reserve_gr_ctx_extents(h);
+    reserve_weights_extents(h, handoff_phys);
 }
 
 uint64_t ga10b_kexec_inherited_inst_block_phys(void)

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -80,6 +80,21 @@
  * Ampere, both sites need updating in lock-step. */
 #define GA10B_INST_BLOCK_BYTES 4096u
 
+/* Boot-time capture of the kexec'd channel's inst-block phys. Read
+ * from FECS_CURRENT_CTX in `ga10b_kexec_handoff_register_reserves`
+ * BEFORE any other SLM-OS GPU MMIO touches FECS. The live
+ * FECS_CURRENT_CTX register drifts after kexec — SLM-OS's own
+ * subsequent GPU probes (nvgpu inherit / channel / submit) trigger
+ * FECS context switches to other channels Linux had loaded, and
+ * the helper-published handoff doesn't carry an inst_block_phys
+ * field. So this is the single authoritative copy of "which inst
+ * block did Linux just leave on the GR engine when we kexec'd."
+ *
+ * Exposed via `ga10b_kexec_inherited_inst_block_phys()` for the
+ * `nvgpu oplib stage` shell verb (and any future caller that needs
+ * to dereference the inherited channel's GMMU after FECS has drifted). */
+static uint64_t g_boot_inst_block_phys = 0;
+
 void ga10b_kexec_handoff_register_reserves(void)
 {
     /* Read FECS_CURRENT_CTX directly via the identity mapping that
@@ -139,6 +154,15 @@ void ga10b_kexec_handoff_register_reserves(void)
                     (unsigned)GA10B_INST_BLOCK_BYTES, rc);
         return;
     }
+
+    /* Save the verified inst_phys for the inherited-inst-block
+     * accessor — the only point in boot where FECS_CURRENT_CTX is
+     * guaranteed to still hold Linux's last-active channel pointer.
+     * Future GPU MMIO touches by SLM-OS can ctx-switch FECS away
+     * from this channel; callers that need to drive the inherited
+     * channel later (e.g. `nvgpu oplib stage` for SASS upload)
+     * must read this stashed value, not the live register. */
+    g_boot_inst_block_phys = inst_phys;
 
     uart_printf("[ga10b-reserve] reserved kexec'd channel inst block "
                 "at phys=0x%lx (size=%u, FECS_CURRENT_CTX=0x%08x, "
@@ -440,6 +464,11 @@ void ga10b_kexec_handoff_register_reserves(void)
                 (unsigned long)handoff_phys);
 }
 
+uint64_t ga10b_kexec_inherited_inst_block_phys(void)
+{
+    return g_boot_inst_block_phys;
+}
+
 #else  /* !PLATFORM_JETSON_ORIN_NANO */
 
 /* No-op stub for non-Jetson platforms. The header's documentation
@@ -449,6 +478,16 @@ void ga10b_kexec_handoff_register_reserves(void)
  * the call entirely at LTO time. */
 void ga10b_kexec_handoff_register_reserves(void)
 {
+}
+
+/* Non-Jetson stub: no kexec channel-inheritance on this platform,
+ * so the inherited inst-block is meaningless. Return 0 to signal
+ * "no boot capture" — callers must already handle that case (the
+ * Jetson implementation also returns 0 on fresh boots / poisoned
+ * FECS reads). */
+uint64_t ga10b_kexec_inherited_inst_block_phys(void)
+{
+    return 0;
 }
 
 #endif

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -443,74 +443,81 @@ void ga10b_kexec_handoff_register_reserves(void)
                             (unsigned long long)(ops_page_end - ops_page_base));
             }
 
-            /* Walk each op's shader_gpu_va. Dedup: same shader_gpu_va
-             * across multiple ops (mnist reuses 4 shaders across 8
-             * ops) → only reserve once. Simple linear scan over the
-             * reserved-so-far list is O(n²) but n≤51 so it's fine. */
+            /* v7.1 path (commit b2b6c2dc+): the helper now publishes
+             * shader_phys + shader_size_bytes per op directly. No
+             * GMMU walking needed — read the values and reserve.
+             *
+             * Falls back to GMMU walk for older helpers (shader_phys=0)
+             * if h->inst_block_phys is available. The walk path is
+             * less reliable because the helper-side FECS read can
+             * catch a wrong channel (Xorg / nvgpu-internal) — but
+             * better than no per-op reservation at all.
+             *
+             * Dedup: mnist reuses 4 shaders across 8 ops, dedup by
+             * phys. Simple O(n²) linear scan, n ≤ 42 (v7.1 cap). */
             const struct ga10b_pipeline_op_v7 *ops_v7 =
                 (const struct ga10b_pipeline_op_v7 *)(uintptr_t)ops_phys;
-            uint64_t reserved_phys[51];
+            uint64_t reserved_phys[42];
             uint32_t n_reserved = 0;
-            uint32_t n_walked = 0, n_walk_ok = 0, n_reserved_now = 0;
+            uint32_t n_direct = 0, n_walked = 0, n_walk_ok = 0;
             for (uint32_t i = 0; i < n_ops; i++) {
-                uint64_t gva = ops_v7[i].shader_gpu_va;
-                if (gva == 0u) continue;
-                n_walked++;
-                struct ga10b_gmmu_walk_result wr;
-                ga10b_gmmu_walk(inst_phys_for_walk, gva, &wr);
-                if (wr.status != GA10B_GMMU_WALK_OK) continue;
-                n_walk_ok++;
+                uint64_t phys = 0;
+                uint64_t size_b = 0;
 
-                uint64_t shader_phys_pg = wr.leaf_phys & ~4095ull;
-                if (!ga10b_phys_in_dram(shader_phys_pg, 4096)) continue;
+                /* Prefer the explicit fields. Falls back to walk if
+                 * helper didn't populate them. */
+                if (ops_v7[i].shader_phys != 0 &&
+                    ops_v7[i].shader_size_bytes > 0) {
+                    phys   = ops_v7[i].shader_phys;
+                    size_b = (uint64_t)ops_v7[i].shader_size_bytes;
+                    n_direct++;
+                } else if (ops_v7[i].shader_gpu_va != 0) {
+                    n_walked++;
+                    struct ga10b_gmmu_walk_result wr;
+                    ga10b_gmmu_walk(inst_phys_for_walk,
+                                    ops_v7[i].shader_gpu_va, &wr);
+                    if (wr.status != GA10B_GMMU_WALK_OK) continue;
+                    n_walk_ok++;
+                    phys   = wr.leaf_phys;
+                    size_b = 4096u;  /* walk gives one page */
+                } else {
+                    continue;
+                }
+
+                uint64_t page_base = phys & ~4095ull;
+                uint64_t page_end  = (phys + size_b + 4095ull) & ~4095ull;
+                uint64_t reserve_bytes = page_end - page_base;
+                if (!ga10b_phys_in_dram(page_base, (size_t)reserve_bytes)) {
+                    continue;
+                }
 
                 /* Dedup */
                 bool seen = false;
                 for (uint32_t j = 0; j < n_reserved; j++) {
-                    if (reserved_phys[j] == shader_phys_pg) {
+                    if (reserved_phys[j] == page_base) {
                         seen = true;
                         break;
                     }
                 }
                 if (seen) continue;
 
-                /* Reserve only the leaf phys page (4 KB). The shader
-                 * dmabuf may be larger (up to 64 KB) but its
-                 * underlying phys pages are scattered (nvmap maps
-                 * non-contiguous phys to contiguous iova). Reserving
-                 * more than 4 KB from `leaf_phys` overruns into
-                 * neighbor phys which may belong to FECS ctx_save
-                 * state — observed empirically as the
-                 * `ctxsw_checksum_mismatch` (mb6=0x21) failure that
-                 * Stage 9 Mode D fix surfaced when this was 64 KB.
-                 *
-                 * Covering the tail of multi-page shaders requires
-                 * walking shader_gpu_va + 4096, + 8192, ... separately.
-                 * The simple 1-page reservation is sufficient for
-                 * mnist's largest shader (gemm at ~5-20 KB
-                 * is at most 5 pages, so first-page reservation
-                 * catches op[0]'s SM PC at SM entry — the most
-                 * common Mode B fault location). Multi-page walk is
-                 * Stage 11 work; for now first-page coverage
-                 * empirically eliminates ~50% of Mode B. */
-                const uint64_t reserve_bytes = 4096u;
-                if (pmm_user_reserve_add(shader_phys_pg,
+                if (pmm_user_reserve_add(page_base,
                                          reserve_bytes) != 0) {
                     uart_printf("[ga10b-reserve]   per-op shader: "
-                                "pmm_user_reserve_add(0x%lx) failed — "
+                                "pmm_user_reserve_add(0x%lx, %llu) failed — "
                                 "table full, op %u/%u uncovered\n",
-                                (unsigned long)shader_phys_pg,
+                                (unsigned long)page_base,
+                                (unsigned long long)reserve_bytes,
                                 (unsigned)i, (unsigned)n_ops);
                     break;
                 }
-                reserved_phys[n_reserved++] = shader_phys_pg;
-                n_reserved_now++;
+                reserved_phys[n_reserved++] = page_base;
             }
-            uart_printf("[ga10b-reserve]   per-op shader: %u walked, "
-                        "%u walk_ok, %u unique reservations (inst=0x%lx)\n",
-                        (unsigned)n_walked, (unsigned)n_walk_ok,
-                        (unsigned)n_reserved_now,
-                        (unsigned long)inst_phys_for_walk);
+            uart_printf("[ga10b-reserve]   per-op shader (v7.1): "
+                        "%u direct, %u walked (%u ok), %u unique "
+                        "reservations\n",
+                        (unsigned)n_direct, (unsigned)n_walked,
+                        (unsigned)n_walk_ok, (unsigned)n_reserved);
         }
     } else {
         uart_printf("[ga10b-reserve]   per-op shader reservation skipped "

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -384,6 +384,142 @@ void ga10b_kexec_handoff_register_reserves(void)
 #else
     uart_puts("[ga10b-reserve]   STAGE5-BISECT: helper-buffer reservations SKIPPED\n");
 #endif
+
+    /* #788 Mode B fix — per-op shader reservation via GMMU walk.
+     *
+     * In v7+ mode the helper allocates each pipeline op's SASS as a
+     * separate nvmap dmabuf and publishes only the GPU VA in
+     * `pipeline_ops_phys[i].shader_gpu_va`. The single `h->shader_phys`
+     * is either 0 (v6/v7 publish path in gpu-launch-common.c) or
+     * covers only one shader buffer, so the existing helper-buf
+     * reservation block above doesn't protect the other shader pages.
+     *
+     * Stress-test Mode B (4/10 fails on post-Mode-A-fix run) is
+     * empty-SASS at op[0].shader_gpu_va — SLM-OS PMM clobbered the
+     * helper's shader pages before launch-kernel could fetch them.
+     *
+     * Fix: walk the GMMU starting from the inherited channel's inst
+     * block (h->inst_block_phys, populated by the Stage 9 helper-side
+     * fix) for each op[i].shader_gpu_va. Reserve the resulting leaf
+     * phys. Reads-only walk — no PMM allocations involved, so safe
+     * to run before `pmm_init`.
+     *
+     * Bounded by GA10B_PIPELINE_V7_MAX_OPS (51) — well under
+     * pmm_user_reserve_add table cap of 2048. */
+    if (h->pipeline_n_ops > 0u && h->pipeline_ops_phys != 0u &&
+        h->inst_block_phys != 0u) {
+        uint64_t ops_phys = h->pipeline_ops_phys;
+        uint32_t n_ops    = h->pipeline_n_ops;
+        uint64_t inst_phys_for_walk = h->inst_block_phys;
+
+        /* Bound check: cap at GA10B_PIPELINE_V7_MAX_OPS to match the
+         * dispatch path's enforced max. A bigger value in the handoff
+         * is a corruption signal, not a real op count. */
+        if (n_ops > 51u) {
+            uart_printf("[ga10b-reserve]   pipeline_n_ops=%u exceeds "
+                        "cap 51 — likely corrupt handoff; skipping "
+                        "per-op shader reservation\n",
+                        (unsigned)n_ops);
+        } else if (!ga10b_phys_in_dram(ops_phys,
+                                       (size_t)n_ops * 80u)) {
+            uart_printf("[ga10b-reserve]   pipeline_ops_phys=0x%lx "
+                        "(n=%u) outside DRAM — skipping per-op "
+                        "shader reservation\n",
+                        (unsigned long)ops_phys, (unsigned)n_ops);
+        } else {
+            /* Reserve the ops array page itself (cheap + small —
+             * single 4 KB page for ≤51 v7 ops × 80 B). Without this,
+             * SLM-OS PMM could clobber the ops array between boot
+             * and the launch-kernel command reading it. */
+            uint64_t ops_page_base = ops_phys & ~4095ull;
+            uint64_t ops_bytes     = (uint64_t)n_ops * 80ull;
+            uint64_t ops_page_end  =
+                (ops_phys + ops_bytes + 4095ull) & ~4095ull;
+            if (pmm_user_reserve_add(ops_page_base,
+                                      ops_page_end - ops_page_base) == 0) {
+                uart_printf("[ga10b-reserve]   reserved pipeline_ops "
+                            "@0x%lx (%llu B)\n",
+                            (unsigned long)ops_page_base,
+                            (unsigned long long)(ops_page_end - ops_page_base));
+            }
+
+            /* Walk each op's shader_gpu_va. Dedup: same shader_gpu_va
+             * across multiple ops (mnist reuses 4 shaders across 8
+             * ops) → only reserve once. Simple linear scan over the
+             * reserved-so-far list is O(n²) but n≤51 so it's fine. */
+            const struct ga10b_pipeline_op_v7 *ops_v7 =
+                (const struct ga10b_pipeline_op_v7 *)(uintptr_t)ops_phys;
+            uint64_t reserved_phys[51];
+            uint32_t n_reserved = 0;
+            uint32_t n_walked = 0, n_walk_ok = 0, n_reserved_now = 0;
+            for (uint32_t i = 0; i < n_ops; i++) {
+                uint64_t gva = ops_v7[i].shader_gpu_va;
+                if (gva == 0u) continue;
+                n_walked++;
+                struct ga10b_gmmu_walk_result wr;
+                ga10b_gmmu_walk(inst_phys_for_walk, gva, &wr);
+                if (wr.status != GA10B_GMMU_WALK_OK) continue;
+                n_walk_ok++;
+
+                uint64_t shader_phys_pg = wr.leaf_phys & ~4095ull;
+                if (!ga10b_phys_in_dram(shader_phys_pg, 4096)) continue;
+
+                /* Dedup */
+                bool seen = false;
+                for (uint32_t j = 0; j < n_reserved; j++) {
+                    if (reserved_phys[j] == shader_phys_pg) {
+                        seen = true;
+                        break;
+                    }
+                }
+                if (seen) continue;
+
+                /* Reserve only the leaf phys page (4 KB). The shader
+                 * dmabuf may be larger (up to 64 KB) but its
+                 * underlying phys pages are scattered (nvmap maps
+                 * non-contiguous phys to contiguous iova). Reserving
+                 * more than 4 KB from `leaf_phys` overruns into
+                 * neighbor phys which may belong to FECS ctx_save
+                 * state — observed empirically as the
+                 * `ctxsw_checksum_mismatch` (mb6=0x21) failure that
+                 * Stage 9 Mode D fix surfaced when this was 64 KB.
+                 *
+                 * Covering the tail of multi-page shaders requires
+                 * walking shader_gpu_va + 4096, + 8192, ... separately.
+                 * The simple 1-page reservation is sufficient for
+                 * mnist's largest shader (gemm at ~5-20 KB
+                 * is at most 5 pages, so first-page reservation
+                 * catches op[0]'s SM PC at SM entry — the most
+                 * common Mode B fault location). Multi-page walk is
+                 * Stage 11 work; for now first-page coverage
+                 * empirically eliminates ~50% of Mode B. */
+                const uint64_t reserve_bytes = 4096u;
+                if (pmm_user_reserve_add(shader_phys_pg,
+                                         reserve_bytes) != 0) {
+                    uart_printf("[ga10b-reserve]   per-op shader: "
+                                "pmm_user_reserve_add(0x%lx) failed — "
+                                "table full, op %u/%u uncovered\n",
+                                (unsigned long)shader_phys_pg,
+                                (unsigned)i, (unsigned)n_ops);
+                    break;
+                }
+                reserved_phys[n_reserved++] = shader_phys_pg;
+                n_reserved_now++;
+            }
+            uart_printf("[ga10b-reserve]   per-op shader: %u walked, "
+                        "%u walk_ok, %u unique reservations (inst=0x%lx)\n",
+                        (unsigned)n_walked, (unsigned)n_walk_ok,
+                        (unsigned)n_reserved_now,
+                        (unsigned long)inst_phys_for_walk);
+        }
+    } else {
+        uart_printf("[ga10b-reserve]   per-op shader reservation skipped "
+                    "(n_ops=%u ops_phys=0x%lx inst_block_phys=0x%lx)\n",
+                    (unsigned)h->pipeline_n_ops,
+                    (unsigned long)h->pipeline_ops_phys,
+                    (unsigned long)h->inst_block_phys);
+    }
+
     if (version < 9u || n_extents == 0u || extents_phys == 0u) {
         uart_printf("[ga10b-reserve]   handoff@0x%lx v=%u no v9 "
                     "extents (n=%u extents_phys=0x%lx) — skipping\n",

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -47,7 +47,9 @@
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 
+#include "ga10b_channel_handoff.h"
 #include "ga10b_gmmu.h"
+#include "../../include/dtb.h"
 #include "../../include/pmm.h"
 #include "../../include/uart.h"
 
@@ -144,6 +146,193 @@ void ga10b_kexec_handoff_register_reserves(void)
                 (unsigned long)inst_phys,
                 (unsigned)GA10B_INST_BLOCK_BYTES,
                 (unsigned)reg, (unsigned)target);
+
+    /* #788 Stage 4 — scan DRAM for the handoff and reserve every
+     * weights-pool extent it lists. The IOVMM-stitched 1.5 GB
+     * weights pool is physically scattered across hundreds-to-
+     * thousands of contiguous runs; without reserving each run's
+     * pages, SLM-OS PMM allocates from those pages and the CE
+     * memcpy writes during W3 staging clobber whatever kernel
+     * data SLM-OS put there.
+     *
+     * The handoff itself lives somewhere in the 4-8 GB DRAM
+     * range (the helper's nvmap allocation lands wherever the
+     * IOVMM heap has room). Scanning at 4 KB stride is ~50 ms
+     * one-time-only at boot; acceptable cost for the protection.
+     *
+     * If the scan fails (no handoff found) we still finished the
+     * inst-block reservation above — a fresh-boot or no-helper
+     * test path that doesn't have a kexec'd channel works
+     * normally without the extents protection. */
+    uart_puts("[ga10b-reserve] scanning DRAM for handoff magic + "
+              "weights-pool extents...\n");
+    uint64_t handoff_phys =
+        ga10b_find_handoff_in_range(0x100000000ull, 0x200000000ull,
+                                     4096ull);
+    if (handoff_phys == 0) {
+        uart_puts("[ga10b-reserve]   handoff not found — skipping "
+                  "weights-pool extent reservation\n");
+        return;
+    }
+
+    /* Reserve the handoff dmabuf page itself first (cheap + small). */
+    if (pmm_user_reserve_add(handoff_phys & ~4095ull, 4096ull) != 0) {
+        uart_printf("[ga10b-reserve]   pmm_user_reserve_add for "
+                    "handoff page @0x%lx failed (table full?)\n",
+                    (unsigned long)handoff_phys);
+    } else {
+        uart_printf("[ga10b-reserve]   reserved handoff dmabuf "
+                    "@0x%lx (4 KB)\n",
+                    (unsigned long)(handoff_phys & ~4095ull));
+    }
+    const volatile struct ga10b_channel_handoff *h =
+        (const volatile struct ga10b_channel_handoff *)
+        (uintptr_t)handoff_phys;
+    uint32_t version = h->version;
+    uint32_t n_extents = h->weights_n_extents;
+    uint64_t extents_phys = h->weights_extents_phys;
+
+    /* Reserve every helper-allocated buffer the channel needs
+     * (USERD, GPFIFO, pushbuf, sem, SASS pool, cbuf, QMD pool).
+     * Without these, SLM-OS PMM can hand them out to its own
+     * allocations (e.g. the GMMU rebuild's page-table pages —
+     * Stage 4 maps a 1.5 GB weights pool which requires ~3 MB of
+     * PTE tables, way more PMM activity than the Stage 3
+     * single-page case), and the channel state gets clobbered.
+     * Stage 3 worked without these because the PTE-table footprint
+     * was tiny (a few pages); Stage 4's larger PTE footprint
+     * surfaced the latent collision.
+     *
+     * Each buffer is small + finite (max ~1 MB for SASS pool);
+     * collectively well under the PMM user-reserve table cap.
+     * Read the (volatile) handoff fields into locals first so the
+     * struct-initializer fits a static helper table cleanly. */
+    {
+        uint64_t userd_p   = h->userd_phys;
+        uint64_t gpfifo_p  = h->gpfifo_phys;
+        uint32_t gpfifo_e  = h->gpfifo_entries;
+        uint32_t gpfifo_es = h->gpfifo_entry_size;
+        uint64_t pushbuf_p = h->pushbuf_phys;
+        uint32_t pushbuf_s = h->pushbuf_size;
+        uint64_t sem_p     = h->semaphore_phys;
+        uint64_t shader_p  = h->shader_phys;
+        uint32_t shader_s  = h->shader_size;
+        uint64_t cbuf_p    = h->cbuf_phys;
+        uint32_t cbuf_s    = h->cbuf_size;
+        uint64_t qmd_p     = h->qmd_pool_phys;
+        uint32_t qmd_s     = h->qmd_pool_size_bytes;
+
+        struct {
+            const char *tag;
+            uint64_t phys;
+            uint64_t size;
+        } refs[] = {
+            { "userd",    userd_p,   4096 },
+            { "gpfifo",   gpfifo_p,  (uint64_t)gpfifo_e * (uint64_t)gpfifo_es },
+            { "pushbuf",  pushbuf_p, (uint64_t)pushbuf_s },
+            { "sem",      sem_p,     4096 },
+            { "shader",   shader_p,  (uint64_t)shader_s },
+            { "cbuf",     cbuf_p,    (uint64_t)cbuf_s },
+            { "qmd_pool", qmd_p,     (uint64_t)qmd_s },
+        };
+        for (size_t i = 0; i < sizeof(refs) / sizeof(refs[0]); i++) {
+            if (refs[i].phys == 0 || refs[i].size == 0) {
+                continue;
+            }
+            uint64_t base = refs[i].phys & ~4095ull;
+            uint64_t end  = (refs[i].phys + refs[i].size + 4095ull) &
+                            ~4095ull;
+            uint64_t sz   = end - base;
+            if (pmm_user_reserve_add(base, sz) != 0) {
+                uart_printf("[ga10b-reserve]   pmm_user_reserve_add "
+                            "for %s @0x%lx failed (table full?)\n",
+                            refs[i].tag, (unsigned long)base);
+            } else {
+                uart_printf("[ga10b-reserve]   reserved %s @0x%lx "
+                            "(%llu B)\n",
+                            refs[i].tag, (unsigned long)base,
+                            (unsigned long long)sz);
+            }
+        }
+    }
+    if (version < 9u || n_extents == 0u || extents_phys == 0u) {
+        uart_printf("[ga10b-reserve]   handoff@0x%lx v=%u no v9 "
+                    "extents (n=%u extents_phys=0x%lx) — skipping\n",
+                    (unsigned long)handoff_phys, (unsigned)version,
+                    (unsigned)n_extents, (unsigned long)extents_phys);
+        return;
+    }
+    uint64_t extents_bytes =
+        (uint64_t)n_extents * sizeof(struct ga10b_phys_extent);
+    if (!ga10b_phys_in_dram(extents_phys, (size_t)extents_bytes)) {
+        uart_printf("[ga10b-reserve]   extents_phys=0x%lx (n=%u) "
+                    "outside DRAM — skipping\n",
+                    (unsigned long)extents_phys, (unsigned)n_extents);
+        return;
+    }
+
+    /* Reserve the extents dmabuf itself so PMM doesn't allocate
+     * from it before the rebuild path reads it. The dmabuf can
+     * be 100s of KB for a fragmented IOVMM allocation (1033
+     * extents × 16 B = 16 KB; capped at GA10B_WEIGHTS_EXTENTS_MAX
+     * × 16 B = 128 KB), much larger than the inst-block page or
+     * handoff dmabuf — without explicit reservation, SLM-OS PMM
+     * easily hands those pages to ramdisk allocations or model
+     * preload buffers, and by rebuild-time the extents array
+     * reads as random bytes. */
+    {
+        uint64_t extents_page_base = extents_phys & ~4095ull;
+        uint64_t extents_page_end =
+            (extents_phys + extents_bytes + 4095ull) & ~4095ull;
+        uint64_t extents_reserve_bytes =
+            extents_page_end - extents_page_base;
+        if (pmm_user_reserve_add(extents_page_base,
+                                  extents_reserve_bytes) != 0) {
+            uart_printf("[ga10b-reserve]   pmm_user_reserve_add for "
+                        "extents dmabuf failed — array will be at "
+                        "risk of clobber between boot and rebuild\n");
+        } else {
+            uart_printf("[ga10b-reserve]   reserved extents dmabuf "
+                        "@0x%lx (%llu B)\n",
+                        (unsigned long)extents_page_base,
+                        (unsigned long long)extents_reserve_bytes);
+        }
+    }
+
+    const struct ga10b_phys_extent *exts =
+        (const struct ga10b_phys_extent *)(uintptr_t)extents_phys;
+    int reserved_count = 0;
+    int skipped_count = 0;
+    uint64_t total_pages = 0;
+    for (uint32_t i = 0; i < n_extents; i++) {
+        uint64_t ph = exts[i].phys;
+        uint32_t np = exts[i].n_pages;
+        if (np == 0u) {
+            continue;
+        }
+        uint64_t sz = (uint64_t)np * 4096ull;
+        if (!ga10b_phys_in_dram(ph, sz)) {
+            skipped_count++;
+            continue;
+        }
+        if (pmm_user_reserve_add(ph, sz) != 0) {
+            uart_printf("[ga10b-reserve]   pmm_user_reserve_add "
+                        "failed at extent %u/%u — table full, "
+                        "tail unprotected\n",
+                        (unsigned)i, (unsigned)n_extents);
+            break;
+        }
+        reserved_count++;
+        total_pages += np;
+    }
+    uart_printf("[ga10b-reserve]   weights extents: %u reserved "
+                "(%llu pages, ~%llu MB), %u skipped (outside DRAM), "
+                "from handoff@0x%lx\n",
+                (unsigned)reserved_count,
+                (unsigned long long)total_pages,
+                (unsigned long long)(total_pages / 256ull),
+                (unsigned)skipped_count,
+                (unsigned long)handoff_phys);
 }
 
 #else  /* !PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.h
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.h
@@ -43,6 +43,8 @@
 #ifndef GPU_NVIDIA_GA10B_HANDOFF_RESERVE_H
 #define GPU_NVIDIA_GA10B_HANDOFF_RESERVE_H
 
+#include <stdint.h>
+
 /*
  * Discover the kexec'd channel's inst block via FECS_CURRENT_CTX and
  * register its physical page with the PMM as a user-supplied reserve.
@@ -60,5 +62,25 @@
  * a no-op via the file-level platform guard in `ga10b_handoff_reserve.c`.
  */
 void ga10b_kexec_handoff_register_reserves(void);
+
+/*
+ * Return the inst-block phys captured by `ga10b_kexec_handoff_-
+ * register_reserves` at boot from FECS_CURRENT_CTX.
+ *
+ * Returns 0 if the boot capture was skipped (fresh boot / no current
+ * ctx / poisoned read) or if the function hasn't run yet. Non-zero
+ * means the kernel saved a valid inst-block phys from the very first
+ * FECS read after kexec — before any subsequent SLM-OS GPU MMIO
+ * could trigger a FECS context switch.
+ *
+ * Use case (#788 Stage 9): `nvgpu oplib stage`'s auto-discovery
+ * reads FECS_CURRENT_CTX at command time, but by then FECS may
+ * have ctx-switched to a different channel (observed empirically:
+ * boot read 0x13e647000, but post-`nvgpu channel` FECS reads
+ * 0x127ebb000 — both valid inst blocks, but only the boot capture
+ * matches the inherited channel SLM-OS wants to drive). Prefer the
+ * boot capture over live FECS reads for that workflow.
+ */
+uint64_t ga10b_kexec_inherited_inst_block_phys(void);
 
 #endif /* GPU_NVIDIA_GA10B_HANDOFF_RESERVE_H */

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.h
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.h
@@ -1,0 +1,64 @@
+/*
+ * ga10b_handoff_reserve.h — register GA10B kexec-handoff state with
+ * the PMM as user-supplied memory reservations.
+ *
+ * Problem statement (#788): when SLM-OS kexecs over Linux while
+ * `gpu-channel-helper` is holding an nvgpu channel open, the
+ * channel's inst block + GMMU page tables + GR ctxsw save buffer
+ * survive kexec in DRAM — Linux doesn't actively free them, the
+ * helper kept the fds open. But SLM-OS's PMM has no knowledge of
+ * those allocations and happily hands the same physical pages out
+ * to its own kernel code, model preload buffers, ramdisks, etc.
+ * By the time SLM-OS issues its first GPU submit, the channel
+ * state has been clobbered byte-for-byte — proven by the
+ * `nvgpu instdump` shell command (PR #797).
+ *
+ * Fix: read FECS_CURRENT_CTX before PMM init publishes pages, decode
+ * the channel's inst block phys, validate it's inside DRAM, and
+ * register it as a user reserve via `pmm_user_reserve_add`. PMM
+ * carves the registered range out of every region it adds to the
+ * buddy allocator, so kernel allocations naturally steer around the
+ * inherited channel's pages.
+ *
+ * **Scope of this MVP:** reserves the channel inst block only — one
+ * 4 KB page identified via the FECS_CURRENT_CTX MMIO register. The
+ * inst block carries the PDB pointer; without protecting it, any
+ * GMMU walk reads garbage and faults at the first dispatch. Future
+ * work will extend to walking the PDB tree and reserving every page
+ * table page, plus the helper-allocated dmabufs (USERD / GPFIFO /
+ * pushbuffer / semaphore / SASS pool) listed in the v9 handoff. The
+ * MVP picks the highest-value single reservation first so the
+ * hardware verification gives a clean before/after signal on whether
+ * inst-block-only protection is enough to keep the wedge from firing.
+ *
+ * Hooked from `kernel_main` between `vmm_init` (which sets up the
+ * identity mappings the function needs to read GPU MMIO and DRAM)
+ * and `pmm_init` (the consumer of `pmm_user_reserve_add`). Safe to
+ * call from non-kexec boots — the function early-returns when
+ * `FECS_CURRENT_CTX` reads zero / target=0 / a poisoned-MMIO
+ * pattern, all of which characterise fresh boots where no channel
+ * was ever live.
+ */
+
+#ifndef GPU_NVIDIA_GA10B_HANDOFF_RESERVE_H
+#define GPU_NVIDIA_GA10B_HANDOFF_RESERVE_H
+
+/*
+ * Discover the kexec'd channel's inst block via FECS_CURRENT_CTX and
+ * register its physical page with the PMM as a user-supplied reserve.
+ *
+ * No return value: the function logs every decision (skipped because
+ * no current ctx / outside DRAM / reserve table full / success) so
+ * the UART log carries the diagnostic trail, but the caller has
+ * nothing it could meaningfully act on — if the reservation fails,
+ * the channel will subsequently wedge during inheritance and the
+ * existing wedge handler will dump enough state to triage.
+ *
+ * Safe to call on non-Jetson platforms only via the platform-guarded
+ * call site; the implementation reads Jetson-specific MMIO (BAR0 at
+ * 0x17000000) directly. Building the function for other targets is
+ * a no-op via the file-level platform guard in `ga10b_handoff_reserve.c`.
+ */
+void ga10b_kexec_handoff_register_reserves(void);
+
+#endif /* GPU_NVIDIA_GA10B_HANDOFF_RESERVE_H */

--- a/kernel/include/pmm.h
+++ b/kernel/include/pmm.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "dtb.h"  /* dtb_memreserve_t for pmm_user_reserve_add_array */
 
 /* Page sizes */
 #define PAGE_SIZE           4096            /* 4 KB standard page */
@@ -101,6 +102,27 @@ void pmm_init(void);
  * in single-CPU context before scheduler bring-up, so callers don't
  * need to synchronize. */
 int pmm_user_reserve_add(uint64_t phys, uint64_t size);
+
+/*
+ * Bulk wrapper around `pmm_user_reserve_add` for callers that have
+ * a contiguous array of (phys, size) pairs to register — the
+ * canonical case being #788 Stage 4's weights-pool extent list,
+ * where the helper publishes potentially thousands of extents
+ * describing the physically-scattered IOVMM allocation. Calling
+ * `pmm_user_reserve_add` per-entry would still work but spreads
+ * the loop into the caller; this helper keeps the loop centralized
+ * with the rest of the user-reserve API.
+ *
+ * `extents[i].addr` and `extents[i].size` are passed through to
+ * `pmm_user_reserve_add` unchanged. Returns the number of
+ * successfully-added entries; stops early on the first failure
+ * (table full or zero-size entry), which lets the caller see
+ * how many made it before truncation.
+ *
+ * Same pre-`pmm_init` ordering constraint as the single-entry
+ * variant. */
+int pmm_user_reserve_add_array(const dtb_memreserve_t *extents,
+                                size_t n_extents);
 
 /*
  * Test-only accessor: read back the number of user reserves currently

--- a/kernel/include/pmm.h
+++ b/kernel/include/pmm.h
@@ -70,6 +70,54 @@ struct pmm_buddy_stats {
 void pmm_init(void);
 
 /*
+ * Register a physical range that PMM must NOT hand out to the buddy
+ * allocator. Adds to an internal list that `pmm_init` reads alongside
+ * the firmware-supplied /memreserve/ entries from the DTB; both lists
+ * feed `pmm_carve_reserves` so the buddy never sees the reserved pages.
+ *
+ * Use this for runtime-discovered reservations the firmware doesn't
+ * know about — primarily GPU kexec handoff state (channel inst block,
+ * page tables, save buffers) that nvgpu allocated pre-kexec and that
+ * SLM-OS must not clobber. The caller discovers the physical addresses
+ * from GPU MMIO registers (FECS_CURRENT_CTX, etc.) at a point in boot
+ * after the MMU is up but before PMM publishes pages. See
+ * `ga10b_handoff_reserve.c` for the canonical Jetson-side caller.
+ *
+ * MUST be called BEFORE `pmm_init`. Reservations added after pmm_init
+ * are ignored (the buddy has already been built); the function still
+ * returns 0 in that case to keep the API tolerant of mis-ordered boot
+ * code, but no protection is granted. The caller is responsible for
+ * the ordering — there's no late-binding rescan.
+ *
+ * `size` is the byte length; the carve helper page-rounds internally
+ * so partial-page reservations protect the containing 4 KB page.
+ *
+ * Returns 0 on success, -1 if the user-reserve table is full
+ * (PMM_MAX_USER_RESERVES, file-static in pmm.c) or `size == 0`. The
+ * cap is currently 16 — generous for the kexec-handoff use case
+ * which adds a handful of regions per boot.
+ *
+ * Thread-safety: file-static array, no locking. PMM init runs early
+ * in single-CPU context before scheduler bring-up, so callers don't
+ * need to synchronize. */
+int pmm_user_reserve_add(uint64_t phys, uint64_t size);
+
+/*
+ * Test-only accessor: read back the number of user reserves currently
+ * registered. Returns 0 if `pmm_user_reserve_add` has never been
+ * called. Used by `test_pmm.c` to verify the reservation API without
+ * having to expose the file-static array.
+ */
+size_t pmm_user_reserve_count(void);
+
+/*
+ * Test-only accessor: reset the user-reserve table. The production
+ * path adds reserves once during boot and never clears them; tests
+ * need to wipe state between cases.
+ */
+void pmm_user_reserve_reset(void);
+
+/*
  * Allocate a single 4KB physical page.
  *
  * Returns: Physical address of allocated page, or 0 on failure.

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -535,9 +535,9 @@ int pmm_user_reserve_add_array(const dtb_memreserve_t *extents,
              * `added < n_extents` and the wedge that fires later
              * on the unprotected tail is otherwise hard to
              * attribute back to "PMM reserve table was full". */
-            uart_printf("[pmm] WARN: user-reserve table full at "
-                        "entry %zu/%zu (cap=%u). Pages from extent "
-                        "%zu onward are NOT protected — expect "
+            uart_printf("Warning: user-reserve table full at entry "
+                        "%zu/%zu (cap=%u). Pages from extent %zu "
+                        "onward are NOT protected — expect "
                         "downstream clobber.\n",
                         i, n_extents,
                         (unsigned)PMM_MAX_USER_RESERVES, i);

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -464,9 +464,55 @@ int pmm_carve_reserves(uintptr_t start, uintptr_t end,
  * cap grows in the future, the worst-case ~1 KB stack footprint per
  * call would otherwise scale with it.
  */
-static uintptr_t        pmm_split_starts[DTB_MAX_MEMRESERVES + 1];
-static uintptr_t        pmm_split_ends  [DTB_MAX_MEMRESERVES + 1];
-static dtb_memreserve_t pmm_split_rsv   [DTB_MAX_MEMRESERVES];
+/* User-supplied reserve slots. PMM init feeds these into the same
+ * `pmm_carve_reserves` pipeline as the firmware /memreserve/ entries,
+ * so runtime-discovered protected ranges (the canonical case: nvgpu
+ * inst block + GMMU page tables that survived kexec but live in
+ * physical pages SLM-OS would otherwise allocate from) get carved
+ * out before any page is published to the buddy. See
+ * `pmm_user_reserve_add` in pmm.h.
+ *
+ * Capacity sized for the Jetson kexec-handoff caller, which adds at
+ * most a handful of regions per boot. Sized to PMM_MAX_USER_RESERVES
+ * = 16 — generous for the current use case, leaves room for
+ * follow-on work (PDB-tree-walk-style enumeration) without revisiting
+ * the cap. */
+#define PMM_MAX_USER_RESERVES 16
+static dtb_memreserve_t pmm_user_reserves[PMM_MAX_USER_RESERVES];
+static size_t           pmm_n_user_reserves = 0;
+
+/* Scratch arrays are sized to fit the worst case = firmware reserves
+ * + user reserves, plus one extra slot for the split helper's own
+ * bookkeeping (matches the prior `DTB_MAX_MEMRESERVES + 1` rationale
+ * for `pmm_split_starts`/`pmm_split_ends`). */
+#define PMM_SPLIT_RSV_MAX  (DTB_MAX_MEMRESERVES + PMM_MAX_USER_RESERVES)
+static uintptr_t        pmm_split_starts[PMM_SPLIT_RSV_MAX + 1];
+static uintptr_t        pmm_split_ends  [PMM_SPLIT_RSV_MAX + 1];
+static dtb_memreserve_t pmm_split_rsv   [PMM_SPLIT_RSV_MAX];
+
+int pmm_user_reserve_add(uint64_t phys, uint64_t size)
+{
+    if (size == 0u) {
+        return -1;
+    }
+    if (pmm_n_user_reserves >= PMM_MAX_USER_RESERVES) {
+        return -1;
+    }
+    pmm_user_reserves[pmm_n_user_reserves].addr = phys;
+    pmm_user_reserves[pmm_n_user_reserves].size = size;
+    pmm_n_user_reserves++;
+    return 0;
+}
+
+size_t pmm_user_reserve_count(void)
+{
+    return pmm_n_user_reserves;
+}
+
+void pmm_user_reserve_reset(void)
+{
+    pmm_n_user_reserves = 0;
+}
 
 static void pmm_add_region_split(uintptr_t start, uintptr_t end)
 {
@@ -493,9 +539,22 @@ static void pmm_add_region_split(uintptr_t start, uintptr_t end)
     in_split = true;
 
     int n_rsv = dtb_get_memreserves(pmm_split_rsv, DTB_MAX_MEMRESERVES);
+    /* Append the user-registered reserves (e.g. GPU kexec handoff
+     * state — see `pmm_user_reserve_add`). The carve helper handles
+     * unsorted, overlapping, and out-of-region entries identically
+     * to firmware reserves, so the two lists can be concatenated
+     * without further bookkeeping. Bounded by PMM_SPLIT_RSV_MAX so
+     * the writes can never overrun `pmm_split_rsv[]`. */
+    for (size_t i = 0;
+         i < pmm_n_user_reserves && (size_t)n_rsv < PMM_SPLIT_RSV_MAX;
+         i++) {
+        pmm_split_rsv[n_rsv].addr = pmm_user_reserves[i].addr;
+        pmm_split_rsv[n_rsv].size = pmm_user_reserves[i].size;
+        n_rsv++;
+    }
     int n_out = pmm_carve_reserves(start, end, pmm_split_rsv, n_rsv,
                                    pmm_split_starts, pmm_split_ends,
-                                   DTB_MAX_MEMRESERVES + 1);
+                                   PMM_SPLIT_RSV_MAX + 1);
     for (int i = 0; i < n_out; i++) {
         pmm_add_region(pmm_split_starts[i], pmm_split_ends[i]);
     }

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -467,17 +467,34 @@ int pmm_carve_reserves(uintptr_t start, uintptr_t end,
 /* User-supplied reserve slots. PMM init feeds these into the same
  * `pmm_carve_reserves` pipeline as the firmware /memreserve/ entries,
  * so runtime-discovered protected ranges (the canonical case: nvgpu
- * inst block + GMMU page tables that survived kexec but live in
- * physical pages SLM-OS would otherwise allocate from) get carved
- * out before any page is published to the buddy. See
- * `pmm_user_reserve_add` in pmm.h.
+ * inst block + GMMU page tables + IOVMM-stitched weights-pool
+ * extents that survived kexec but live in physical pages SLM-OS
+ * would otherwise allocate from) get carved out before any page is
+ * published to the buddy. See `pmm_user_reserve_add` in pmm.h.
  *
- * Capacity sized for the Jetson kexec-handoff caller, which adds at
- * most a handful of regions per boot. Sized to PMM_MAX_USER_RESERVES
- * = 16 — generous for the current use case, leaves room for
- * follow-on work (PDB-tree-walk-style enumeration) without revisiting
- * the cap. */
-#define PMM_MAX_USER_RESERVES 16
+ * Capacity bumped from 16 → 2048 in #788 Stage 4 to accommodate the
+ * weights-pool extents: a 1.5 GB IOVMM-stitched allocation
+ * empirically decomposes into 2-1100 contiguous runs on Tegra
+ * GA10B (depends on CMA fragmentation at allocation time on a
+ * freshly-booted vs long-running Linux). 2048 caps the array at
+ * 32 KB (2048 × 16 bytes) — generous over the highest observed
+ * extent count (~1033 on a fragmented allocation), and small
+ * enough that the boot-time BSS bloat is well within the
+ * kernel image's existing budget. If a future helper logs
+ * "extents truncated", bump this cap and the helper's
+ * `GA10B_WEIGHTS_EXTENTS_MAX` together.
+ *
+ * The helper-side cap in `ga10b_channel_handoff.h`
+ * (`GA10B_WEIGHTS_EXTENTS_MAX = 8192`) is larger than this cap on
+ * purpose: the helper publishes the full list, and SLM-OS picks
+ * the prefix that fits — anything past entry 2048 won't get a
+ * PMM reservation but WILL still get a GMMU mapping (the rebuild
+ * path walks the entire list, only the reservation hook truncates).
+ * A page mapped but not reserved is at risk if PMM also allocates
+ * from it; in practice the helper's IOVMM phys range and SLM-OS
+ * PMM's allocations rarely overlap, so the partial protection is
+ * sufficient until a future bump. */
+#define PMM_MAX_USER_RESERVES 2048
 static dtb_memreserve_t pmm_user_reserves[PMM_MAX_USER_RESERVES];
 static size_t           pmm_n_user_reserves = 0;
 
@@ -502,6 +519,23 @@ int pmm_user_reserve_add(uint64_t phys, uint64_t size)
     pmm_user_reserves[pmm_n_user_reserves].size = size;
     pmm_n_user_reserves++;
     return 0;
+}
+
+int pmm_user_reserve_add_array(const dtb_memreserve_t *extents,
+                                size_t n_extents)
+{
+    if (extents == NULL) {
+        return 0;
+    }
+    int added = 0;
+    for (size_t i = 0; i < n_extents; i++) {
+        if (pmm_user_reserve_add(extents[i].addr,
+                                  extents[i].size) != 0) {
+            break;
+        }
+        added++;
+    }
+    return added;
 }
 
 size_t pmm_user_reserve_count(void)

--- a/kernel/mm/pmm.c
+++ b/kernel/mm/pmm.c
@@ -531,6 +531,16 @@ int pmm_user_reserve_add_array(const dtb_memreserve_t *extents,
     for (size_t i = 0; i < n_extents; i++) {
         if (pmm_user_reserve_add(extents[i].addr,
                                   extents[i].size) != 0) {
+            /* Surface truncation loudly — the caller will see
+             * `added < n_extents` and the wedge that fires later
+             * on the unprotected tail is otherwise hard to
+             * attribute back to "PMM reserve table was full". */
+            uart_printf("[pmm] WARN: user-reserve table full at "
+                        "entry %zu/%zu (cap=%u). Pages from extent "
+                        "%zu onward are NOT protected — expect "
+                        "downstream clobber.\n",
+                        i, n_extents,
+                        (unsigned)PMM_MAX_USER_RESERVES, i);
             break;
         }
         added++;

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -21,6 +21,9 @@
 #include "gpu.h"
 #include "shell.h"
 #include "dtb.h"
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+#include "../gpu/nvidia/ga10b_handoff_reserve.h"
+#endif
 #if !defined(PLATFORM_X86_64)
 #include "hailo_trace.h"
 #endif
@@ -378,10 +381,7 @@ void kernel_main(void *dtb)
      * doesn't fire. Safe to call on non-kexec boots: the function
      * early-returns when FECS_CURRENT_CTX is zero / target=0 / a
      * poisoned-MMIO pattern. */
-    {
-        extern void ga10b_kexec_handoff_register_reserves(void);
-        ga10b_kexec_handoff_register_reserves();
-    }
+    ga10b_kexec_handoff_register_reserves();
 #endif
 
     uart_puts("\n");

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -366,6 +366,24 @@ void kernel_main(void *dtb)
     uart_puts("\n");
     vmm_init();
 
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    /* #788 root-cause fix: register the kexec'd nvgpu channel's
+     * inst block as a PMM user-reserve BEFORE pmm_init publishes
+     * pages. The MMU is up (vmm_init just ran) so reading the GPU
+     * BAR0 MMIO and the inst-block DRAM page is safe. The reservation
+     * feeds into the same /memreserve/ carve path firmware DTB entries
+     * use, so kernel allocations naturally steer around the channel's
+     * pages and the post-kexec wedge (inst block clobbered with
+     * SLM-OS kernel code or model bytes — see PR #797 diagnostic)
+     * doesn't fire. Safe to call on non-kexec boots: the function
+     * early-returns when FECS_CURRENT_CTX is zero / target=0 / a
+     * poisoned-MMIO pattern. */
+    {
+        extern void ga10b_kexec_handoff_register_reserves(void);
+        ga10b_kexec_handoff_register_reserves();
+    }
+#endif
+
     uart_puts("\n");
     pmm_init();
     pmm_dump_stats();

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4022,6 +4022,7 @@ int cmd_telemetry(int argc, char *argv[])
 #include "../gpu/nvidia/ga10b_bringup.h"
 #include "../gpu/nvidia/ga10b_channel_handoff.h"
 #include "../gpu/nvidia/ga10b_gmmu.h"
+#include "../gpu/nvidia/ga10b_handoff_reserve.h"
 #include "../gpu/nvidia/ga10b_ce.h"
 #include "oplib_pool.h"
 #include "oplib_weights_pool.h"
@@ -4746,6 +4747,56 @@ int cmd_nvgpu(int argc, char *argv[])
                 if (h != NULL && h->inst_block_phys != 0) {
                     inst_phys = h->inst_block_phys;
                 } else {
+                    /* Prefer the boot-time capture from
+                     * `ga10b_kexec_handoff_register_reserves` over a
+                     * live FECS_CURRENT_CTX read. The live register
+                     * has drifted by this point — SLM-OS's GPU
+                     * touches between boot and `oplib stage`
+                     * (vmm_init's GPU BAR0 identity map probe,
+                     * `nvgpu inherit`'s mailbox/cpuctl reads,
+                     * `nvgpu channel`'s handoff scan, etc.) trigger
+                     * FECS context switches to other inst blocks
+                     * Linux had loaded, which then fail the
+                     * pushbuf-PA cross-check below.
+                     *
+                     * BUT the boot capture may itself be Xorg's
+                     * channel or another non-helper channel that
+                     * happened to be GR-current at kexec time. So
+                     * we still run the same pushbuf-PA walk
+                     * validation as the live-FECS path. If the boot
+                     * capture's inst block walks to the handoff's
+                     * pushbuf_phys, we use it. Otherwise we fall
+                     * through to the existing live-FECS + DRAM walk
+                     * (which has its own validation).
+                     *
+                     * See `issue_788_stage9_gr_exception_root_cause.md`. */
+                    uint64_t boot_inst =
+                        ga10b_kexec_inherited_inst_block_phys();
+                    if (boot_inst != 0 && h != NULL &&
+                        h->pushbuf_gpu_va != 0 && h->pushbuf_phys != 0) {
+                        struct ga10b_gmmu_walk_result bwr;
+                        ga10b_gmmu_walk(boot_inst, h->pushbuf_gpu_va,
+                                        &bwr);
+                        shell_printf("oplib stage: boot-captured inst=0x%lx "
+                                     "walk status=%d levels=%d pdb=0x%lx "
+                                     "leaf=0x%lx (want 0x%lx)\r\n",
+                                     (unsigned long)boot_inst,
+                                     (int)bwr.status, bwr.levels_walked,
+                                     (unsigned long)bwr.pdb_phys,
+                                     (unsigned long)bwr.leaf_phys,
+                                     (unsigned long)h->pushbuf_phys);
+                        if (bwr.status == GA10B_GMMU_WALK_OK &&
+                            bwr.leaf_phys == h->pushbuf_phys) {
+                            inst_phys = boot_inst;
+                            goto oplib_stage_call;
+                        }
+                        shell_puts("oplib stage: boot-captured inst doesn't "
+                                   "map handoff PB — likely Xorg or another "
+                                   "non-helper channel was GR-current at "
+                                   "kexec; falling through to FECS + DRAM "
+                                   "walk\r\n");
+                    }
+
                     /* FECS_CURRENT_CTX may hold a stale pointer when
                      * Linux nvgpu freed and reused the inst-block-
                      * pointing memory between the helper's last
@@ -4792,14 +4843,28 @@ int cmd_nvgpu(int argc, char *argv[])
                          * in allocation order. The phys_in_dram
                          * helper already excludes the OP-TEE
                          * carveout (0xBE..0xC2) so the walker won't
-                         * fault inside it. */
+                         * fault inside it.
+                         *
+                         * #788 Stage 9: extended ranges to cover the
+                         * full SLM-OS PMM aperture (up to
+                         * GA10B_GMMU_DRAM_TOP=0x240000000). On
+                         * jetson-nano-2 the helper's inst block
+                         * wasn't in [0x100M..0x180M] — looks like
+                         * nvgpu places the channel inst at the
+                         * upper end of system DRAM, separate from
+                         * the dmabufs (the dmabufs themselves are
+                         * at 0x10xxxxxxx). Walks ~3.5 GB of phys at
+                         * 4 KB stride which is the cost of getting
+                         * `nvgpu oplib stage` working without
+                         * helper changes. */
                         struct { uint64_t lo, hi; } ranges[] = {
+                            { 0x180000000ull, 0x240000000ull },
                             { 0x100000000ull, 0x180000000ull },
                             { 0x80000000ull,  0x100000000ull },
                         };
                         shell_printf("oplib stage: FECS inst=0x%lx didn't "
                                      "map handoff PB; walking DRAM "
-                                     "(2 ranges)\r\n",
+                                     "(3 ranges)\r\n",
                                      (unsigned long)inst_phys);
                         inst_phys = 0;
                         for (size_t r = 0; r < sizeof(ranges)/sizeof(ranges[0]);

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4242,6 +4242,37 @@ static int cmd_nvgpu_engine_status(void)
     return 0;
 }
 
+/* #788 Stage 2: rebuild the kexec'd channel's PDB tree.
+ *
+ * Allocate a fresh PDB tree in SLM-OS, overwrite the inst block's
+ * PDB pointer, and re-install PTEs mapping every preserved dmabuf
+ * at its original GPU VA. See `ga10b_gmmu_rebuild_for_handoff` in
+ * ga10b_gmmu.c.
+ *
+ * Requires `nvgpu channel` to have run first (so the handoff is
+ * loaded). Reads `inst_block_phys` from FECS_CURRENT_CTX — the
+ * runlist still references that physical page, so filling it with
+ * valid contents is what makes the channel usable post-kexec. */
+static int cmd_nvgpu_rebuild_gmmu(void)
+{
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h == NULL || h->magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
+        shell_puts("rebuild-gmmu: handoff not loaded — "
+                   "run `nvgpu channel` first\r\n");
+        return -1;
+    }
+    uint64_t inst_phys = ga10b_gmmu_discover_inst_block_phys();
+    if (inst_phys == 0) {
+        shell_puts("rebuild-gmmu: FECS_CURRENT_CTX returned no "
+                   "current ctx (target=0)\r\n");
+        return -1;
+    }
+    int rc = ga10b_gmmu_rebuild_for_handoff(inst_phys, h);
+    shell_printf("rebuild-gmmu: rc=%d (inst_phys=0x%lx)\r\n",
+                 rc, (unsigned long)inst_phys);
+    return rc;
+}
+
 /* ============================================================================
  * `nvgpu oplib smoke <op_kind>` per-op fixtures
  * ============================================================================
@@ -4578,37 +4609,7 @@ int cmd_nvgpu(int argc, char *argv[])
         return 0;
     }
     if (strcmp(argv[1], "rebuild-gmmu") == 0) {
-        /* #788 Stage 2: allocate a fresh PDB tree in SLM-OS,
-         * overwrite the inst block's PDB pointer, and re-install
-         * PTEs mapping every preserved dmabuf at its original GPU
-         * VA. See `ga10b_gmmu_rebuild_for_handoff` in
-         * ga10b_gmmu.c.
-         *
-         * Requires `nvgpu channel` to have run first (so the
-         * handoff is loaded). Reads `inst_block_phys` from
-         * FECS_CURRENT_CTX — the runlist still references that
-         * physical page, so filling it with valid contents is
-         * what makes the channel usable post-kexec.
-         *
-         * Usage:
-         *   nvgpu rebuild-gmmu     — rebuild against the handoff
-         *                            and FECS_CURRENT_CTX */
-        const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
-        if (h == NULL || h->magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
-            shell_puts("rebuild-gmmu: handoff not loaded — "
-                       "run `nvgpu channel` first\r\n");
-            return -1;
-        }
-        uint64_t inst_phys = ga10b_gmmu_discover_inst_block_phys();
-        if (inst_phys == 0) {
-            shell_puts("rebuild-gmmu: FECS_CURRENT_CTX returned no "
-                       "current ctx (target=0)\r\n");
-            return -1;
-        }
-        int rc = ga10b_gmmu_rebuild_for_handoff(inst_phys, h);
-        shell_printf("rebuild-gmmu: rc=%d (inst_phys=0x%lx)\r\n",
-                     rc, (unsigned long)inst_phys);
-        return rc;
+        return cmd_nvgpu_rebuild_gmmu();
     }
     if (strcmp(argv[1], "engine-clear") == 0) {
         return cmd_nvgpu_engine_clear();

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4576,6 +4576,39 @@ int cmd_nvgpu(int argc, char *argv[])
         ga10b_dump_inst_blocks_atomic("nvgpu-instdump");
         return 0;
     }
+    if (strcmp(argv[1], "rebuild-gmmu") == 0) {
+        /* #788 Stage 2: allocate a fresh PDB tree in SLM-OS,
+         * overwrite the inst block's PDB pointer, and re-install
+         * PTEs mapping every preserved dmabuf at its original GPU
+         * VA. See `ga10b_gmmu_rebuild_for_handoff` in
+         * ga10b_gmmu.c.
+         *
+         * Requires `nvgpu channel` to have run first (so the
+         * handoff is loaded). Reads `inst_block_phys` from
+         * FECS_CURRENT_CTX — the runlist still references that
+         * physical page, so filling it with valid contents is
+         * what makes the channel usable post-kexec.
+         *
+         * Usage:
+         *   nvgpu rebuild-gmmu     — rebuild against the handoff
+         *                            and FECS_CURRENT_CTX */
+        const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+        if (h == NULL || h->magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
+            shell_puts("rebuild-gmmu: handoff not loaded — "
+                       "run `nvgpu channel` first\r\n");
+            return -1;
+        }
+        uint64_t inst_phys = ga10b_gmmu_discover_inst_block_phys();
+        if (inst_phys == 0) {
+            shell_puts("rebuild-gmmu: FECS_CURRENT_CTX returned no "
+                       "current ctx (target=0)\r\n");
+            return -1;
+        }
+        int rc = ga10b_gmmu_rebuild_for_handoff(inst_phys, h);
+        shell_printf("rebuild-gmmu: rc=%d (inst_phys=0x%lx)\r\n",
+                     rc, (unsigned long)inst_phys);
+        return rc;
+    }
     if (strcmp(argv[1], "engine-clear") == 0) {
         return cmd_nvgpu_engine_clear();
     }

--- a/kernel/tests/test_pmm.c
+++ b/kernel/tests/test_pmm.c
@@ -1058,6 +1058,97 @@ static void test_carve_null_output_returns_zero(void)
 }
 
 /* ============================================================================
+ * User-reserve API (#788)
+ * ============================================================================
+ *
+ * `pmm_user_reserve_add` registers a (phys, size) range that PMM init
+ * carves out of every region added to the buddy allocator. The
+ * production caller is `ga10b_kexec_handoff_register_reserves` in
+ * the Jetson early-boot path; these unit tests cover the API shape
+ * (count tracking, reset, full-table behaviour) so a regression
+ * shows up in QEMU `make test` before it can break the Jetson
+ * boot path.
+ *
+ * Every test resets the table at entry so it doesn't matter which
+ * other test ran before. */
+
+static void test_user_reserve_count_starts_zero(void)
+{
+    pmm_user_reserve_reset();
+    TEST_ASSERT_EQUAL_UINT64(0, pmm_user_reserve_count());
+}
+
+static void test_user_reserve_add_increments_count(void)
+{
+    pmm_user_reserve_reset();
+
+    TEST_ASSERT_EQUAL_INT(0, pmm_user_reserve_add(0x100000, 0x1000));
+    TEST_ASSERT_EQUAL_UINT64(1, pmm_user_reserve_count());
+
+    TEST_ASSERT_EQUAL_INT(0, pmm_user_reserve_add(0x200000, 0x2000));
+    TEST_ASSERT_EQUAL_UINT64(2, pmm_user_reserve_count());
+
+    TEST_ASSERT_EQUAL_INT(0, pmm_user_reserve_add(0x300000, 0x1000));
+    TEST_ASSERT_EQUAL_UINT64(3, pmm_user_reserve_count());
+}
+
+static void test_user_reserve_zero_size_rejected(void)
+{
+    pmm_user_reserve_reset();
+
+    /* Zero-size reservations are nonsense — `pmm_carve_reserves`
+     * silently skips them, so accepting them here would just bloat
+     * the table without effect. Reject up front. */
+    TEST_ASSERT_EQUAL_INT(-1, pmm_user_reserve_add(0x100000, 0));
+    TEST_ASSERT_EQUAL_UINT64(0, pmm_user_reserve_count());
+}
+
+static void test_user_reserve_reset_zeros_count(void)
+{
+    pmm_user_reserve_reset();
+    (void)pmm_user_reserve_add(0x100000, 0x1000);
+    (void)pmm_user_reserve_add(0x200000, 0x1000);
+    TEST_ASSERT_EQUAL_UINT64(2, pmm_user_reserve_count());
+
+    pmm_user_reserve_reset();
+    TEST_ASSERT_EQUAL_UINT64(0, pmm_user_reserve_count());
+}
+
+static void test_user_reserve_table_full_rejects(void)
+{
+    pmm_user_reserve_reset();
+
+    /* Fill the table — capacity = PMM_MAX_USER_RESERVES (16, file-
+     * static in pmm.c). Use an inflated upper bound (32) to avoid
+     * the test breaking when the capacity is bumped; the loop just
+     * notices when adds start failing and asserts the count tops
+     * out at the natural cap. */
+    int last_ok_count = 0;
+    for (int i = 0; i < 32; i++) {
+        int rc = pmm_user_reserve_add(
+            (uint64_t)(0x100000 + (uint64_t)i * 0x1000), 0x1000);
+        if (rc == 0) {
+            last_ok_count = i + 1;
+        } else {
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(last_ok_count >= 1);
+
+    /* Once the table is full, further adds reject. */
+    TEST_ASSERT_EQUAL_INT(-1, pmm_user_reserve_add(0x900000, 0x1000));
+
+    /* Count is stable at the cap, not silently incremented. */
+    TEST_ASSERT_EQUAL_UINT64((size_t)last_ok_count,
+                             pmm_user_reserve_count());
+
+    /* Clean up so a later test doesn't inherit a full table — defensive
+     * even though every test starts with a reset (one consistent
+     * idiom). */
+    pmm_user_reserve_reset();
+}
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -1139,6 +1230,19 @@ int test_suite_pmm(void)
     RUN_TEST(test_ncmem_oversize_rejected);
     RUN_TEST(test_ncmem_overflow_rejected);
 #endif
+
+    /* User-reserve API (#788 root-cause fix prep). The integration
+     * test that the reserves are actually honored by `pmm_init` is
+     * impractical here — `pmm_init` has already run by the time the
+     * test harness starts, so a fresh registration has no effect on
+     * the live buddy. The unit tests below cover the API shape
+     * (count, add, reset, full-table behavior); the integration is
+     * exercised on hardware via the call site in `kernel_main`. */
+    RUN_TEST(test_user_reserve_count_starts_zero);
+    RUN_TEST(test_user_reserve_add_increments_count);
+    RUN_TEST(test_user_reserve_zero_size_rejected);
+    RUN_TEST(test_user_reserve_reset_zeros_count);
+    RUN_TEST(test_user_reserve_table_full_rejects);
 
     return UnityEnd();
 }

--- a/kernel/tests/test_pmm.c
+++ b/kernel/tests/test_pmm.c
@@ -1118,13 +1118,13 @@ static void test_user_reserve_table_full_rejects(void)
 {
     pmm_user_reserve_reset();
 
-    /* Fill the table — capacity = PMM_MAX_USER_RESERVES (16, file-
-     * static in pmm.c). Use an inflated upper bound (32) to avoid
-     * the test breaking when the capacity is bumped; the loop just
-     * notices when adds start failing and asserts the count tops
-     * out at the natural cap. */
+    /* Fill the table — capacity = PMM_MAX_USER_RESERVES (file-static
+     * in pmm.c). The current value is 8192 (#788 Stage 4 bumped from
+     * 16 to fit the weights-pool extents list); the upper-bound here
+     * is 10000 so the loop has headroom over the cap and the
+     * test still works if the cap is bumped further. */
     int last_ok_count = 0;
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < 10000; i++) {
         int rc = pmm_user_reserve_add(
             (uint64_t)(0x100000 + (uint64_t)i * 0x1000), 0x1000);
         if (rc == 0) {

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -261,6 +261,105 @@ static uint64_t virt_to_phys(void *vaddr)
     return pfn * 4096 + ((uint64_t)vaddr & 0xFFF);
 }
 
+/* Read FECS_CURRENT_CTX via /dev/mem and decode the channel inst-
+ * block phys it points to. Used to publish `inst_block_phys` in the
+ * handoff so SLM-OS's post-kexec `nvgpu oplib stage` can locate the
+ * inherited channel's GMMU root without scanning DRAM.
+ *
+ * Background (#788 Stage 9): SLM-OS captures FECS_CURRENT_CTX at
+ * boot, but by that time the live register may show a *different*
+ * channel than the helper's — Xorg / nvgpu's GR-internal channel /
+ * etc. were GR-current when kexec landed. Reading FECS here in the
+ * helper's process gives us a chance to capture the value while our
+ * channel is more likely to be the current GR context — and even if
+ * it's wrong, having a concrete address in the handoff lets SLM-OS's
+ * existing `if (h->inst_block_phys != 0)` fast path try it before
+ * falling back to walk-based discovery.
+ *
+ * GA10B FECS_CURRENT_CTX encoding (per
+ * `~/slmos-ref/nvidia/nvgpu-include-nvgpu-hw-gv11b-hw_gr_gv11b.h`):
+ *   bits [27:0]  = inst_block_phys >> 12
+ *   bits [29:28] = target aperture
+ *                  0 = vid_mem (Tegra has none — treat as invalid)
+ *                  2 = sys_mem_coherent
+ *                  3 = sys_mem_noncoherent
+ *
+ * Returns the decoded inst-block phys on success, or 0 if:
+ *   - /dev/mem can't be opened (helper isn't running as root)
+ *   - mmap fails
+ *   - The register reads as poison (`0xbadfXXXX`)
+ *   - The target aperture is 0 (no current ctx)
+ *
+ * On failure the function logs a diagnostic line — caller treats 0
+ * the same way SLM-OS does (skip publish, fall back to discovery). */
+#define GA10B_BAR0_BASE                  0x17000000ull
+#define GA10B_GR_FECS_CURRENT_CTX_OFFSET 0x00409b00u
+#define GA10B_INST_BLOCK_PAGE_SIZE       4096u
+
+static uint64_t read_fecs_current_ctx_inst_phys(void)
+{
+    int fd = open("/dev/mem", O_RDONLY | O_SYNC);
+    if (fd < 0) {
+        fprintf(stderr,
+                "[gpu-helper] FECS read: open(/dev/mem) failed: %s "
+                "(running as root?). inst_block_phys will be 0; "
+                "SLM-OS falls back to walk-based discovery.\n",
+                strerror(errno));
+        return 0;
+    }
+
+    /* mmap the page containing FECS_CURRENT_CTX. Page-align the mmap
+     * base since mmap() requires it; index within with the byte
+     * offset. The FECS register is 4 bytes at BAR0+0x409b00, which
+     * sits inside the 4 KB page at BAR0+0x409000. */
+    const uint64_t page_size = 4096u;
+    uint64_t reg_abs = GA10B_BAR0_BASE + GA10B_GR_FECS_CURRENT_CTX_OFFSET;
+    uint64_t page_base = reg_abs & ~(page_size - 1);
+    uint32_t page_off  = (uint32_t)(reg_abs & (page_size - 1));
+
+    void *map = mmap(NULL, page_size, PROT_READ, MAP_SHARED, fd,
+                     (off_t)page_base);
+    close(fd);
+    if (map == MAP_FAILED) {
+        fprintf(stderr,
+                "[gpu-helper] FECS read: mmap @0x%llx failed: %s\n",
+                (unsigned long long)page_base, strerror(errno));
+        return 0;
+    }
+
+    volatile uint32_t *reg_ptr =
+        (volatile uint32_t *)((uint8_t *)map + page_off);
+    uint32_t reg = *reg_ptr;
+    munmap(map, page_size);
+
+    if ((reg & 0xFFFF0000u) == 0xbadf0000u) {
+        fprintf(stderr,
+                "[gpu-helper] FECS read: register=0x%08x (priv-bad "
+                "poison — GPU power-gated?). Publishing inst_block_phys=0.\n",
+                reg);
+        return 0;
+    }
+
+    uint32_t target = (reg >> 28) & 0x3u;
+    if (target == 0) {
+        fprintf(stderr,
+                "[gpu-helper] FECS read: register=0x%08x (target=0 — no "
+                "current ctx). Publishing inst_block_phys=0.\n",
+                reg);
+        return 0;
+    }
+
+    uint64_t inst_phys = ((uint64_t)(reg & 0x0FFFFFFFu)) << 12;
+    printf("[gpu-helper] FECS_CURRENT_CTX=0x%08x → inst_block_phys=0x%llx "
+           "(target=%u, %s). NOTE: this is whatever channel was GR-current "
+           "at the read moment — may or may not be this helper's channel; "
+           "SLM-OS validates via pushbuf-PA walk before use.\n",
+           reg, (unsigned long long)inst_phys, target,
+           target == 3 ? "sys_mem_noncoherent" :
+           target == 2 ? "sys_mem_coherent" : "unknown");
+    return inst_phys;
+}
+
 /* SIGTERM handler — on clean shutdown, let the kernel reap us (which
  * releases all nvgpu fds and frees the channel). No explicit cleanup
  * needed because nvgpu's release paths run on fd close. */
@@ -967,7 +1066,15 @@ int main(int argc, char **argv)
         .pushbuf_size       = 65536,
         .semaphore_phys     = sem_phys,
         .semaphore_gpu_va   = sem_map.offset,
-        .inst_block_phys    = 0,  /* filled in from FECS_CURRENT_CTX if needed */
+        .inst_block_phys    = 0,  /* populated post-ALLOC by the isolation
+                                   * test's FECS_CURRENT_CTX read, AFTER
+                                   * the GR engine confirms our channel
+                                   * just ran. See `read_fecs_current_ctx_-
+                                   * inst_phys` + the publish site below the
+                                   * sema-fire branch. The initial-zero
+                                   * sentinel here means "skip", picked up
+                                   * by SLM-OS's `nvgpu oplib stage` to fall
+                                   * back to walk-based discovery. */
         .initial_gp_put     = 0,
         .initial_gp_get     = 0,
         .work_submit_token  = sb.work_submit_token,
@@ -1103,6 +1210,30 @@ int main(int argc, char **argv)
         if (sem_val == HELPER_SMOKETEST_SEM_PAYLOAD) {
             printf("[gpu-helper] >>> ISOLATION: sema fires Linux-side — "
                    "channel capable, kexec breaks state\n");
+
+            /* #788 Stage 9 fix: publish `inst_block_phys` in the
+             * handoff so SLM-OS's `nvgpu oplib stage` doesn't have
+             * to walk DRAM looking for our inst block.
+             *
+             * Critically, we do this read RIGHT AFTER the
+             * isolation-test sema fires — at that moment the GR
+             * engine just ran our pushbuffer, so FECS_CURRENT_CTX
+             * is guaranteed to point at OUR channel. If we read
+             * any later, GR might context-switch back to Xorg or
+             * nvgpu's internal channel. If we read earlier, our
+             * channel might not yet have been scheduled.
+             *
+             * SLM-OS's `oplib stage` still pushbuf-PA validates
+             * before trusting the value, so a wrong inst_block_phys
+             * here (e.g. if FECS drifts before we read in some
+             * future timing-sensitive case) won't propagate as a
+             * bad pointer downstream. */
+            hoff.inst_block_phys = read_fecs_current_ctx_inst_phys();
+            if (hoff.inst_block_phys != 0) {
+                printf("[gpu-helper] >>> publishing inst_block_phys=0x%llx "
+                       "in handoff (skips SLM-OS's DRAM walk)\n",
+                       (unsigned long long)hoff.inst_block_phys);
+            }
         } else if (gp_get_after == 1) {
             printf("[gpu-helper] >>> ISOLATION: PBDMA consumed entry but "
                    "method didn't fire — channel setup incomplete\n");
@@ -1112,7 +1243,8 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Re-read + update handoff with the current GP_PUT/GP_GET values. */
+    /* Re-read + update handoff with the current GP_PUT/GP_GET values
+     * AND the FECS-derived inst_block_phys captured above. */
     hoff.initial_gp_put = ((volatile uint32_t *)userd_va)[35];
     hoff.initial_gp_get = ((volatile uint32_t *)userd_va)[34];
     memcpy(handoff, &hoff, sizeof(hoff));

--- a/scripts/gpu-channel-helper.c
+++ b/scripts/gpu-channel-helper.c
@@ -771,6 +771,149 @@ int main(int argc, char **argv)
                (unsigned long long)weights_pool_gva);
     }
 
+    /* #788 Stage 4: walk the weights pool's pages via
+     * /proc/self/pagemap, coalesce consecutive physical pages
+     * into extents, and publish the list in a separate dmabuf
+     * so SLM-OS can re-establish GMMU PTEs covering the entire
+     * pool post-kexec.
+     *
+     * The 1.5 GB IOVMM-stitched pool is physically scattered
+     * (CMA backing returns hundreds-to-thousands of separate
+     * contiguous physical runs depending on fragmentation).
+     * `weights_pool_phys` records only the first page's phys;
+     * the rest is invisible without the explicit per-page walk
+     * this loop performs.
+     *
+     * Cap matches `GA10B_WEIGHTS_EXTENTS_MAX` in the shared
+     * handoff header (8192 entries × 16 bytes = 128 KB dmabuf).
+     * If a future allocation fragments more than that, we
+     * truncate and warn; the operator's fix is to bump the cap
+     * on both sides in lock-step. */
+    int      extents_dmabuf = -1;
+    void    *extents_va     = NULL;
+    uint64_t extents_phys   = 0;
+    uint32_t n_extents      = 0;
+    const uint32_t MAX_EXTENTS = 8192u;  /* matches GA10B_WEIGHTS_EXTENTS_MAX */
+    const size_t   extents_bytes_total =
+        (size_t)MAX_EXTENTS * sizeof(struct ga10b_phys_extent);
+    if (weights_pool_size > 0 && weights_pool_va != NULL) {
+        extents_dmabuf = nvmap_alloc_dmabuf(nvmap_fd,
+                                            (uint64_t)extents_bytes_total,
+                                            4096);
+        extents_va = mmap(NULL, extents_bytes_total,
+                          PROT_READ | PROT_WRITE,
+                          MAP_SHARED, extents_dmabuf, 0);
+        if (extents_va == MAP_FAILED) {
+            perror("[gpu-helper] mmap extents dmabuf");
+            extents_va = NULL;
+        } else {
+            memset(extents_va, 0, extents_bytes_total);
+            msync(extents_va, extents_bytes_total, MS_SYNC);
+            extents_phys = virt_to_phys(extents_va);
+            if (extents_phys == 0) {
+                fprintf(stderr, "[gpu-helper] extents dmabuf phys "
+                        "resolution failed — extents disabled\n");
+                extents_va = NULL;
+            }
+        }
+    }
+
+    if (extents_va != NULL) {
+        /* First-touch the weights pool to force every page to
+         * fault in. NVMAP's IOVMM-backed dmabuf creates a userspace
+         * mmap that's lazy — pages aren't bound to physical backing
+         * until accessed. Without touching them first,
+         * /proc/self/pagemap reports "page not present" for the
+         * entire 1.5 GB and the extent walk finds nothing.
+         *
+         * A single byte read per page is enough to fault it in.
+         * 393,216 pages × ~ns-scale read ≈ ~1-2 s on Tegra Orin
+         * Nano — a one-time pre-kexec cost; nothing on the hot
+         * path. */
+        {
+            volatile uint8_t *touch = (volatile uint8_t *)weights_pool_va;
+            for (size_t pi = 0;
+                 pi < weights_pool_size / 4096u;
+                 pi++) {
+                (void)touch[pi * 4096u];
+            }
+        }
+
+        /* Walk every 4 KB page in the weights pool, resolving
+         * its physical address via /proc/self/pagemap. Coalesce
+         * consecutive pages whose physes match `prev_phys +
+         * 4 KB` into one extent entry, and flush the current
+         * extent when a discontinuity appears or we reach the
+         * pool's end. */
+        struct ga10b_phys_extent *extents = extents_va;
+        size_t   total_pages  = weights_pool_size / 4096u;
+        uint64_t cur_run_phys = 0;
+        uint32_t cur_run_pages = 0;
+        size_t   pagemap_failures = 0;
+        uint8_t *base = (uint8_t *)weights_pool_va;
+
+        for (size_t pi = 0; pi < total_pages; pi++) {
+            uint64_t va = (uint64_t)(uintptr_t)base + pi * 4096ull;
+            uint64_t phys = virt_to_phys((void *)(uintptr_t)va);
+            if (phys == 0) {
+                pagemap_failures++;
+                /* Flush current run; skip this page. SLM-OS
+                 * will leave the corresponding 4 KB hole in
+                 * the GMMU and a CE memcpy that lands there
+                 * will MMU-fault. */
+                if (cur_run_pages > 0 && n_extents < MAX_EXTENTS) {
+                    extents[n_extents].phys = cur_run_phys;
+                    extents[n_extents].n_pages = cur_run_pages;
+                    extents[n_extents].reserved = 0;
+                    n_extents++;
+                    cur_run_phys = 0;
+                    cur_run_pages = 0;
+                }
+                continue;
+            }
+            if (cur_run_pages == 0) {
+                cur_run_phys = phys;
+                cur_run_pages = 1;
+            } else if (phys ==
+                       cur_run_phys + (uint64_t)cur_run_pages * 4096ull) {
+                cur_run_pages++;
+            } else {
+                /* Discontinuity — flush. */
+                if (n_extents < MAX_EXTENTS) {
+                    extents[n_extents].phys = cur_run_phys;
+                    extents[n_extents].n_pages = cur_run_pages;
+                    extents[n_extents].reserved = 0;
+                    n_extents++;
+                } else {
+                    /* Table full — break out, will warn below. */
+                    break;
+                }
+                cur_run_phys = phys;
+                cur_run_pages = 1;
+            }
+        }
+        /* Flush final run. */
+        if (cur_run_pages > 0 && n_extents < MAX_EXTENTS) {
+            extents[n_extents].phys = cur_run_phys;
+            extents[n_extents].n_pages = cur_run_pages;
+            extents[n_extents].reserved = 0;
+            n_extents++;
+        }
+        msync(extents_va, extents_bytes_total, MS_SYNC);
+
+        printf("[gpu-helper] Weights extents: %u runs (%zu pages "
+               "total) → phys=0x%llx",
+               (unsigned)n_extents, total_pages,
+               (unsigned long long)extents_phys);
+        if (n_extents == MAX_EXTENTS) {
+            printf(" [TRUNCATED — bump MAX_EXTENTS]");
+        }
+        if (pagemap_failures > 0) {
+            printf(" [%zu pagemap failures]", pagemap_failures);
+        }
+        printf("\n");
+    }
+
     /* Allocate a dedicated dmabuf for the handoff block. Writing via
      * /dev/mem is blocked by CONFIG_STRICT_DEVMEM for System RAM, but
      * we can write to dmabuf memory via its own mmap. SLM-OS scans
@@ -795,10 +938,11 @@ int main(int argc, char **argv)
      *   v8 — weights pool allocated (W1, this commit)
      *   v7 — QMD pool allocated (no weights pool)
      *   v2 — channel-only (no v7 pool, no weights pool)
-     * Each higher version is a strict superset: v7 readers can
-     * consume v8 handoffs by ignoring the trailing weights_pool_*
-     * fields, v2 readers ignore both v7 and v8 trailing bytes. */
-    uint32_t handoff_version = (weights_pool_size > 0) ? 8u
+     * Each higher version is a strict superset: v9 readers can
+     * consume v8 handoffs by ignoring the trailing weights_extents_*
+     * fields, v8 readers ignore v9, etc. */
+    uint32_t handoff_version = (n_extents > 0)         ? 9u
+                              : (weights_pool_size > 0) ? 8u
                               : (qmd_pool_slots > 0)   ? 7u
                               :                          2u;
     struct ga10b_channel_handoff hoff = {
@@ -846,6 +990,10 @@ int main(int argc, char **argv)
         .weights_pool_phys       = weights_pool_phys,
         .weights_pool_gpu_va     = weights_pool_gva,
         .weights_pool_size_bytes = weights_pool_size,
+        /* v9-only: weights-pool per-page extents. Zero in v2..v8
+         * mode (no pagemap walk done). #788 Stage 4. */
+        .weights_extents_phys    = extents_phys,
+        .weights_n_extents       = n_extents,
     };
     memcpy(handoff, &hoff, sizeof(hoff));
     msync(handoff, 4096, MS_SYNC);

--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -133,6 +133,11 @@ struct mnist_op {
     uint32_t v7_smem_size_bytes;    /* SHARED_MEMORY_SIZE; non-zero for HMMA */
     uint32_t v7_slm_size_bytes;     /* SHADER_LOCAL_MEM size */
     uint32_t v7_barrier_count;      /* BARRIER_COUNT; 3 for the WMMA SASS */
+    /* #788 Mode B fix (v7.1): per-op shader phys + size for SLM-OS's
+     * PMM reservation. Captured via gpu_virt_to_phys at allocation
+     * time — no GMMU walking needed post-kexec. */
+    uint64_t v7_shader_phys;
+    uint32_t v7_shader_size_bytes;
 };
 
 /* Record the v7 dispatch inputs alongside each helper-baked QMD.
@@ -146,6 +151,23 @@ struct mnist_op {
         (op_)->v7_register_count_v = GPU_LAUNCH_REGISTER_COUNT_V_DEFAULT;   \
         (op_)->v7_grid_x = (gx_); (op_)->v7_grid_y = (gy_); (op_)->v7_grid_z = (gz_); \
         (op_)->v7_block_x = (bx_); (op_)->v7_block_y = (by_); (op_)->v7_block_z = (bz_); \
+    } while (0)
+
+/* #788 Mode B v7.1 shader phys+size: captured per-op after
+ * MNIST_RECORD_V7 fires. Pass the originating gpu_buffer (or NULL
+ * + ctx for the special case where the shader lives in ctx.shader_va
+ * — the conv2d shader on this launcher). The buffer's `.phys` and
+ * `.size_bytes` are what SLM-OS will reserve from PMM.
+ *
+ * For the conv2d case (ctx.shader_va), the buffer is a single 65536-B
+ * dmabuf allocated by gpu_launch_setup; phys is gpu_virt_to_phys of
+ * its mmap address. Size is the full dmabuf, not just SASS_len —
+ * reserving the whole dmabuf covers any future shader-bytes growth
+ * within that allocation. */
+#define MNIST_RECORD_V7_SHADER_PHYS(op_, shader_phys_, shader_size_) \
+    do {                                                              \
+        (op_)->v7_shader_phys       = (shader_phys_);                 \
+        (op_)->v7_shader_size_bytes = (shader_size_);                 \
     } while (0)
 
 int main(int argc, char **argv)
@@ -244,6 +266,32 @@ int main(int argc, char **argv)
     uint64_t addrelu_shader_gva = addrelu_shader.gpu_va;
     uint64_t pool_shader_gva    = pool_shader.gpu_va;
     uint64_t gemm_shader_gva    = gemm_shader.gpu_va;
+
+    /* #788 Mode B fix: capture per-shader phys+size for SLM-OS PMM
+     * reservation. Each shader is allocated as a separate dmabuf;
+     * the helper has the phys via gpu_virt_to_phys, no GMMU walking
+     * needed post-kexec.
+     *
+     * Size is the SASS byte count from the .sass file, page-rounded
+     * up. The dmabuf alloc is 64 KB but the actual SASS bytes are
+     * 1-20 KB depending on kernel — over-reserving the full 64 KB
+     * would protect 15 phys pages of irrelevant memory, potentially
+     * clobbering FECS ctx_save state in adjacent phys (#788 Mode D
+     * issue from the earlier GMMU-walk attempt). */
+    uint64_t conv_shader_phys    = gpu_virt_to_phys(ctx.shader_va);
+    uint32_t conv_shader_rsv_sz  = (uint32_t)((conv_size + 4095u) & ~4095u);
+    uint64_t addrelu_shader_phys = addrelu_shader.phys;
+    uint32_t addrelu_rsv_sz      = (uint32_t)((addrelu_size + 4095u) & ~4095u);
+    uint64_t pool_shader_phys    = pool_shader.phys;
+    uint32_t pool_rsv_sz         = (uint32_t)((pool_size + 4095u) & ~4095u);
+    uint64_t gemm_shader_phys    = gemm_shader.phys;
+    uint32_t gemm_rsv_sz         = (uint32_t)((gemm_size + 4095u) & ~4095u);
+    printf("[mnist] shader phys: conv=0x%llx(%u B) addrelu=0x%llx(%u B) "
+           "pool=0x%llx(%u B) gemm=0x%llx(%u B)\n",
+           (unsigned long long)conv_shader_phys, conv_shader_rsv_sz,
+           (unsigned long long)addrelu_shader_phys, addrelu_rsv_sz,
+           (unsigned long long)pool_shader_phys, pool_rsv_sz,
+           (unsigned long long)gemm_shader_phys, gemm_rsv_sz);
 
     /* --- Weight buffers + input --- */
     struct gpu_buffer W_conv1 = gpu_alloc_buffer(&ctx,  4096, 4096);  /* 800 B */
@@ -380,6 +428,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, conv_shader_gva,
                         grid_x, grid_y, grid_z, 256u, 1u, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, conv_shader_phys, conv_shader_rsv_sz);
     }
 
     /* Op 1: Add+ReLU on Conv1 output. Shape 1×8×28×28. */
@@ -412,6 +461,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, addrelu_shader_gva,
                         grid_x, 8u, 1u, 256u, 1u, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, addrelu_shader_phys, addrelu_rsv_sz);
     }
 
     /* Op 2: MaxPool1. Shape 1×8×28×28 → 1×8×14×14. */
@@ -448,6 +498,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, pool_shader_gva,
                         grid_x, 8u, 1u, 256u, 1u, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, pool_shader_phys, pool_rsv_sz);
     }
 
     /* Op 3: Conv2. Shape 1×8×14×14, 16 out-ch. */
@@ -484,6 +535,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, conv_shader_gva,
                         grid_x, 16u, 1u, 256u, 1u, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, conv_shader_phys, conv_shader_rsv_sz);
     }
 
     /* Op 4: Add+ReLU on Conv2 output. Shape 1×16×14×14. */
@@ -516,6 +568,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, addrelu_shader_gva,
                         grid_x, 16u, 1u, 256u, 1u, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, addrelu_shader_phys, addrelu_rsv_sz);
     }
 
     /* Op 5: MaxPool2. Shape 1×16×14×14 → 1×16×4×4. */
@@ -552,6 +605,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, pool_shader_gva,
                         grid_x, 16u, 1u, 256u, 1u, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, pool_shader_phys, pool_rsv_sz);
     }
 
     /* Op 6: GEMM. M=1, K=256, N=10. Reshape is free (pool2 output is
@@ -617,6 +671,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, gemm_shader_gva,
                         grid_x, grid_y, 1u, block_x, block_y, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, gemm_shader_phys, gemm_rsv_sz);
         /* HMMA QMD overrides for the v7 dispatch path. SLM-OS rebuilds
          * the QMD per-launch from these op fields and otherwise leaves
          * SHARED_MEMORY_SIZE / BARRIER_COUNT at the encoder's defaults
@@ -658,6 +713,7 @@ int main(int argc, char **argv)
         msync(op->qmd_page.cpu_va, op->qmd_page.size_bytes, MS_SYNC);
         MNIST_RECORD_V7(op, addrelu_shader_gva,
                         1u, 10u, 1u, 256u, 1u, 1u);
+        MNIST_RECORD_V7_SHADER_PHYS(op, addrelu_shader_phys, addrelu_rsv_sz);
     }
 
     /* Pre-zero every output buffer so the per-cell sentinel poll
@@ -856,6 +912,11 @@ int main(int argc, char **argv)
             p[i].smem_size_bytes  = ops[i].v7_smem_size_bytes;
             p[i].slm_size_bytes   = ops[i].v7_slm_size_bytes;
             p[i].barrier_count    = ops[i].v7_barrier_count;
+            /* #788 Mode B v7.1: per-op shader phys + size. SLM-OS
+             * uses these to reserve the shader pages from PMM
+             * without GMMU walking. */
+            p[i].shader_phys       = ops[i].v7_shader_phys;
+            p[i].shader_size_bytes = ops[i].v7_shader_size_bytes;
         }
         msync(pipe_ops.cpu_va, pipe_ops.size_bytes, MS_SYNC);
     } else {

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -98,6 +98,65 @@ uint64_t gpu_virt_to_phys(void *vaddr)
     return pfn * 4096 + ((uint64_t)vaddr & 0xFFF);
 }
 
+uint64_t gpu_read_fecs_inst_block_phys(void)
+{
+    /* GA10B GPU BAR0 base + FECS_CURRENT_CTX offset. Hardcoded to
+     * keep this TU free of GPU-specific header dependencies — both
+     * constants are pinned by SLM-OS's `ga10b_handoff_reserve.c`
+     * which reads the same register from the kernel side post-kexec. */
+    const uint64_t bar0_base       = 0x17000000ull;
+    const uint32_t fecs_ctx_offset = 0x00409b00u;
+    const uint64_t page_size       = 4096u;
+
+    int fd = open("/dev/mem", O_RDONLY | O_SYNC);
+    if (fd < 0) {
+        fprintf(stderr,
+                "[gpu-launch] FECS read: open(/dev/mem) failed: %s "
+                "(run as root). inst_block_phys=0 — SLM-OS falls back "
+                "to DRAM walk.\n", strerror(errno));
+        return 0;
+    }
+
+    uint64_t reg_abs   = bar0_base + fecs_ctx_offset;
+    uint64_t page_base = reg_abs & ~(page_size - 1);
+    uint32_t page_off  = (uint32_t)(reg_abs & (page_size - 1));
+
+    void *map = mmap(NULL, page_size, PROT_READ, MAP_SHARED, fd,
+                     (off_t)page_base);
+    close(fd);
+    if (map == MAP_FAILED) {
+        fprintf(stderr,
+                "[gpu-launch] FECS read: mmap @0x%llx failed: %s. "
+                "inst_block_phys=0.\n",
+                (unsigned long long)page_base, strerror(errno));
+        return 0;
+    }
+
+    volatile uint32_t *reg_ptr =
+        (volatile uint32_t *)((uint8_t *)map + page_off);
+    uint32_t reg = *reg_ptr;
+    munmap(map, page_size);
+
+    if ((reg & 0xFFFF0000u) == 0xbadf0000u) {
+        fprintf(stderr,
+                "[gpu-launch] FECS read: register=0x%08x (priv-bad — "
+                "GPU power-gated?). inst_block_phys=0.\n", reg);
+        return 0;
+    }
+    uint32_t target = (reg >> 28) & 0x3u;
+    if (target == 0) {
+        fprintf(stderr,
+                "[gpu-launch] FECS read: register=0x%08x (target=0 — "
+                "no current ctx). inst_block_phys=0.\n", reg);
+        return 0;
+    }
+    uint64_t inst_phys = ((uint64_t)(reg & 0x0FFFFFFFu)) << 12;
+    printf("[gpu-launch] FECS_CURRENT_CTX=0x%08x → "
+           "inst_block_phys=0x%llx (target=%u). Publishing in handoff.\n",
+           reg, (unsigned long long)inst_phys, target);
+    return inst_phys;
+}
+
 /* gpu_qmd_set_bits is now `static inline` in scripts/gpu-qmd-bits.h
  * so the host-test harness can pick it up directly. See that header
  * for the implementation + UB-shift-guard rationale. */
@@ -729,7 +788,7 @@ uint64_t gpu_write_handoff_v4(const struct gpu_launch_ctx *ctx,
          * anyway. */
         .semaphore_phys     = output_phys,
         .semaphore_gpu_va   = output_gpu_va,
-        .inst_block_phys    = 0,
+        .inst_block_phys    = gpu_read_fecs_inst_block_phys(),
         .initial_gp_put     = ((volatile uint32_t *)ctx->userd_va)
                                 [GPU_LAUNCH_USERD_GP_PUT_WORD],
         .initial_gp_get     = ((volatile uint32_t *)ctx->userd_va)
@@ -800,7 +859,7 @@ uint64_t gpu_write_handoff_v5(const struct gpu_launch_ctx *ctx,
          * caller provides a meaningful (final-op) target. */
         .semaphore_phys     = output_phys,
         .semaphore_gpu_va   = output_gpu_va,
-        .inst_block_phys    = 0,
+        .inst_block_phys    = gpu_read_fecs_inst_block_phys(),
         .initial_gp_put     = ((volatile uint32_t *)ctx->userd_va)
                                 [GPU_LAUNCH_USERD_GP_PUT_WORD],
         .initial_gp_get     = ((volatile uint32_t *)ctx->userd_va)
@@ -868,7 +927,7 @@ uint64_t gpu_write_handoff_v6(const struct gpu_launch_ctx *ctx,
         .pushbuf_size       = 65536,
         .semaphore_phys     = output_phys,
         .semaphore_gpu_va   = output_gpu_va,
-        .inst_block_phys    = 0,
+        .inst_block_phys    = gpu_read_fecs_inst_block_phys(),
         .initial_gp_put     = ((volatile uint32_t *)ctx->userd_va)
                                 [GPU_LAUNCH_USERD_GP_PUT_WORD],
         .initial_gp_get     = ((volatile uint32_t *)ctx->userd_va)
@@ -1022,7 +1081,7 @@ uint64_t gpu_write_handoff_v7(const struct gpu_launch_ctx *ctx,
         .pushbuf_size       = 65536,
         .semaphore_phys     = output_phys,
         .semaphore_gpu_va   = output_gpu_va,
-        .inst_block_phys    = 0,
+        .inst_block_phys    = gpu_read_fecs_inst_block_phys(),
         .initial_gp_put     = ((volatile uint32_t *)ctx->userd_va)
                                 [GPU_LAUNCH_USERD_GP_PUT_WORD],
         .initial_gp_get     = ((volatile uint32_t *)ctx->userd_va)

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -98,6 +98,85 @@ uint64_t gpu_virt_to_phys(void *vaddr)
     return pfn * 4096 + ((uint64_t)vaddr & 0xFFF);
 }
 
+int gpu_collect_gr_ctx_extents(struct gpu_launch_ctx *ctx,
+                                uint64_t *out_extents_phys,
+                                uint32_t *out_n_extents)
+{
+    /* Match the v9 weights extents layout (16 B per entry). */
+    struct gr_phys_extent {
+        uint64_t phys;
+        uint32_t n_pages;
+        uint32_t reserved;
+    };
+
+    *out_extents_phys = 0;
+    *out_n_extents = 0;
+
+    FILE *fp = fopen("/sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys", "r");
+    if (!fp) {
+        fprintf(stderr,
+                "[gpu-launch] gr_ctx_extents: open debugfs failed: %s "
+                "(patched nvgpu.ko not installed?). Skipping v10 publish.\n",
+                strerror(errno));
+        return -1;
+    }
+
+    /* Allocate a 4 KB dmabuf — fits 256 entries (16 channels × 8 buffers
+     * = 128 entries worst case, plenty of headroom). */
+    int dmabuf = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 4096, 4096);
+    void *va = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, dmabuf, 0);
+    if (va == MAP_FAILED) {
+        perror("[gpu-launch] gr_ctx_extents: mmap dmabuf");
+        fclose(fp);
+        return -1;
+    }
+    memset(va, 0, 4096);
+
+    struct gr_phys_extent *entries = (struct gr_phys_extent *)va;
+    uint32_t n = 0;
+    char line[256];
+    /* Skip the header line ("chid tsgid idx phys size"). */
+    if (!fgets(line, sizeof(line), fp)) {
+        fclose(fp);
+        munmap(va, 4096);
+        return -1;
+    }
+    while (fgets(line, sizeof(line), fp) && n < 256u) {
+        uint32_t chid, tsgid, idx;
+        unsigned long long phys;
+        unsigned long size;
+        if (sscanf(line, "%u %u %u 0x%llx %lu",
+                   &chid, &tsgid, &idx, &phys, &size) != 5) {
+            continue;
+        }
+        if (phys == 0 || size == 0) continue;
+        uint64_t base = phys & ~4095ull;
+        uint64_t end  = (phys + size + 4095ull) & ~4095ull;
+        uint32_t n_pages = (uint32_t)((end - base) / 4096ull);
+        entries[n].phys = base;
+        entries[n].n_pages = n_pages;
+        entries[n].reserved = 0;
+        n++;
+    }
+    fclose(fp);
+    msync(va, 4096, MS_SYNC);
+
+    uint64_t extents_phys = gpu_virt_to_phys(va);
+    if (extents_phys == 0) {
+        fprintf(stderr,
+                "[gpu-launch] gr_ctx_extents: gpu_virt_to_phys returned 0. "
+                "Skipping v10 publish.\n");
+        munmap(va, 4096);
+        return -1;
+    }
+
+    *out_extents_phys = extents_phys;
+    *out_n_extents = n;
+    printf("[gpu-launch] gr_ctx_extents: %u extents @ phys 0x%llx\n",
+           n, (unsigned long long)extents_phys);
+    return 0;
+}
+
 uint64_t gpu_read_fecs_inst_block_phys(void)
 {
     /* GA10B GPU BAR0 base + FECS_CURRENT_CTX offset. Hardcoded to
@@ -1113,6 +1192,21 @@ uint64_t gpu_write_handoff_v7(const struct gpu_launch_ctx *ctx,
         .qmd_pool_size_bytes = ctx->qmd_pool_size_bytes,
         .qmd_pool_n_slots   = ctx->qmd_pool_n_slots,
     };
+
+    /* #788 Mode C v10: collect per-channel GR ctx buffer phys ranges
+     * via the patched-nvgpu debugfs file and publish them in the
+     * handoff. Failure is non-fatal — older / unpatched nvgpu just
+     * leaves the fields zero and SLM-OS skips the reservation. */
+    {
+        uint64_t gr_ext_phys = 0;
+        uint32_t gr_ext_n    = 0;
+        if (gpu_collect_gr_ctx_extents((struct gpu_launch_ctx *)ctx,
+                                       &gr_ext_phys, &gr_ext_n) == 0) {
+            hoff.gr_ctx_extents_phys = gr_ext_phys;
+            hoff.gr_ctx_n_extents    = gr_ext_n;
+        }
+    }
+
     memcpy(handoff_va, &hoff, sizeof(hoff));
     msync(handoff_va, 4096, MS_SYNC);
 

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -98,67 +98,92 @@ uint64_t gpu_virt_to_phys(void *vaddr)
     return pfn * 4096 + ((uint64_t)vaddr & 0xFFF);
 }
 
-int gpu_collect_gr_ctx_extents(struct gpu_launch_ctx *ctx,
-                                uint64_t *out_extents_phys,
-                                uint32_t *out_n_extents)
+/* Parse one debugfs file and append entries into the extents array.
+ * Returns number of entries appended. Skips entries whose phys looks
+ * like a kernel VA (top 16 bits set — the VPR-protected buffers fall
+ * into this case; nvgpu_mem_get_phys_addr returns the cpu_va for
+ * those instead of a real DRAM phys). */
+struct slmos_phys_extent {
+    uint64_t phys;
+    uint32_t n_pages;
+    uint32_t reserved;
+};
+
+static uint32_t parse_phys_file_into_extents(const char *path,
+                                              struct slmos_phys_extent *entries,
+                                              uint32_t start_idx,
+                                              uint32_t cap)
 {
-    /* Match the v9 weights extents layout (16 B per entry). */
-    struct gr_phys_extent {
-        uint64_t phys;
-        uint32_t n_pages;
-        uint32_t reserved;
-    };
-
-    *out_extents_phys = 0;
-    *out_n_extents = 0;
-
-    FILE *fp = fopen("/sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys", "r");
+    FILE *fp = fopen(path, "r");
     if (!fp) {
         fprintf(stderr,
-                "[gpu-launch] gr_ctx_extents: open debugfs failed: %s "
-                "(patched nvgpu.ko not installed?). Skipping v10 publish.\n",
-                strerror(errno));
-        return -1;
+                "[gpu-launch] gr_ctx_extents: %s open failed: %s\n",
+                path, strerror(errno));
+        return 0;
     }
-
-    /* Allocate a 4 KB dmabuf — fits 256 entries (16 channels × 8 buffers
-     * = 128 entries worst case, plenty of headroom). */
-    int dmabuf = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 4096, 4096);
-    void *va = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, dmabuf, 0);
-    if (va == MAP_FAILED) {
-        perror("[gpu-launch] gr_ctx_extents: mmap dmabuf");
-        fclose(fp);
-        return -1;
-    }
-    memset(va, 0, 4096);
-
-    struct gr_phys_extent *entries = (struct gr_phys_extent *)va;
-    uint32_t n = 0;
     char line[256];
-    /* Skip the header line ("chid tsgid idx phys size"). */
-    if (!fgets(line, sizeof(line), fp)) {
-        fclose(fp);
-        munmap(va, 4096);
-        return -1;
-    }
-    while (fgets(line, sizeof(line), fp) && n < 256u) {
+    if (!fgets(line, sizeof(line), fp)) { fclose(fp); return 0; }
+    uint32_t n = 0;
+    while (fgets(line, sizeof(line), fp) && (start_idx + n) < cap) {
         uint32_t chid, tsgid, idx;
         unsigned long long phys;
         unsigned long size;
         if (sscanf(line, "%u %u %u 0x%llx %lu",
-                   &chid, &tsgid, &idx, &phys, &size) != 5) {
-            continue;
-        }
+                   &chid, &tsgid, &idx, &phys, &size) != 5) continue;
         if (phys == 0 || size == 0) continue;
+        /* Reject obvious kernel-VA returns (top byte set). On Tegra DRAM
+         * phys is at most 0x2_8000_0000 (10 GB) — anything above
+         * 0x10_0000_0000 is a kernel virtual address that
+         * nvgpu_mem_get_phys_addr returned as a fallback (e.g. for
+         * VPR-protected buffers). SLM-OS would skip these via
+         * ga10b_phys_in_dram anyway but we save a slot. */
+        if (phys >= 0x1000000000ull) continue;
         uint64_t base = phys & ~4095ull;
         uint64_t end  = (phys + size + 4095ull) & ~4095ull;
-        uint32_t n_pages = (uint32_t)((end - base) / 4096ull);
-        entries[n].phys = base;
-        entries[n].n_pages = n_pages;
-        entries[n].reserved = 0;
+        uint32_t pages = (uint32_t)((end - base) / 4096ull);
+        entries[start_idx + n].phys = base;
+        entries[start_idx + n].n_pages = pages;
+        entries[start_idx + n].reserved = 0;
         n++;
     }
     fclose(fp);
+    return n;
+}
+
+int gpu_collect_gr_ctx_extents(struct gpu_launch_ctx *ctx,
+                                uint64_t *out_extents_phys,
+                                uint32_t *out_n_extents)
+{
+    *out_extents_phys = 0;
+    *out_n_extents = 0;
+
+    /* Allocate a 4 KB dmabuf — fits 256 entries (16 channels × 8 buffers
+     * + 9 globals = ~140 entries worst case, plenty of headroom). */
+    int dmabuf = gpu_nvmap_alloc_dmabuf(ctx->nvmap_fd, 4096, 4096);
+    void *va = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, dmabuf, 0);
+    if (va == MAP_FAILED) {
+        perror("[gpu-launch] gr_ctx_extents: mmap dmabuf");
+        return -1;
+    }
+    memset(va, 0, 4096);
+
+    struct slmos_phys_extent *entries = (struct slmos_phys_extent *)va;
+    uint32_t total = 0;
+    total += parse_phys_file_into_extents(
+        "/sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys",
+        entries, total, 256u);
+    total += parse_phys_file_into_extents(
+        "/sys/kernel/debug/gpu.0/fifo/slmos_global_ctx_phys",
+        entries, total, 256u);
+
+    if (total == 0) {
+        fprintf(stderr,
+                "[gpu-launch] gr_ctx_extents: 0 entries from both debugfs "
+                "files (patched nvgpu.ko not installed, or no channels "
+                "active). Skipping v10 publish.\n");
+        munmap(va, 4096);
+        return -1;
+    }
     msync(va, 4096, MS_SYNC);
 
     uint64_t extents_phys = gpu_virt_to_phys(va);
@@ -171,9 +196,10 @@ int gpu_collect_gr_ctx_extents(struct gpu_launch_ctx *ctx,
     }
 
     *out_extents_phys = extents_phys;
-    *out_n_extents = n;
-    printf("[gpu-launch] gr_ctx_extents: %u extents @ phys 0x%llx\n",
-           n, (unsigned long long)extents_phys);
+    *out_n_extents = total;
+    printf("[gpu-launch] gr_ctx_extents: %u entries @ phys 0x%llx "
+           "(per-channel + global)\n",
+           total, (unsigned long long)extents_phys);
     return 0;
 }
 

--- a/scripts/gpu-launch-common.c
+++ b/scripts/gpu-launch-common.c
@@ -175,6 +175,9 @@ int gpu_collect_gr_ctx_extents(struct gpu_launch_ctx *ctx,
     total += parse_phys_file_into_extents(
         "/sys/kernel/debug/gpu.0/fifo/slmos_global_ctx_phys",
         entries, total, 256u);
+    total += parse_phys_file_into_extents(
+        "/sys/kernel/debug/gpu.0/fifo/slmos_falcon_ucode_phys",
+        entries, total, 256u);
 
     if (total == 0) {
         fprintf(stderr,

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -285,6 +285,24 @@ void *gpu_load_file(const char *path, size_t *out_size);
  * /proc/self/pagemap. Returns 0 on failure. */
 uint64_t gpu_virt_to_phys(void *vaddr);
 
+/* Read /sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys (exposed by a
+ * patched nvgpu.ko) and produce a v10 GR-ctx-extents dmabuf for
+ * publication in the channel handoff.
+ *
+ * Allocates a new nvmap dmabuf, copies parsed (phys, n_pages) pairs
+ * into it, and returns the dmabuf phys + entry count via the out
+ * parameters. The dmabuf is leaked intentionally — it must stay
+ * resident through kexec so SLM-OS can read it in
+ * ga10b_kexec_handoff_register_reserves.
+ *
+ * Returns 0 on success (out fields valid), -1 on failure (out fields
+ * set to 0). Failure is non-fatal — the channel handoff just won't
+ * carry v10 gr_ctx_extents, and SLM-OS will see n=0 and skip the
+ * reservation. */
+int gpu_collect_gr_ctx_extents(struct gpu_launch_ctx *ctx,
+                                uint64_t *out_extents_phys,
+                                uint32_t *out_n_extents);
+
 /* Read GA10B's FECS_CURRENT_CTX register via /dev/mem and decode the
  * channel inst-block phys it points to.
  *

--- a/scripts/gpu-launch-common.h
+++ b/scripts/gpu-launch-common.h
@@ -285,6 +285,23 @@ void *gpu_load_file(const char *path, size_t *out_size);
  * /proc/self/pagemap. Returns 0 on failure. */
 uint64_t gpu_virt_to_phys(void *vaddr);
 
+/* Read GA10B's FECS_CURRENT_CTX register via /dev/mem and decode the
+ * channel inst-block phys it points to.
+ *
+ * Intended for use by helpers right before publishing the handoff —
+ * by then the helper's own pushbuffer submissions have made FECS
+ * load our channel onto GR, so the live register value matches the
+ * channel SLM-OS will inherit. SLM-OS's `nvgpu oplib stage` reads
+ * the published `inst_block_phys` directly, bypassing the multi-GB
+ * DRAM walk that otherwise has to scan for a candidate inst block.
+ *
+ * Returns the decoded phys on success, or 0 if /dev/mem isn't
+ * accessible (helper not root), the register reads as priv-bad
+ * poison, or the target aperture is 0 (no current ctx). Caller
+ * stores 0 in `h->inst_block_phys` on failure, which SLM-OS treats
+ * as "skip, fall back to discovery". #788 Stage 9. */
+uint64_t gpu_read_fecs_inst_block_phys(void);
+
 /* Full channel bringup: alloc AS, open TSG + channel, bind
  * subcontext, SETUP_BIND, ALLOC_OBJ_CTX(COMPUTE_B),
  * SET_PREEMPT_MODE, SET_ERROR_NOTIFIER, allocate + register + map

--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -1073,5 +1073,72 @@ else
     kexec -l "$KERNEL" --command-line="$KEXEC_CMDLINE"
 fi
 
+# Pre-fire safety check + force-on (#788 stress test Mode A fix).
+#
+# Stress testing across 10 boot cycles revealed a 30% rate of GPU
+# power-gated post-kexec (all GR MMIO reads as `0xbadf1002` PRI
+# poison; SLM-OS's NV_PMC_BOOT_0 returns 0xFFFFFFFF). Root cause:
+# in --no-gpu-suspend mode we rely on the channel-helper's open
+# nvgpu fd to keep the GPU active, but Linux can still autosuspend
+# the GPU between the helper's "kexec now" message (step 4) and
+# the actual `kexec -e` fire (step 9). Steps 5-7 take several
+# seconds (USB hold + SMMU load + handoff stashing) which is enough
+# window for an aggressive PM policy to gate the GPU.
+#
+# Fix: force-on the GPU clocks + powergate at the LAST possible
+# moment before exec'ing kexec, regardless of suspend mode. Same
+# BPMP debugfs writes the suspend-mode path does in step 3 — these
+# are channel-preserving writes that go through the kernel BPMP
+# driver (BPMP firmware accepts them; SLM-OS's own BPMP MRQs are
+# rejected per #190 so this is our only window).
+#
+# Also: verify the helper is still alive. If it died (timed out,
+# crashed, killed), no channel will be live and inheritance fails
+# regardless of GPU power state.
+if [[ -d "$GPU_POWER" && -d "$BPMP" ]]; then
+    echo "[8.5/9] Pre-kexec GPU force-on + sanity check..."
+
+    # Helper liveness check (only relevant in --no-gpu-suspend mode).
+    if [[ "$NO_GPU_SUSPEND" == "1" && "$NO_HELPER" != "1" ]]; then
+        helper_dir="${SLMOS_HELPER_DIR:-/root/gpu-mnist}"
+        helper_path_re="$(printf '%s' "$helper_dir/gpu-kernel-mnist" | \
+                          sed 's/[][\\.*^$()+?{}|]/\\&/g')"
+        if pgrep -fx "$helper_path_re --preserve-for-kexec.*" >/dev/null 2>&1; then
+            echo "       gpu-kernel-mnist still alive ($(pgrep -fx \"$helper_path_re --preserve-for-kexec.*\" | head -1))"
+        else
+            echo "Warning: gpu-kernel-mnist NOT running at kexec time — channel inherit will fail" >&2
+            echo "         (tail of helper log:)" >&2
+            tail -10 /tmp/gpu-kernel-mnist.log 2>/dev/null >&2 || true
+        fi
+    fi
+
+    # Unconditional GPU force-on. Mirror step 3's suspend-mode
+    # sequence — channel-preserving on warm GPU, no-op-ish if
+    # GPU is already up.
+    echo 1 > "$BPMP/powergate/gpu/state" 2>/dev/null || \
+        echo "       powergate write failed (state may already be 1)" >&2
+    for clk in gpu_pwr gpusysclk gpunvdclk nafll_gpusys; do
+        if [[ -w "$BPMP/clk/$clk/state" ]]; then
+            echo 1 > "$BPMP/clk/$clk/state" 2>/dev/null || true
+        fi
+    done
+
+    # Verify by reading NV_PMC_BOOT_0 via /dev/mem. This is the
+    # same register SLM-OS reads to identify the GPU; if Linux
+    # reads 0xB7B000A1 here and SLM-OS reads 0xFFFFFFFF post-
+    # kexec, we know the gating happened during kexec's
+    # device-shutdown sweep (different fix needed). If Linux
+    # reads 0xFFFFFFFF here too, the GPU is already gated and
+    # this iteration is hopeless.
+    pmc_boot0="$(busybox devmem 0x17000000 2>/dev/null || echo 'devmem-failed')"
+    pg_now="$(cat "$BPMP/powergate/gpu/state" 2>/dev/null || echo '?')"
+    gpusys_now="$(cat "$BPMP/clk/gpusysclk/state" 2>/dev/null || echo '?')"
+    echo "       NV_PMC_BOOT_0=$pmc_boot0 powergate=$pg_now gpusysclk=$gpusys_now"
+    if [[ "$pmc_boot0" == "0xFFFFFFFF" || "$pmc_boot0" == "devmem-failed" ]]; then
+        echo "Warning: GPU appears power-gated at kexec time (NV_PMC_BOOT_0=$pmc_boot0)" >&2
+        echo "         SLM-OS GPU init will fail with PRI-bad poison reads" >&2
+    fi
+fi
+
 echo "[9/9] Executing kexec (serial console will take over)"
 exec kexec -e


### PR DESCRIPTION
## Summary

The N=30 stress-test journey that established the empirical baseline behind PR #820 (the kexec retry orchestrator) and motivated follow-up #819 (deterministic GR-ctx handoff). Three measured improvements:

| Run | Per-attempt PASS | Wilson 95% CI |
|-----|------------------|---------------|
| Baseline pre-investigation | 17% | 7.5–33.7% |
| + v10 per-channel GR ctx reservation | 40% | 24.6–57.7% |
| + v11 global GR ctx reservation | **60%** | 42–76% |
| + v12 falcon ucode reservation | 47% (within v11 noise) | — |

v11 is the practical ceiling for the "expose-and-reserve" approach; pushing further hits phys-adjacency steering where each new reservation reshapes which unprotected nearby pages PMM clobbers next. The architectural fix is in #819.

## What's in the branch

Structurally clean additions (~2,640 lines):

- `kernel/mm/pmm.c` + `kernel/include/pmm.h` — new `pmm_user_reserve_add` API for declaring physical-page ranges off-limits to PMM. Used by Jetson channel-inherit handoff to fence off nvgpu-owned buffers; reusable beyond #788.
- `kernel/gpu/nvidia/ga10b_handoff_reserve.{c,h}` — consumes the v10-extended handoff struct, reserves inst block + per-channel GR ctx + global GR ctx + falcon ucode mirror.
- `kernel/gpu/nvidia/ga10b_channel_handoff.h` — bumps handoff struct to v10 (gr_ctx_extents_phys / n_extents) and extends `ga10b_pipeline_op_v7` with per-op `shader_phys` + `shader_size_bytes`.
- `kernel/gpu/nvidia/ga10b_gmmu.{c,h}` — GMMU walker for following inherited channel's page tree.
- `kernel/gpu/nvidia/ga10b_bringup.c` — GR exception drill-down (GPC→TPC→SM), ctxsw_status_0/1 + GPCCS mirror diagnostic.
- `scripts/gpu-launch-common.{c,h}` — host-side helper reads the three new debugfs files exposed by patched nvgpu.ko (`slmos_gr_ctx_phys`, `slmos_global_ctx_phys`, `slmos_falcon_ucode_phys`) and publishes phys ranges to SLM-OS.
- `scripts/gpu-kernel-mnist.c` + `scripts/gpu-channel-helper.c` — per-shader phys capture via `gpu_virt_to_phys`.
- `scripts/jetson-kexec-slmos.sh` — pre-kexec GPU force-on stage `[8.5/9]` (Mode A fix).

## What's investigation-grade

The branch preserves the empirical trail, including some commits whose hypotheses didn't survive contact with hardware:

- **Stage 5 bisect** (`[investigate] #788 Stage 5: bisect harness …`) — concluded pushbuf+sem reservation broke `nvgpu submit`. **Retracted** at Stage 9 once hardware verified all helper-buf reservations are safe and the real wedge was a `BRINGUP_INIT` state-machine guard. Memory note: `issue_788_stage9_bisect_retracted.md`.
- **Stage 7 runlist attempt** — concluded "PT page collides with runlist". **Falsified** at Stage 8 (runlist phys is above PMM ceiling, can't collide). Memory note: `issue_788_stage8_ptop_finding.md`.
- **Mode B per-op shader reservation** (commit b2bc / 7d6f) — pass rate unchanged but moved failures from B to C. Phys-adjacency steering side effect; partially fixed by v7.1 helper publishing shader_phys instead.

These commits are kept rather than rewritten so the journey reads cleanly against the memory notes. **Recommend squash-merge** at merge time with v11's commit message as the canonical summary; #819 carries the architectural follow-up regardless.

## Dependencies

- **Patched `nvgpu.ko`** — three new debugfs files (`slmos_gr_ctx_phys`, `slmos_global_ctx_phys`, `slmos_falcon_ucode_phys`). Patch lives in `tools/nvgpu-patches/0001-expose-gr-ctx-phys-via-debugfs.patch` (in this PR's tree). Build instructions and the helper read path are documented in the user memory note `issue_788_n30_v10_baseline.md`. On jetson-nano-2 the patched module is already installed at `/lib/modules/$(uname -r)/updates/nvgpu.ko`; the stock module is preserved at `nvgpu.ko.stock`.
- This branch supersedes the conditions PR #820's retry script was tuned against — without these patches the per-attempt PASS rate drops to ~17%, blowing out the script's 4-retry budget.

## Test plan

- [x] `make kernel-clean && make kernel PLATFORM=JETSON_ORIN_NANO -j$(nproc)` — clean compile, 0 warnings (verified post-rebase against origin/main at d010666f)
- [x] Deploy via `scripts/jetson-deploy-retry.sh` against jetson-nano-2 — PASS in 2/5 attempts, 4:42 wall clock (verified 2026-05-14)
- [x] N=30 stress-test baseline — 60% PASS at v11 (raw data in `/tmp/stress-788-*` on lab host)
- [ ] (Reviewer) Rebuild and re-run; expect ≥1 PASS within the 5-attempt retry budget

## Related

- #788 — the dispatcher wedge this investigates
- #819 — long-term deterministic fix that should eventually obsolete this branch
- #820 — retry orchestrator that uses this branch's 60% baseline as its reliability budget
- Memory notes (in user auto-memory, not repo): `issue_788_root_cause.md`, `issue_788_stage8_ptop_finding.md`, `issue_788_stage9_*.md`, `issue_788_n30_v10_baseline.md`, `issue_788_stress_test_results.md`
