### PR TITLE
hailo-re(qemu-stub): seq-bounded region rules — #795

### DIFF
--- a/docs/hailo-re-corpus-format.md
+++ b/docs/hailo-re-corpus-format.md
@@ -91,8 +91,8 @@ A region rule short-circuits per-`seq` capture for a contiguous BAR range whose 
 | `source_offset` | integer | yes (for `source_kind="file"`) | Byte offset within the file corresponding to BAR `start` |
 | `validated_at_commit` | string\|null | yes | Audit field, same semantics as op entries — full 40-char SHA when validated, `null` until a verification pass confirms HailoRT writes match the region |
 | `validated_at` | string\|null | yes | ISO 8601 timestamp, same semantics |
-| `applies_from_seq` | integer | no | Inclusive lower seq bound — region rule fires only for accesses with `seq >= applies_from_seq`. Defaults to `1`. See "Seq-bounded regions" below |
-| `applies_to_seq` | integer | no | Inclusive upper seq bound — region rule fires only for accesses with `seq <= applies_to_seq`. Defaults to "unbounded" (treated as `UINT64_MAX` internally). Must be `>= applies_from_seq` |
+| `applies_from_seq` | integer | no | Inclusive lower seq bound — region rule fires only for accesses with `seq >= applies_from_seq`. Defaults to `1`. Must be `>= 1`. See "Seq-bounded regions" below |
+| `applies_to_seq` | integer | no | Inclusive upper seq bound — region rule fires only for accesses with `seq <= applies_to_seq`. **Omit the field to mean "unbounded"** — the loader's hand-rolled JSON parser stores integers as `int64_t`, so explicitly encoding `UINT64_MAX` (`18446744073709551615`) overflows to a negative value and is rejected. Defaults to unbounded. Must be `>= applies_from_seq` |
 | `note` | string | no | Free-form annotation (e.g. "Hailo-8 firmware code section, identified via signature match on first 32 bytes") |
 
 (Fields use flat names — `source_kind` etc. — rather than a nested `source` object so the existing hand-rolled JSON parser in the QEMU stub doesn't need to grow nested-object support. Functionally equivalent to a nested representation.)

--- a/docs/hailo-re-corpus-format.md
+++ b/docs/hailo-re-corpus-format.md
@@ -91,6 +91,8 @@ A region rule short-circuits per-`seq` capture for a contiguous BAR range whose 
 | `source_offset` | integer | yes (for `source_kind="file"`) | Byte offset within the file corresponding to BAR `start` |
 | `validated_at_commit` | string\|null | yes | Audit field, same semantics as op entries — full 40-char SHA when validated, `null` until a verification pass confirms HailoRT writes match the region |
 | `validated_at` | string\|null | yes | ISO 8601 timestamp, same semantics |
+| `applies_from_seq` | integer | no | Inclusive lower seq bound — region rule fires only for accesses with `seq >= applies_from_seq`. Defaults to `1`. See "Seq-bounded regions" below |
+| `applies_to_seq` | integer | no | Inclusive upper seq bound — region rule fires only for accesses with `seq <= applies_to_seq`. Defaults to "unbounded" (treated as `UINT64_MAX` internally). Must be `>= applies_from_seq` |
 | `note` | string | no | Free-form annotation (e.g. "Hailo-8 firmware code section, identified via signature match on first 32 bytes") |
 
 (Fields use flat names — `source_kind` etc. — rather than a nested `source` object so the existing hand-rolled JSON parser in the QEMU stub doesn't need to grow nested-object support. Functionally equivalent to a nested representation.)
@@ -101,9 +103,24 @@ A region rule short-circuits per-`seq` capture for a contiguous BAR range whose 
 
 **Write semantics under a region rule:** the stub computes the expected bytes from the file and compares against the incoming write data. On match: silent success, no corpus append. On mismatch: emit `HAILO_RE_CORPUS_DIVERGENCE` with `reason=region_write_mismatch`, halt. This catches the case where HailoRT writes something not present in the artifact, indicating either an incorrect region rule or HailoRT applying a runtime transformation before upload.
 
-**Multiple regions:** A corpus may contain multiple region rules for different BAR ranges. Overlapping regions within the same BAR are a configuration error and tools SHOULD reject the corpus on load.
+**Multiple regions:** A corpus may contain multiple region rules for different BAR ranges. Overlapping regions within the same BAR are a configuration error and tools SHOULD reject the corpus on load — UNLESS their seq windows are disjoint (see below).
 
-**Backward compatibility:** Region entries are an additive extension. Tools that don't recognize `type="region"` MUST silently skip those lines. `format_version` remains at `1`. Tools that DO consume region rules MUST also implement the precedence rule above.
+### Seq-bounded regions
+
+`applies_from_seq` and `applies_to_seq` narrow a region rule to a specific seq window. The intended use case is **multi-pass firmware uploads**, where HailoRT writes one firmware section into a BAR window, then later writes a *different* section into the *same* BAR window. A single region rule can only describe one of the two passes; seq-bounded regions let both coexist.
+
+Two regions on the same BAR with overlapping offset ranges are legitimate IF their seq windows are disjoint (`A.applies_to_seq < B.applies_from_seq` OR vice versa). The loader rejects regions that overlap in BOTH offset and seq.
+
+Lookup: for each access, the stub finds the unique region whose `(bar, offset+size)` covers the access AND whose `[applies_from_seq, applies_to_seq]` includes the access's `seq`. If no such region exists, the stub falls through to per-seq lookup as usual.
+
+Example: a corpus with two passes over BAR4 [0, 0x272B8):
+
+```json
+{"type":"region","bar":4,"start":72,"end":164536,"source_kind":"file","source_path":"/lib/firmware/hailo/hailo8_fw.4.23.0.bin","source_offset":96,"applies_to_seq":2107,"validated_at_commit":null,"validated_at":null,"note":"pass 1 — section A"}
+{"type":"region","bar":4,"start":0,"end":160440,"source_kind":"file","source_path":"/lib/firmware/hailo/hailo8_fw.4.23.0.bin","source_offset":4120,"applies_from_seq":2118,"validated_at_commit":null,"validated_at":null,"note":"pass 2 — section B"}
+```
+
+**Backward compatibility:** Region entries are an additive extension. Tools that don't recognize `type="region"` MUST silently skip those lines. `format_version` remains at `1`. Tools that DO consume region rules MUST also implement the precedence rule above. Tools that consume region rules but predate `applies_from_seq` / `applies_to_seq` see them as unknown keys (tolerated) and treat the region as universally applicable — which is wrong for a corpus that depends on the seq filter to avoid overlap. Producers of seq-bounded regions therefore should not co-publish such corpora to consumers known to be on the older schema; in practice this isn't a concern since the only consumer is the in-tree QEMU stub built from the same revision.
 
 ## Sequence semantics
 

--- a/host-tools/qemu-hailo8-stub/src/hailo8.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8.c
@@ -162,10 +162,11 @@ static uint64_t hailo8_bar_read(void *opaque, hwaddr addr, unsigned size)
 
     /* Phase 4 region check — takes precedence over per-seq lookup per
      * docs/hailo-re-corpus-format.md §"Region rule (Phase 4 compression)".
-     * If the access falls inside a region, serve from the region's
-     * artifact and skip the per-seq path entirely. */
+     * If the access falls inside a region AND seq is in the region's
+     * seq window, serve from the region's artifact and skip the per-seq
+     * path entirely. */
     const hailo_region_t *rgn = hailo_corpus_region_lookup(
-        s->corpus, ctx->bar_index, (uint64_t)addr, size);
+        s->corpus, ctx->bar_index, (uint64_t)addr, size, seq);
     if (rgn) {
         uint64_t val = 0;
         if (hailo_region_get_value(rgn, (uint64_t)addr, size, &val) != 0) {
@@ -215,11 +216,12 @@ static void hailo8_bar_write(void *opaque, hwaddr addr,
     data &= mask;
 
     /* Phase 4 region check — takes precedence over per-seq lookup. A write
-     * landing inside a region is expected to match the artifact bytes
-     * verbatim; any divergence is a real protocol change, not a corpus
-     * extension, so we surface it loudly instead of appending. */
+     * landing inside a region (with matching seq window) is expected to
+     * match the artifact bytes verbatim; any divergence is a real
+     * protocol change, not a corpus extension, so we surface it loudly
+     * instead of appending. */
     const hailo_region_t *rgn = hailo_corpus_region_lookup(
-        s->corpus, ctx->bar_index, (uint64_t)addr, size);
+        s->corpus, ctx->bar_index, (uint64_t)addr, size, seq);
     if (rgn) {
         uint64_t expected = 0;
         if (hailo_region_get_value(rgn, (uint64_t)addr, size, &expected) != 0) {

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.c
@@ -13,6 +13,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -465,6 +466,12 @@ static int parse_region_line(const char *line, size_t linelen,
                              char *errbuf, size_t errlen)
 {
     memset(rp, 0, sizeof(*rp));
+    /* Seq window defaults — region applies to every seq unless caller
+     * overrides. memset's zero would make applies_from_seq=0 which would
+     * still include seq=1 (the first op), but for clarity we set the
+     * explicit default to 1. UINT64_MAX is the "no upper bound" sentinel. */
+    rp->region.applies_from_seq = 1;
+    rp->region.applies_to_seq = UINT64_MAX;
     json_cursor_t cur = { .p = line, .end = line + linelen };
     skip_ws(&cur);
     if (cur.p >= cur.end || *cur.p != '{') {
@@ -549,6 +556,22 @@ static int parse_region_line(const char *line, size_t linelen,
             }
             rp->region.source_offset = (uint64_t)intval;
             rp->has_source_offset = 1;
+        } else if (strcmp(key, "applies_from_seq") == 0 && is_int) {
+            if (intval < 1) {
+                set_err(errbuf, errlen,
+                        "region 'applies_from_seq' must be >= 1 (got %lld)",
+                        (long long)intval);
+                return -1;
+            }
+            rp->region.applies_from_seq = (uint64_t)intval;
+        } else if (strcmp(key, "applies_to_seq") == 0 && is_int) {
+            if (intval < 1) {
+                set_err(errbuf, errlen,
+                        "region 'applies_to_seq' must be >= 1 (got %lld)",
+                        (long long)intval);
+                return -1;
+            }
+            rp->region.applies_to_seq = (uint64_t)intval;
         } else if (strcmp(key, "validated_at_commit") == 0 && is_str) {
             copy_str(rp->region.validated_at_commit,
                      sizeof(rp->region.validated_at_commit), strbuf);
@@ -582,6 +605,13 @@ static int parse_region_line(const char *line, size_t linelen,
                 "region end (%llu) must be > start (%llu)",
                 (unsigned long long)rp->region.end,
                 (unsigned long long)rp->region.start);
+        return -1;
+    }
+    if (rp->region.applies_to_seq < rp->region.applies_from_seq) {
+        set_err(errbuf, errlen,
+                "region applies_to_seq (%llu) must be >= applies_from_seq (%llu)",
+                (unsigned long long)rp->region.applies_to_seq,
+                (unsigned long long)rp->region.applies_from_seq);
         return -1;
     }
     uint64_t span = rp->region.end - rp->region.start;
@@ -648,19 +678,29 @@ static int region_load_data(hailo_region_t *r, char *errbuf, size_t errlen)
 static int push_region(hailo_corpus_t *c, const hailo_region_t *src,
                        char *errbuf, size_t errlen)
 {
-    /* Overlap check — spec rejects overlapping regions on the same BAR. */
+    /* Overlap check — two regions on the same BAR conflict only if their
+     * offset ranges AND their seq windows both overlap. Same offsets in
+     * disjoint seq windows is the multi-pass firmware upload case and is
+     * legitimate. */
     for (size_t i = 0; i < c->n_regions; i++) {
         const hailo_region_t *other = &c->regions[i];
         if (other->bar != src->bar) continue;
-        bool overlaps = !(src->end <= other->start || other->end <= src->start);
-        if (overlaps) {
+        bool off_overlap = !(src->end <= other->start || other->end <= src->start);
+        bool seq_overlap = !(src->applies_to_seq < other->applies_from_seq ||
+                             other->applies_to_seq < src->applies_from_seq);
+        if (off_overlap && seq_overlap) {
             set_err(errbuf, errlen,
-                    "region overlap on bar=%d: new [%llu,%llu) vs existing [%llu,%llu)",
+                    "region overlap on bar=%d: new [%llu,%llu) seq [%llu,%llu] "
+                    "vs existing [%llu,%llu) seq [%llu,%llu]",
                     src->bar,
                     (unsigned long long)src->start,
                     (unsigned long long)src->end,
+                    (unsigned long long)src->applies_from_seq,
+                    (unsigned long long)src->applies_to_seq,
                     (unsigned long long)other->start,
-                    (unsigned long long)other->end);
+                    (unsigned long long)other->end,
+                    (unsigned long long)other->applies_from_seq,
+                    (unsigned long long)other->applies_to_seq);
             return -1;
         }
     }
@@ -993,7 +1033,7 @@ int hailo_corpus_append_write(hailo_corpus_t *c,
 
 const hailo_region_t *hailo_corpus_region_lookup(const hailo_corpus_t *c,
                                                  int bar, uint64_t offset,
-                                                 uint32_t size)
+                                                 uint32_t size, uint64_t seq)
 {
     if (!c || size == 0) return NULL;
     uint64_t access_end = offset + size;  /* exclusive */
@@ -1004,6 +1044,8 @@ const hailo_region_t *hailo_corpus_region_lookup(const hailo_corpus_t *c,
     for (size_t i = 0; i < c->n_regions; i++) {
         const hailo_region_t *r = &c->regions[i];
         if (r->bar != bar) continue;
+        /* Seq window filter — see hailo_region_t docs. */
+        if (seq < r->applies_from_seq || seq > r->applies_to_seq) continue;
         /* Require the access to be ENTIRELY inside the region. Partial
          * overlap counts as not covered — serving a sliced access half
          * from the artifact and half from the per-seq lookup is incoherent. */

--- a/host-tools/qemu-hailo8-stub/src/hailo8_corpus.h
+++ b/host-tools/qemu-hailo8-stub/src/hailo8_corpus.h
@@ -88,6 +88,16 @@ typedef struct hailo_region {
     char      source_path[HAILO_CORPUS_MAX_PATH + 1];
     uint64_t  source_offset;  /* byte offset within source_path */
 
+    /* Optional seq window — region rule fires only for accesses whose
+     * `seq` is in [applies_from_seq, applies_to_seq], inclusive. Lets
+     * multiple regions on the same BAR with overlapping offset ranges
+     * coexist as long as their seq windows are disjoint (e.g. multi-pass
+     * firmware uploads that re-use the same BAR window for different
+     * bytes). Defaults: applies_from_seq=1, applies_to_seq=UINT64_MAX
+     * (i.e. no seq filter — original Phase 4 behavior). */
+    uint64_t  applies_from_seq;
+    uint64_t  applies_to_seq;
+
     /* Loaded artifact bytes. Owned by the region; freed in
      * hailo_corpus_free. `data[i]` corresponds to BAR offset
      * `start + i` (after subtracting source_offset). */
@@ -155,14 +165,17 @@ const hailo_op_entry_t *hailo_corpus_get(const hailo_corpus_t *c, uint64_t seq);
 
 /*
  * Phase 4 region lookup. Returns the region covering the half-open range
- * `[offset, offset + size)` on `bar`, or NULL if no region covers the
- * access. The covering region must contain the ENTIRE access width — a
- * partial overlap counts as NOT covered, since serving a fraction of an
- * access from the artifact and the rest from … nowhere is incoherent.
+ * `[offset, offset + size)` on `bar` AND whose seq window includes `seq`,
+ * or NULL if no such region exists. The covering region must contain the
+ * ENTIRE access width — a partial overlap counts as NOT covered, since
+ * serving a fraction of an access from the artifact and the rest from …
+ * nowhere is incoherent. The seq filter lets multiple regions on the
+ * same BAR cover the same offset range across disjoint seq windows
+ * (e.g. multi-pass firmware uploads).
  */
 const hailo_region_t *hailo_corpus_region_lookup(const hailo_corpus_t *c,
                                                  int bar, uint64_t offset,
-                                                 uint32_t size);
+                                                 uint32_t size, uint64_t seq);
 
 /*
  * Extract `size` bytes from the region's loaded artifact starting at BAR

--- a/host-tools/qemu-hailo8-stub/tests/test_corpus.c
+++ b/host-tools/qemu-hailo8-stub/tests/test_corpus.c
@@ -763,6 +763,100 @@ static int test_region_rejects_inverted_seq_window(void)
     return 1;
 }
 
+static int test_region_rejects_zero_seq_bounds(void)
+{
+    /* applies_from_seq and applies_to_seq must be >= 1 — seq=0 is never
+     * produced by the stub (seq counter starts at 1) and a zero bound
+     * usually means the field was accidentally omitted from a struct
+     * initializer somewhere in a producer tool. Reject loudly. */
+    uint8_t bytes[16];
+    memset(bytes, 0x77, sizeof(bytes));
+    write_tmp_artifact(bytes, sizeof(bytes));
+
+    make_tmp();
+    char buf[2048];
+    /* applies_from_seq=0 */
+    snprintf(buf, sizeof(buf),
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"2026-05-14T00:00:00Z\"}\n"
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":0,"
+        "\"applies_from_seq\":0,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n",
+        tmp_artifact_path);
+    write_file(tmp_path, buf);
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "applies_from_seq") != NULL);
+    unlink(tmp_path);
+
+    /* applies_to_seq=0 */
+    make_tmp();
+    snprintf(buf, sizeof(buf),
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"2026-05-14T00:00:00Z\"}\n"
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":0,"
+        "\"applies_to_seq\":0,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n",
+        tmp_artifact_path);
+    write_file(tmp_path, buf);
+    c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "applies_to_seq") != NULL);
+    unlink(tmp_path);
+    unlink(tmp_artifact_path);
+    return 1;
+}
+
+static int test_region_disjoint_offsets_overlapping_seq_allowed(void)
+{
+    /* Two regions on the same BAR with disjoint OFFSET ranges but
+     * overlapping (or default-unbounded) SEQ windows are legitimate —
+     * the offset disjointness alone is enough to disambiguate which
+     * region serves an access. Lock in that this isn't flagged as a
+     * conflict. */
+    uint8_t bytes[64];
+    memset(bytes, 0x42, sizeof(bytes));
+    write_tmp_artifact(bytes, sizeof(bytes));
+
+    make_tmp();
+    char buf[2048];
+    snprintf(buf, sizeof(buf),
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"2026-05-14T00:00:00Z\"}\n"
+        /* Region A: bar=4 offsets [0, 16), seq unbounded */
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":0,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n"
+        /* Region B: bar=4 offsets [32, 48), seq unbounded */
+        "{\"type\":\"region\",\"bar\":4,\"start\":32,\"end\":48,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":32,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n",
+        tmp_artifact_path, tmp_artifact_path);
+    write_file(tmp_path, buf);
+
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    if (!c) {
+        fprintf(stderr, "load failed: %s\n", err);
+        return 0;
+    }
+    EXPECT_EQ(c->n_regions, 2);
+    /* Same seq, different offsets → different regions. */
+    const hailo_region_t *rA = hailo_corpus_region_lookup(c, 4, 0, 4, 1000);
+    const hailo_region_t *rB = hailo_corpus_region_lookup(c, 4, 32, 4, 1000);
+    EXPECT(rA != NULL);
+    EXPECT(rB != NULL);
+    EXPECT(rA != rB);
+    /* The 16-byte gap [16, 32) belongs to neither. */
+    EXPECT(hailo_corpus_region_lookup(c, 4, 16, 4, 1000) == NULL);
+    EXPECT(hailo_corpus_region_lookup(c, 4, 28, 4, 1000) == NULL);
+
+    hailo_corpus_free(c);
+    unlink(tmp_path);
+    unlink(tmp_artifact_path);
+    return 1;
+}
+
 int main(void)
 {
     TEST(test_hex_roundtrip_u32);
@@ -792,6 +886,8 @@ int main(void)
     TEST(test_region_seq_window_disjoint_allowed);
     TEST(test_region_seq_window_overlapping_rejected);
     TEST(test_region_rejects_inverted_seq_window);
+    TEST(test_region_rejects_zero_seq_bounds);
+    TEST(test_region_disjoint_offsets_overlapping_seq_allowed);
     fprintf(stderr, "\n%d / %d tests passed\n", g_test_count - g_fail_count, g_test_count);
     return g_fail_count == 0 ? 0 : 1;
 }

--- a/host-tools/qemu-hailo8-stub/tests/test_corpus.c
+++ b/host-tools/qemu-hailo8-stub/tests/test_corpus.c
@@ -9,6 +9,7 @@
 #include "../src/hailo8_corpus.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -429,17 +430,21 @@ static int test_region_load_and_lookup(void)
     EXPECT_EQ(c->regions[0].data[0], 0x10);
     EXPECT_EQ(c->regions[0].data[15], 0x1F);
 
-    /* In-range lookups. */
-    const hailo_region_t *r = hailo_corpus_region_lookup(c, 4, 256, 4);
+    /* In-range lookups (any seq — default window is [1, UINT64_MAX]). */
+    const hailo_region_t *r = hailo_corpus_region_lookup(c, 4, 256, 4, 1);
     EXPECT(r != NULL);
-    r = hailo_corpus_region_lookup(c, 4, 268, 4);  /* last 4 bytes */
+    r = hailo_corpus_region_lookup(c, 4, 268, 4, 12345);  /* last 4 bytes */
     EXPECT(r != NULL);
 
     /* Out-of-range: before, after, wrong BAR, partial-overlap-at-end. */
-    EXPECT(hailo_corpus_region_lookup(c, 4, 255, 1) == NULL);
-    EXPECT(hailo_corpus_region_lookup(c, 4, 272, 1) == NULL);
-    EXPECT(hailo_corpus_region_lookup(c, 2, 256, 4) == NULL);
-    EXPECT(hailo_corpus_region_lookup(c, 4, 270, 4) == NULL);  /* spans end */
+    EXPECT(hailo_corpus_region_lookup(c, 4, 255, 1, 1) == NULL);
+    EXPECT(hailo_corpus_region_lookup(c, 4, 272, 1, 1) == NULL);
+    EXPECT(hailo_corpus_region_lookup(c, 2, 256, 4, 1) == NULL);
+    EXPECT(hailo_corpus_region_lookup(c, 4, 270, 4, 1) == NULL);  /* spans end */
+
+    /* Default seq window is full range — region should accept seq=1 and seq=UINT64_MAX. */
+    EXPECT(c->regions[0].applies_from_seq == 1);
+    EXPECT(c->regions[0].applies_to_seq == UINT64_MAX);
 
     /* Value decode (little-endian, matches op value semantics). */
     uint64_t v = 0;
@@ -638,6 +643,126 @@ static int test_region_free_handles_empty(void)
     return 1;
 }
 
+static int test_region_seq_window_disjoint_allowed(void)
+{
+    /* Two regions on the same BAR with the same offset range BUT disjoint
+     * seq windows should both load — the multi-pass firmware upload case.
+     * The first region serves seq [1, 100], the second serves seq [200, ∞). */
+    uint8_t bytes[32];
+    for (size_t i = 0; i < sizeof(bytes); i++) bytes[i] = (uint8_t)(0xA0 + i);
+    write_tmp_artifact(bytes, sizeof(bytes));
+
+    make_tmp();
+    char buf[2048];
+    snprintf(buf, sizeof(buf),
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"2026-05-14T00:00:00Z\"}\n"
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":0,"
+        "\"applies_from_seq\":1,\"applies_to_seq\":100,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n"
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":16,"
+        "\"applies_from_seq\":200,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n",
+        tmp_artifact_path, tmp_artifact_path);
+    write_file(tmp_path, buf);
+
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    if (!c) {
+        fprintf(stderr, "load failed: %s\n", err);
+        return 0;
+    }
+    EXPECT_EQ(c->n_regions, 2);
+    EXPECT_EQ(c->regions[0].applies_from_seq, 1);
+    EXPECT_EQ(c->regions[0].applies_to_seq, 100);
+    EXPECT_EQ(c->regions[1].applies_from_seq, 200);
+    EXPECT_EQ(c->regions[1].applies_to_seq, UINT64_MAX);
+
+    /* Seq-bounded lookup: same offset, different seqs → different regions. */
+    const hailo_region_t *r1 = hailo_corpus_region_lookup(c, 4, 0, 4, 50);
+    const hailo_region_t *r2 = hailo_corpus_region_lookup(c, 4, 0, 4, 500);
+    EXPECT(r1 != NULL);
+    EXPECT(r2 != NULL);
+    EXPECT(r1 != r2);
+    /* Verify the right region serves the right bytes (source_offset differs). */
+    uint64_t v1 = 0, v2 = 0;
+    EXPECT_EQ(hailo_region_get_value(r1, 0, 4, &v1), 0);
+    EXPECT_EQ(hailo_region_get_value(r2, 0, 4, &v2), 0);
+    EXPECT_EQ(v1, 0xA3A2A1A0ULL);  /* first 4 bytes of artifact */
+    EXPECT_EQ(v2, 0xB3B2B1B0ULL);  /* bytes 16..20 of artifact */
+
+    /* Gap between windows: seq=150 should miss both. */
+    EXPECT(hailo_corpus_region_lookup(c, 4, 0, 4, 150) == NULL);
+    /* Boundary tests — both ends inclusive. */
+    EXPECT(hailo_corpus_region_lookup(c, 4, 0, 4, 1) == r1);
+    EXPECT(hailo_corpus_region_lookup(c, 4, 0, 4, 100) == r1);
+    EXPECT(hailo_corpus_region_lookup(c, 4, 0, 4, 200) == r2);
+
+    hailo_corpus_free(c);
+    unlink(tmp_path);
+    unlink(tmp_artifact_path);
+    return 1;
+}
+
+static int test_region_seq_window_overlapping_rejected(void)
+{
+    /* Same offset range, OVERLAPPING seq windows → must be rejected. */
+    uint8_t bytes[32];
+    memset(bytes, 0x55, sizeof(bytes));
+    write_tmp_artifact(bytes, sizeof(bytes));
+
+    make_tmp();
+    char buf[2048];
+    snprintf(buf, sizeof(buf),
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"2026-05-14T00:00:00Z\"}\n"
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":0,"
+        "\"applies_from_seq\":1,\"applies_to_seq\":100,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n"
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":16,"
+        "\"applies_from_seq\":50,\"applies_to_seq\":150,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n",
+        tmp_artifact_path, tmp_artifact_path);
+    write_file(tmp_path, buf);
+
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "overlap") != NULL);
+    unlink(tmp_path);
+    unlink(tmp_artifact_path);
+    return 1;
+}
+
+static int test_region_rejects_inverted_seq_window(void)
+{
+    /* applies_to_seq < applies_from_seq is nonsense — reject. */
+    uint8_t bytes[16];
+    memset(bytes, 0x66, sizeof(bytes));
+    write_tmp_artifact(bytes, sizeof(bytes));
+
+    make_tmp();
+    char buf[2048];
+    snprintf(buf, sizeof(buf),
+        "{\"type\":\"header\",\"format_version\":1,\"hailort_version\":\"4.23.0\",\"fw_version\":\"4.23.0\",\"capture_host\":\"qemu\",\"slmos_base_sha\":\"abc\",\"capture_started_at\":\"2026-05-14T00:00:00Z\"}\n"
+        "{\"type\":\"region\",\"bar\":4,\"start\":0,\"end\":16,"
+        "\"source_kind\":\"file\",\"source_path\":\"%s\",\"source_offset\":0,"
+        "\"applies_from_seq\":100,\"applies_to_seq\":50,"
+        "\"validated_at_commit\":null,\"validated_at\":null}\n",
+        tmp_artifact_path);
+    write_file(tmp_path, buf);
+
+    char err[256];
+    hailo_corpus_t *c = hailo_corpus_load(tmp_path, false, err, sizeof(err));
+    EXPECT(c == NULL);
+    EXPECT(strstr(err, "applies_to_seq") != NULL);
+    unlink(tmp_path);
+    unlink(tmp_artifact_path);
+    return 1;
+}
+
 int main(void)
 {
     TEST(test_hex_roundtrip_u32);
@@ -664,6 +789,9 @@ int main(void)
     TEST(test_region_rejects_short_read);
     TEST(test_region_rejects_negative_fields);
     TEST(test_region_free_handles_empty);
+    TEST(test_region_seq_window_disjoint_allowed);
+    TEST(test_region_seq_window_overlapping_rejected);
+    TEST(test_region_rejects_inverted_seq_window);
     fprintf(stderr, "\n%d / %d tests passed\n", g_test_count - g_fail_count, g_test_count);
     return g_fail_count == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Phase 4's region rule covered the first firmware-upload pass cleanly. The post-region grind then surfaced a `region_write_mismatch` at seq=2154 — HailoRT does a **second upload pass** into the same BAR4 window with bytes from a different section of the firmware blob. Signature scan landed all 19 anchors at `fw[0x1018]`, ~4 KB past the section A code we already mapped — pointing to a multi-section firmware container.

A single offset-keyed region can't describe both passes; the stub needs to know which pass it's serving. Add optional `applies_from_seq` / `applies_to_seq` fields:

- **`hailo_region_t`** gains both fields. Defaults: `1` / `UINT64_MAX` — preserves original Phase 4 behavior when omitted.
- **Overlap detection** in `push_region` relaxed: two regions on the same BAR conflict only if their offset ranges AND their seq windows both overlap. Disjoint seq windows make same-offset regions legitimate.
- **`hailo_corpus_region_lookup`** signature now takes `seq`. Filter on seq window in addition to BAR/offset/size.
- **`hailo8.c`** call sites in both bar_read and bar_write pass `seq` through.

Worked example (the working corpus that will be patched next):

\`\`\`json
{"type":"region","bar":4,"start":72,"end":164536,
 "source_kind":"file","source_path":"hailo8_fw.4.23.0.bin","source_offset":96,
 "applies_to_seq":2107, ...}  // pass 1, section A
{"type":"region","bar":4,"start":0,"end":160440,
 "source_kind":"file","source_path":"hailo8_fw.4.23.0.bin","source_offset":4120,
 "applies_from_seq":2118, ...}  // pass 2, section B
\`\`\`

## Test plan

- [x] \`make -C host-tools/qemu-hailo8-stub/tests test\` — **27/27 pass** (24 prior + 3 new: \`seq_window_disjoint_allowed\`, \`seq_window_overlapping_rejected\`, \`rejects_inverted_seq_window\`)
- [x] Full QEMU stub builds clean with ninja
- [ ] Follow-up (post-merge): swap working corpus to two seq-bounded regions and resume Phase 2 grind

🤖 Generated with [Claude Code](https://claude.com/claude-code)