### PR TITLE
tools(nvgpu-patches): add patch file referenced from #823

### DIFF
--- a/tools/nvgpu-patches/0001-expose-gr-ctx-phys-via-debugfs.patch
+++ b/tools/nvgpu-patches/0001-expose-gr-ctx-phys-via-debugfs.patch
@@ -1,0 +1,235 @@
+--- a/drivers/gpu/nvgpu/include/nvgpu/gr/gr_falcon.h
++++ b/drivers/gpu/nvgpu/include/nvgpu/gr/gr_falcon.h
+@@ -316,6 +316,10 @@
+ void *nvgpu_gr_falcon_get_surface_desc_cpu_va(
+ 		struct nvgpu_gr_falcon *falcon);
+ 
++/* SLM-OS #788 v12: return surface_desc nvgpu_mem* for phys dump. */
++struct nvgpu_mem *nvgpu_gr_falcon_get_surface_desc_mem(
++		struct nvgpu_gr_falcon *falcon);
++
+ /**
+  * @brief Get size of golden context image.
+  *
+--- a/drivers/gpu/nvgpu/common/gr/gr_falcon.c
++++ b/drivers/gpu/nvgpu/common/gr/gr_falcon.c
+@@ -763,3 +763,11 @@
+ 	return &falcon->fecs_mutex;
+ }
+ #endif
++
++/* SLM-OS #788 v12: expose surface_desc mem so a debugfs reader
++ * can dump its phys for SLM-OS PMM reservation. */
++struct nvgpu_mem *nvgpu_gr_falcon_get_surface_desc_mem(
++                struct nvgpu_gr_falcon *falcon)
++{
++        return &falcon->ctxsw_ucode_info.surface_desc;
++}
+--- a/drivers/gpu/nvgpu/os/linux/debug_fifo.c
++++ b/drivers/gpu/nvgpu/os/linux/debug_fifo.c
+@@ -24,6 +24,10 @@
+ #include <nvgpu/timers.h>
+ #include <nvgpu/channel.h>
+ #include <nvgpu/gr/ctx.h>
++#include <nvgpu/nvgpu_mem.h>
++#include <nvgpu/gr/global_ctx.h>
++#include <nvgpu/gr/gr_utils.h>
++#include <nvgpu/gr/gr_falcon.h>
+ #include <nvgpu/engines.h>
+ #include <nvgpu/device.h>
+ #include <nvgpu/runlist.h>
+@@ -139,6 +143,181 @@
+ 	.release = seq_release
+ };
+ 
++/*
++ * SLM-OS #788 Mode C fix: expose per-channel GR context buffer phys
++ * addresses via a new debugfs file.
++ *
++ * nvgpu allocates several internal buffers per channel when binding a
++ * compute class (ALLOC_OBJ_CTX). The phys of those buffers is not
++ * available to userspace via the standard ioctl interface — only the
++ * channel's GPU VAs are. After a kexec to SLM-OS, the new kernel has
++ * no way to discover these phys ranges and clobbers them with its own
++ * PMM allocations, causing FECS to fail loading the channel context
++ * (mb6=0x5a watchdog at ~50% iteration rate per the N=30 stress test).
++ *
++ * This file dumps one line per (channel, ctx-buffer-index) tuple:
++ *
++ *   chid <chid> tsgid <tsgid> idx <i> phys 0x<phys> size <bytes>
++ *
++ * The reading helper publishes these phys values in the SLM-OS channel
++ * handoff so post-kexec PMM init can reserve them.
++ */
++static int slmos_gr_ctx_phys_show(struct seq_file *s, void *v)
++{
++	struct gk20a *g = s->private;
++	struct nvgpu_fifo *f = &g->fifo;
++	u32 chid;
++
++	seq_puts(s, "chid tsgid idx phys size\n");
++	for (chid = 0; chid < f->num_channels; chid++) {
++		struct nvgpu_channel *ch = &f->channel[chid];
++		struct nvgpu_tsg *tsg;
++		u32 i;
++
++		if (!nvgpu_channel_get(ch))
++			continue;
++		tsg = nvgpu_tsg_from_ch(ch);
++		if (!tsg || !tsg->gr_ctx) {
++			nvgpu_channel_put(ch);
++			continue;
++		}
++		for (i = 0; i < NVGPU_GR_CTX_COUNT; i++) {
++			struct nvgpu_mem *mem =
++				nvgpu_gr_ctx_get_ctx_mem(tsg->gr_ctx, i);
++			u64 phys;
++			size_t size;
++
++			if (mem == NULL || !nvgpu_mem_is_valid(mem))
++				continue;
++
++			phys = nvgpu_mem_get_phys_addr(g, mem);
++			size = mem->size;
++			if (phys == 0 || size == 0)
++				continue;
++
++			seq_printf(s,
++				"%u %u %u 0x%llx %zu\n",
++				ch->chid, ch->tsgid, i,
++				(unsigned long long)phys, size);
++		}
++		nvgpu_channel_put(ch);
++	}
++	return 0;
++}
++
++static int slmos_gr_ctx_phys_open(struct inode *inode, struct file *file)
++{
++	return single_open(file, slmos_gr_ctx_phys_show, inode->i_private);
++}
++
++static const struct file_operations slmos_gr_ctx_phys_fops = {
++	.owner   = THIS_MODULE,
++	.open    = slmos_gr_ctx_phys_open,
++	.read    = seq_read,
++	.llseek  = seq_lseek,
++	.release = single_release
++};
++
++/*
++ * SLM-OS #788 v11 extension: also dump the per-GPU global context
++ * buffers. These are NOT per-channel but FECS touches them on every
++ * ctxsw (priv_access_map / circular / pagepool / attribute / rtv).
++ * Without protection, SLM-OS PMM clobbers them after kexec, causing
++ * Mode D (mb6=0x21 checksum mismatch) failures.
++ *
++ * Emitted with chid=4294967295 (-1) and tsgid=4294967295 to flag them
++ * as global; idx is the NVGPU_GR_GLOBAL_CTX_* slot.
++ */
++static int slmos_global_ctx_phys_show(struct seq_file *s, void *v)
++{
++	struct gk20a *g = s->private;
++	struct nvgpu_gr_global_ctx_buffer_desc *desc;
++	u32 i;
++
++	seq_puts(s, "chid tsgid idx phys size\n");
++	desc = nvgpu_gr_get_global_ctx_buffer_ptr(g);
++	if (desc == NULL)
++		return 0;
++
++	for (i = 0; i < NVGPU_GR_GLOBAL_CTX_COUNT; i++) {
++		struct nvgpu_mem *mem;
++		u64 phys;
++		size_t size;
++
++		if (!nvgpu_gr_global_ctx_buffer_ready(desc, i))
++			continue;
++		mem = nvgpu_gr_global_ctx_buffer_get_mem(desc, i);
++		if (mem == NULL || !nvgpu_mem_is_valid(mem))
++			continue;
++
++		phys = nvgpu_mem_get_phys_addr(g, mem);
++		size = mem->size;
++		if (phys == 0 || size == 0)
++			continue;
++
++		seq_printf(s,
++			"4294967295 4294967295 %u 0x%llx %zu\n",
++			i, (unsigned long long)phys, size);
++	}
++	return 0;
++}
++
++static int slmos_global_ctx_phys_open(struct inode *inode, struct file *file)
++{
++	return single_open(file, slmos_global_ctx_phys_show, inode->i_private);
++}
++
++static const struct file_operations slmos_global_ctx_phys_fops = {
++	.owner   = THIS_MODULE,
++	.open    = slmos_global_ctx_phys_open,
++	.read    = seq_read,
++	.llseek  = seq_lseek,
++	.release = single_release
++};
++
++/* SLM-OS #788 v12: dump the FECS+GPCCS ctxsw ucode surface
++ * (one combined DRAM mirror, allocated at probe by nvgpu). FECS
++ * reads this during ctxsw to reload itself; if SLM-OS PMM
++ * clobbers it, ctxsw fails with mb6=0x21 / 0x15 / 0x5a.
++ *
++ * Emit with chid=4294967294 (-2) to flag it as a per-GPU
++ * non-channel buffer (distinct from chid=-1 for global ctx). */
++static int slmos_falcon_ucode_phys_show(struct seq_file *s, void *v)
++{
++	struct gk20a *g = s->private;
++	struct nvgpu_gr_falcon *falcon;
++	struct nvgpu_mem *mem;
++	u64 phys;
++
++	seq_puts(s, "chid tsgid idx phys size\n");
++	falcon = nvgpu_gr_get_falcon_ptr(g);
++	if (falcon == NULL)
++		return 0;
++	mem = nvgpu_gr_falcon_get_surface_desc_mem(falcon);
++	if (mem == NULL || !nvgpu_mem_is_valid(mem))
++		return 0;
++	phys = nvgpu_mem_get_phys_addr(g, mem);
++	if (phys != 0 && mem->size != 0) {
++		seq_printf(s,
++			"4294967294 4294967294 0 0x%llx %zu\n",
++			(unsigned long long)phys, mem->size);
++	}
++	return 0;
++}
++
++static int slmos_falcon_ucode_phys_open(struct inode *inode, struct file *file)
++{
++	return single_open(file, slmos_falcon_ucode_phys_show, inode->i_private);
++}
++
++static const struct file_operations slmos_falcon_ucode_phys_fops = {
++	.owner   = THIS_MODULE,
++	.open    = slmos_falcon_ucode_phys_open,
++	.read    = seq_read,
++	.llseek  = seq_lseek,
++	.release = single_release
++};
++
+ void gk20a_fifo_debugfs_init(struct gk20a *g)
+ {
+ 	struct nvgpu_os_linux *l = nvgpu_os_linux_from_gk20a(g);
+@@ -160,4 +339,12 @@
+ 				     "recovery_profiler");
+ 	nvgpu_debugfs_swprofile_init(g, fifo_root, &g->fifo.eng_reset_profiler,
+ 				     "eng_reset_profiler");
++
++	/* SLM-OS #788: per-channel GR context buffer phys dump */
++	debugfs_create_file("slmos_gr_ctx_phys", 0400, fifo_root, g,
++			    &slmos_gr_ctx_phys_fops);
++	debugfs_create_file("slmos_global_ctx_phys", 0400, fifo_root, g,
++			    &slmos_global_ctx_phys_fops);
++	debugfs_create_file("slmos_falcon_ucode_phys", 0400, fifo_root, g,
++			    &slmos_falcon_ucode_phys_fops);
+ }

--- a/tools/nvgpu-patches/README.md
+++ b/tools/nvgpu-patches/README.md
@@ -1,0 +1,133 @@
+# Patches against NVIDIA L4T `nvgpu.ko`
+
+Local modifications to NVIDIA's out-of-tree `nvgpu.ko` (L4T R36.4.x)
+that SLM-OS depends on for Jetson Orin Nano operation. Each patch
+here describes a single behavior change and ships its own short
+rationale at the top of the diff.
+
+The patches are NOT upstreamed — they expose internal allocator
+state that NVIDIA wouldn't ship to production users. They're
+required only for SLM-OS's bare-metal kexec-handoff path; vanilla
+Linux usage of the GPU doesn't need them.
+
+## Patches
+
+### `0001-expose-gr-ctx-phys-via-debugfs.patch`
+
+Adds three debugfs files exposing the physical addresses of nvgpu's
+GR-related buffers, so SLM-OS can reserve those pages from its PMM
+*before* booting and avoid clobbering them when the inherited GPU
+channel runs post-kexec. See the in-tree consumer at
+`kernel/gpu/nvidia/ga10b_handoff_reserve.c` (the
+`reserve_gr_ctx_extents` helper) for what SLM-OS does with the
+addresses, and `#788` / `#823` for the wedge this works around.
+
+The patch adds:
+
+| Debugfs file | Contents |
+|---|---|
+| `/sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys` | Per-channel GR ctx buffer phys ranges (`chid tsgid idx phys size`) |
+| `/sys/kernel/debug/gpu.0/fifo/slmos_global_ctx_phys` | Per-GPU global GR ctx buffers (golden image, attribute cb, priv access map, RTV circular, FECS trace) |
+| `/sys/kernel/debug/gpu.0/fifo/slmos_falcon_ucode_phys` | FECS+GPCCS ctxsw ucode mirror (64 KB) |
+
+It also adds one accessor in `drivers/gpu/nvgpu/common/gr/gr_falcon.c`
+(plus its declaration in
+`drivers/gpu/nvgpu/include/nvgpu/gr/gr_falcon.h`) that returns the
+`nvgpu_mem *` for the GR falcon's ucode surface, so the new debugfs
+file can read its phys.
+
+Without this patch installed, SLM-OS's per-attempt kexec-handoff
+PASS rate regresses from ~60% to the v6 baseline of ~17%.
+
+## Building
+
+The patches target NVIDIA's L4T R36.4.x kernel-OOT-modules tarball
+(`kernel_oot_modules_src.tbz2`, ~13 MB), distributed as part of the
+Linux for Tegra source bundle.
+
+Run as root on the Jetson:
+
+```bash
+cd /root && mkdir -p oot-build && cd oot-build
+tar -xjf /path/to/kernel_oot_modules_src.tbz2
+
+# Apply this patch (only changes three files; round-trip-tested
+# clean on the R36.4.x tarball).
+patch -p1 -d nvgpu < /path/to/0001-expose-gr-ctx-phys-via-debugfs.patch
+
+# Generate conftest.h — required even though the patch doesn't
+# touch nvidia-oot, because nvgpu's Kbuild rules read from it.
+mkdir -p out/nvidia-conftest/nvidia
+cp -av nvidia-oot/scripts/conftest/* out/nvidia-conftest/nvidia/
+make -j$(nproc) ARCH=arm64 \
+    src=$PWD/out/nvidia-conftest/nvidia obj=$PWD/out/nvidia-conftest/nvidia \
+    NV_KERNEL_SOURCES=/lib/modules/$(uname -r)/build \
+    NV_KERNEL_OUTPUT=/lib/modules/$(uname -r)/build \
+    -f $PWD/out/nvidia-conftest/nvidia/Makefile
+
+# Reuse the system's nvidia-oot Module.symvers rather than
+# building all of nvidia-oot.
+cp /usr/src/nvidia/nvidia-oot/Module.symvers nvidia-oot/Module.symvers
+
+# Build nvgpu only.
+make -j$(nproc) ARCH=arm64 \
+    -C /lib/modules/$(uname -r)/build \
+    M=$PWD/nvgpu/drivers/gpu/nvgpu \
+    CONFIG_TEGRA_OOT_MODULE=m \
+    srctree.nvgpu=$PWD/nvgpu \
+    srctree.nvidia=$PWD/nvidia-oot \
+    srctree.nvidia-oot=$PWD/nvidia-oot \
+    srctree.nvconftest=$PWD/out/nvidia-conftest \
+    KBUILD_EXTRA_SYMBOLS=$PWD/nvidia-oot/Module.symvers \
+    modules
+
+# Install + reboot. Stock module preserved as `.stock` sibling.
+cp /lib/modules/$(uname -r)/updates/nvgpu.ko \
+   /lib/modules/$(uname -r)/updates/nvgpu.ko.stock
+cp nvgpu/drivers/gpu/nvgpu/nvgpu.ko \
+   /lib/modules/$(uname -r)/updates/nvgpu.ko
+reboot
+```
+
+After reboot, verify the patched module is loaded:
+
+```bash
+cat /sys/kernel/debug/gpu.0/fifo/slmos_gr_ctx_phys
+# Should print: "chid tsgid idx phys size" + per-channel rows.
+# If the file doesn't exist, the stock module is still active.
+```
+
+## Gotchas
+
+- **Do NOT pass `srctree.nvmap=...`.** The default
+  (`srctree.nvidia/drivers/video/tegra/nvmap`) is what nvgpu's
+  Kbuild expects; overriding it breaks with
+  `nvmap_exports.h: No such file or directory`.
+- **`nvsched` is a sibling of `drivers/`, not a child.** If
+  conftest fails on `nvsched/Makefile.sources`, extract the
+  top-level `nvsched/` directory from the tarball too.
+- **Use the system-installed `Module.symvers`** at
+  `/usr/src/nvidia/nvidia-oot/Module.symvers` (~117 KB). Rebuilding
+  all of nvidia-oot is slow and unnecessary.
+
+## Install status across the lab
+
+| Host | Status | Verified |
+|------|--------|----------|
+| `jetson-nano-2` | Patched | yes (used by every PR #823 hardware run) |
+| `jetson-nano-1` | Unknown | check before relying on the 60% PASS baseline |
+
+Without the patched module, SLM-OS still boots and reaches its
+shell, but `nvgpu launch-kernel` per-attempt PASS regresses to the
+~17% v6 baseline. The retry orchestrator
+(`scripts/jetson-deploy-retry.sh`) will hit its 4-retry budget
+roughly half the time at that rate.
+
+## Long-term plan
+
+This patch + the consumer reservation logic in
+`kernel/gpu/nvidia/ga10b_handoff_reserve.c` are a workaround. The
+permanent fix is tracked in **#819** ("Jetson kexec dispatch
+reliability: replace retry orchestrator with deterministic GR-ctx
+handoff") — when that lands, both this patch and the retry
+orchestrator become obsolete.


### PR DESCRIPTION
## Summary

Closes the gap from PR #823 third-pass review: `kernel/gpu/nvidia/ga10b_handoff_reserve.c` and the #823 description both reference `tools/nvgpu-patches/0001-expose-gr-ctx-phys-via-debugfs.patch`, but the file was never actually committed to the repo. This PR adds it.

## Contents

- **`tools/nvgpu-patches/0001-expose-gr-ctx-phys-via-debugfs.patch`** (202 lines added, 5 hunks across 3 files) — unified diff against L4T R36.4.x `kernel_oot_modules_src.tbz2`. Adds:
  - Three debugfs files in `drivers/gpu/nvgpu/os/linux/debug_fifo.c` that expose phys ranges for per-channel GR ctx, per-GPU global ctx, and FECS+GPCCS ucode mirror
  - One accessor `nvgpu_gr_falcon_get_surface_desc_mem()` in `drivers/gpu/nvgpu/common/gr/gr_falcon.c` plus its declaration in `drivers/gpu/nvgpu/include/nvgpu/gr/gr_falcon.h`
- **`tools/nvgpu-patches/README.md`** — explains what the patch does, the full kbuild recipe, the three known gotchas (`srctree.nvmap` default, `nvsched` location, `Module.symvers` reuse), lab install state, and the long-term plan (#819 supersedes this).

## Verification

- **Round-trip applied cleanly**: extracted fresh tarball, applied patch, diffed against the live module on jetson-nano-2 — byte-identical.
- **No code changes** in this PR; nothing to build/test on hardware.

## Related

- #788 — kexec dispatcher wedge (umbrella, still open)
- #819 — long-term deterministic fix that will obsolete this patch
- #823 — landed kernel-side reservation code that consumes the debugfs files

🤖 Generated with [Claude Code](https://claude.com/claude-code)