### PR TITLE
camera: runtime IMX219 gain/exposure + MNIST polarity/center-crop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1217,8 +1217,8 @@ if(EMBED_DEMO_SCRIPTS)
     set_source_files_properties(
         kernel/src/demo_scripts.S
         PROPERTIES
-        COMPILE_DEFINITIONS "DEMO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo.lua;DEMO_MENU_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;DEMO_AUTO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;DEMO_MULTIPROC_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;DEMO_HAILO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;DEMO_ADMIN_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/admin.lua;DEMO_IMX219_MNIST_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua;DEMO_CAMERA_HEATMAP_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/camera_heatmap.lua"
-        OBJECT_DEPENDS "${CMAKE_SOURCE_DIR}/scripts/demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua;${CMAKE_SOURCE_DIR}/scripts/camera_heatmap.lua"
+        COMPILE_DEFINITIONS "DEMO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo.lua;DEMO_MENU_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;DEMO_AUTO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;DEMO_MULTIPROC_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;DEMO_HAILO_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;DEMO_ADMIN_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/admin.lua;DEMO_IMX219_MNIST_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua;DEMO_CAMERA_HEATMAP_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/camera_heatmap.lua;DEMO_CAMERA_SWEEP_LUA_PATH=${CMAKE_SOURCE_DIR}/scripts/camera_sweep.lua"
+        OBJECT_DEPENDS "${CMAKE_SOURCE_DIR}/scripts/demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_menu.lua;${CMAKE_SOURCE_DIR}/scripts/demo_auto.lua;${CMAKE_SOURCE_DIR}/scripts/multiproc_demo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_hailo.lua;${CMAKE_SOURCE_DIR}/scripts/demo_imx219_mnist.lua;${CMAKE_SOURCE_DIR}/scripts/camera_heatmap.lua;${CMAKE_SOURCE_DIR}/scripts/camera_sweep.lua"
     )
 endif()
 

--- a/kernel/drivers/camera/imx219.c
+++ b/kernel/drivers/camera/imx219.c
@@ -327,15 +327,56 @@ static const struct imx219_reg_seq imx219_mode_binning_1640x1232[] = {
  * frame timing", so the sensor never emits a SOF.
  *
  * For binning mode 1640×1232, VTS=1763 (per supported_modes[2]
- * .vts_def in L4T). EXPOSURE=0x640 (1600 lines, IMX219_EXPOSURE_DEFAULT).
- * DIGITAL_GAIN=0x0100 ("1.0x", IMX219_DGTL_GAIN_DEFAULT).
- * ANALOG_GAIN=0 (IMX219_ANA_GAIN_DEFAULT). */
+ * .vts_def in L4T). VTS is fixed-shape per mode, so it stays in
+ * this const table. Gain + exposure are operator-tunable; they
+ * live in the imx219_runtime_* statics below and are written
+ * inline by imx219_set_mode_binning_1640x1232 after this table. */
 static const struct imx219_reg_seq imx219_default_ctrls_binning[] = {
-    R8 (0x0157, 0),                         /* ANALOG_GAIN */
-    R16(0x0158, 0x0100),                    /* DIGITAL_GAIN = 1.0x */
-    R16(0x015a, 0x0640),                    /* EXPOSURE = 1600 lines */
     R16(0x0160, 1763),                      /* VTS — binning-mode 30 fps frame timing */
 };
+
+/* Runtime-mutable gain + exposure. SLM-OS doesn't run a 3A
+ * (auto-exposure / AGC / AWB) loop, so these are the "ship" values
+ * the sensor wakes up with on every mode init. The
+ * slm.camera.imx219_set_{gain,exposure} Lua bindings (admin) let
+ * the operator override them from the shell to find a usable combo
+ * for the current scene without rebuilding the kernel.
+ *
+ * IMX219 ANALOG_GAIN encoding: register value n maps to gain factor
+ * 256/(256-n). n=192 → 4×, n=224 → 8×, n=232 → ~10.67× (max).
+ * DIGITAL_GAIN is fixed-point: 0x0100 = 1.0×, 0x0200 = 2.0×.
+ *
+ * Iteration history on jetson-nano-1 looking at a 5cm × 5cm hand-
+ * drawn digit on white paper under typical indoor ambient (after
+ * invert + center-crop preprocess):
+ *
+ *   ANALOG=0   DIGITAL=0x0100  → max pixel 0.085, argmax stuck
+ *                                on 5 regardless of scene
+ *                                (degenerate — sensor too dark)
+ *   ANALOG=192 DIGITAL=0x0100  → narrow pixel band [0.82, 0.89],
+ *                                argmax stuck on 4 regardless of
+ *                                input digit (degenerate — input
+ *                                pinned near saturation, classifier
+ *                                sees no shape)
+ *   ANALOG=224 DIGITAL=0x0100  → max pixel 0.252, model began
+ *                                responding to content (e.g. a 6
+ *                                held upside-down classified as 9)
+ *   ANALOG=232 DIGITAL=0x0200  → max pixel ≈0.74, logit spread 3+,
+ *                                model meaningfully discriminates
+ *                                between digit shapes — works on
+ *                                multiple test digits (3, 4) but
+ *                                still misclassifies others (8) due
+ *                                to residual lens vignette and
+ *                                stroke-thickness asymmetry. Best
+ *                                shipping default until flat-field
+ *                                calibration lands.
+ *
+ * Operators can sweep both knobs via slm.camera.imx219_set_{gain,
+ * exposure} from lua-admin when scene changes; see scripts/
+ * camera_sweep.lua for an A×D matrix at fixed exposure. */
+static uint8_t  imx219_runtime_analog_gain  = 232u;
+static uint16_t imx219_runtime_digital_gain = 0x0200u;
+static uint16_t imx219_runtime_exposure     = 0x0640u;
 
 #undef R8
 #undef R16
@@ -393,17 +434,69 @@ int imx219_set_mode_binning_1640x1232(void)
                             / sizeof(imx219_mode_binning_1640x1232[0]));
     if (rc != 0) return rc;
 
-    /* 4. Default controls (4 writes) — VTS for frame timing,
-     * EXPOSURE / GAIN / DIGITAL_GAIN for AE baseline. Without
-     * VTS the sensor never produces a SOF (verified blocker on
-     * jetson-nano-1, this PR's iteration 1). */
+    /* 4a. VTS for frame timing — fixed per mode. Without this the
+     * sensor never produces a SOF (verified blocker on jetson-nano-1
+     * during issue #518 bring-up). */
     rc = imx219_write_table(imx219_default_ctrls_binning,
                             sizeof(imx219_default_ctrls_binning)
                             / sizeof(imx219_default_ctrls_binning[0]));
     if (rc != 0) return rc;
 
-    INFO("imx219: mode-init OK — 1640x1232 RAW10 binning, MODE_SELECT=standby");
+    /* 4b. Apply the current runtime gain + exposure. These are
+     * normal sensor controls (ANALOG_GAIN, DIGITAL_GAIN, EXPOSURE)
+     * but kept out of the const table because operators tune them
+     * from Lua via slm.camera.imx219_set_{gain,exposure} between
+     * captures. A change to the statics takes effect on this next
+     * mode-init pass — the running sensor doesn't latch them
+     * mid-frame, but every capture goes through this function. */
+    rc = tegra_i2c_write_reg16(&tegra_i2c_cam_bus, IMX219_I2C_ADDR,
+                               0x0157, imx219_runtime_analog_gain);
+    if (rc != 0) {
+        WARN("imx219: ANALOG_GAIN write failed rc=%d", rc);
+        return rc;
+    }
+    rc = tegra_i2c_write_reg16_val16(&tegra_i2c_cam_bus, IMX219_I2C_ADDR,
+                                     0x0158, imx219_runtime_digital_gain);
+    if (rc != 0) {
+        WARN("imx219: DIGITAL_GAIN write failed rc=%d", rc);
+        return rc;
+    }
+    rc = tegra_i2c_write_reg16_val16(&tegra_i2c_cam_bus, IMX219_I2C_ADDR,
+                                     0x015a, imx219_runtime_exposure);
+    if (rc != 0) {
+        WARN("imx219: EXPOSURE write failed rc=%d", rc);
+        return rc;
+    }
+
+    INFO("imx219: mode-init OK — 1640x1232 RAW10 binning, gain=(0x%02x,0x%04x) exp=%u, MODE_SELECT=standby",
+         (unsigned)imx219_runtime_analog_gain,
+         (unsigned)imx219_runtime_digital_gain,
+         (unsigned)imx219_runtime_exposure);
     return 0;
+}
+
+int imx219_set_runtime_gain(uint8_t analog, uint16_t digital)
+{
+    imx219_runtime_analog_gain  = analog;
+    imx219_runtime_digital_gain = digital;
+    return 0;
+}
+
+void imx219_get_runtime_gain(uint8_t *analog_out, uint16_t *digital_out)
+{
+    if (analog_out)  *analog_out  = imx219_runtime_analog_gain;
+    if (digital_out) *digital_out = imx219_runtime_digital_gain;
+}
+
+int imx219_set_runtime_exposure(uint16_t lines)
+{
+    imx219_runtime_exposure = lines;
+    return 0;
+}
+
+uint16_t imx219_get_runtime_exposure(void)
+{
+    return imx219_runtime_exposure;
 }
 
 int imx219_streaming_enable(void)
@@ -645,6 +738,11 @@ int imx219_capture_one_frame(struct camera_frame *out)
     out->height = fb_h;
     out->bayer  = CAMERA_BAYER_RGGB;
     out->format = CAMERA_FORMAT_T_R16;
+    /* IMX219 captures raw photographic data through a wide-angle
+     * lens with heavy corner vignette — invert and center-crop are
+     * what MNIST needs to classify the result. */
+    out->recommended_invert      = true;
+    out->recommended_center_crop = true;
     return 0;
 }
 
@@ -664,5 +762,16 @@ int imx219_capture_one_frame(struct camera_frame *out) {
     (void)out;
     return -1;
 }
+int imx219_set_runtime_gain(uint8_t analog, uint16_t digital) {
+    (void)analog; (void)digital; return -1;
+}
+void imx219_get_runtime_gain(uint8_t *analog_out, uint16_t *digital_out) {
+    if (analog_out)  *analog_out  = 0u;
+    if (digital_out) *digital_out = 0u;
+}
+int imx219_set_runtime_exposure(uint16_t lines) {
+    (void)lines; return -1;
+}
+uint16_t imx219_get_runtime_exposure(void) { return 0u; }
 
 #endif /* PLATFORM_JETSON_ORIN_NANO */

--- a/kernel/include/camera.h
+++ b/kernel/include/camera.h
@@ -65,6 +65,20 @@ struct camera_frame {
     uint32_t       height;
     uint32_t       bayer;   /* CAMERA_BAYER_*  */
     uint32_t       format;  /* CAMERA_FORMAT_* */
+
+    /* Per-backend defaults for `camera_preprocess_mnist`'s `invert`
+     * and `center_crop` args. The mock backend ships MNIST-shaped
+     * data (bright stroke on dark background, full-frame digit) so
+     * both default false. The IMX219 backend captures raw
+     * photographic data (black ink on white paper) through a wide-
+     * angle lens with heavy corner vignette, so both default true.
+     *
+     * The Lua wrapper consults these when the caller omits the
+     * corresponding optional arg — keeping the recommendation
+     * data-driven from the backend rather than implicit on the
+     * camera name string. */
+    bool recommended_invert;
+    bool recommended_center_crop;
 };
 
 /*
@@ -109,6 +123,41 @@ int camera_open(const char *name, struct camera_frame *out);
  * the same high-8-bit value per pixel, so the produced fp32 output
  * is byte-identical regardless of source format for a given scene.
  *
+ * `invert` selects the output polarity. MNIST is trained on images
+ * where the *digit strokes* are bright (~1.0) on a dark (~0.0)
+ * background — i.e. the opposite of natural photographic data.
+ *
+ *   invert=false → straight normalize: bright input → output near 1.0
+ *                  Correct for the embedded mock frame, which is
+ *                  already MNIST-shaped (black background, bright
+ *                  stroke pixels). All pre-existing pinned-output
+ *                  tests use this polarity.
+ *
+ *   invert=true  → inverted normalize: bright input → output near 0.0
+ *                  Correct for raw photographic data like the IMX219
+ *                  sensor capturing a hand-drawn black digit on
+ *                  white paper. Without this, the model receives a
+ *                  photographic negative of what it was trained on,
+ *                  and argmax collapses toward closed-shape classes
+ *                  (0/6/8) regardless of the actual digit.
+ *
+ * `center_crop` selects how much of the source frame is sampled.
+ *
+ *   center_crop=false → cover the full 1232-tall frame: 28×44-pixel
+ *                       blocks, no Y-offset, X-offset 204 (matches
+ *                       the legacy mock-frame contract; pinned tests
+ *                       use this mode).
+ *
+ *   center_crop=true  → use a 616×616 region centred on the sensor:
+ *                       28×22-pixel blocks, X-offset 512, Y-offset
+ *                       308. Required for the IMX219 backend because
+ *                       the Tegra ISP isn't reachable from SLM-OS,
+ *                       so the raw sensor frame carries the lens's
+ *                       full vignette pattern (heavy ~50% light
+ *                       fall-off at the corners on the standard
+ *                       wide-angle modules). Sampling only the
+ *                       central half rejects the vignetted region.
+ *
  * Returns 0 on success. Negative on bad arguments:
  *   -1 = NULL pointer / out_bytes too small
  *   -2 = unsupported width/height/bayer/format (only RGGB 1640x1232
@@ -120,5 +169,7 @@ int camera_preprocess_mnist(const uint8_t *data,
                             uint32_t       height,
                             uint32_t       bayer,
                             uint32_t       format,
+                            bool           invert,
+                            bool           center_crop,
                             uint8_t       *out_bytes,
                             size_t         out_capacity);

--- a/kernel/include/imx219.h
+++ b/kernel/include/imx219.h
@@ -181,6 +181,39 @@ int imx219_streaming_disable(void);
 struct camera_frame;
 
 /*
+ * Set the runtime ANALOG_GAIN (reg 0x0157, 8-bit) and DIGITAL_GAIN
+ * (reg 0x0158, 16-bit) values. Both are stored in module-scope
+ * statics and applied to the sensor on every subsequent
+ * `imx219_set_mode_binning_1640x1232` (i.e. every capture). The
+ * running sensor doesn't latch these mid-frame.
+ *
+ * ANALOG_GAIN encoding: register value n maps to gain factor
+ * 256/(256-n). Useful values: 0 (1×), 192 (4×), 224 (8×), 232
+ * (~10.67×, the IMX219 max).
+ *
+ * DIGITAL_GAIN is fixed-point: 0x0100 = 1.0×, 0x0200 = 2.0×,
+ * 0x0400 = 4.0×. Caps at 0x0FFF per the datasheet.
+ *
+ * Returns 0 on success (the writes are deferred to next mode-init,
+ * so there's no I²C path to fail here). QEMU stub returns -1.
+ */
+int imx219_set_runtime_gain(uint8_t analog, uint16_t digital);
+
+/* Read back the current runtime gain values. Either pointer may
+ * be NULL to skip; both NULL is a no-op. */
+void imx219_get_runtime_gain(uint8_t *analog_out, uint16_t *digital_out);
+
+/*
+ * Set the runtime EXPOSURE (reg 0x015a, 16-bit, in sensor lines).
+ * Applied on the next mode-init like the gain setters above.
+ * Useful range for 1640×1232 binning mode is 1..VTS-4 (VTS=1763).
+ * QEMU stub returns -1. */
+int imx219_set_runtime_exposure(uint16_t lines);
+
+/* Read back the current runtime exposure (in lines). */
+uint16_t imx219_get_runtime_exposure(void);
+
+/*
  * Capture exactly one frame end-to-end and fill *out with a pointer
  * into the kernel-owned IMX219 frame-buffer carveout at
  * `CAMRTC_FRAME_BUFFER_PHYS`. Each call walks the full bring-up

--- a/kernel/src/camera.c
+++ b/kernel/src/camera.c
@@ -41,24 +41,26 @@ extern const uint8_t mock_camera_frame_end[]   __attribute__((weak));
 #define MOCK_FRAME_T_R16_BYTES (MOCK_FRAME_W * MOCK_FRAME_H * 2u)
 
 #define MNIST_DIM          28u
-#define MNIST_BLOCK        44u   /* 28 * 44 == 1232 */
-#define MNIST_CROP         (MNIST_DIM * MNIST_BLOCK)
-#define MNIST_CROP_X_OFF   ((MOCK_FRAME_W - MNIST_CROP) / 2u)  /* 204, even */
+#define MNIST_BLOCK_FULL   44u   /* 28 * 44 == 1232 (full frame height) */
+#define MNIST_BLOCK_HALF   22u   /* 28 * 22 == 616  (centre-crop mode)  */
 
-/* Half the RGGB grid is green: 44 * 44 / 2 = 968 samples per block. */
-#define MNIST_GREEN_PER_BLOCK ((MNIST_BLOCK * MNIST_BLOCK) / 2u)
-
-/* Geometry invariants. Pin them at compile time so a future tweak to
- * MOCK_FRAME_W / MNIST_BLOCK can't silently break the algorithm in a
- * way the tests would only catch as an opaque MD5 mismatch. */
-_Static_assert((MNIST_CROP_X_OFF & 1u) == 0u,
-    "Centred crop X offset must be even to preserve RGGB Bayer phase");
-_Static_assert((MNIST_BLOCK & 1u) == 0u,
-    "Box-average block must be even so r0 = i*MNIST_BLOCK stays even "
-    "(preserves Bayer row phase) and so each row contains the same "
-    "number of green pixels");
-_Static_assert(MNIST_CROP == MOCK_FRAME_H,
-    "Centred crop assumes a square equal to the frame height");
+/* Geometry invariants. Both block sizes must be even (preserves Bayer
+ * row phase + identical green-sample count per row), and the centred
+ * crop offsets must be even (preserves RGGB column phase). Numbers
+ * baked at compile time so a future tweak to MOCK_FRAME_W / either
+ * block size can't silently break the algorithm. */
+_Static_assert((MNIST_BLOCK_FULL & 1u) == 0u,
+    "Full-frame box-average block must be even");
+_Static_assert((MNIST_BLOCK_HALF & 1u) == 0u,
+    "Centre-crop box-average block must be even");
+_Static_assert(((MOCK_FRAME_W - MNIST_DIM * MNIST_BLOCK_FULL) / 2u & 1u) == 0u,
+    "Full-frame X-offset must be even (Bayer phase)");
+_Static_assert(((MOCK_FRAME_W - MNIST_DIM * MNIST_BLOCK_HALF) / 2u & 1u) == 0u,
+    "Centre-crop X-offset must be even (Bayer phase)");
+_Static_assert(((MOCK_FRAME_H - MNIST_DIM * MNIST_BLOCK_HALF) / 2u & 1u) == 0u,
+    "Centre-crop Y-offset must be even (Bayer phase)");
+_Static_assert(MNIST_DIM * MNIST_BLOCK_FULL == MOCK_FRAME_H,
+    "Full-frame mode covers the whole frame height with no Y-offset");
 
 /*
  * Read the high 8 bits of pixel `pixel_index` from a RAW10 packed
@@ -154,6 +156,11 @@ int camera_open(const char *name, struct camera_frame *out)
         out->height = MOCK_FRAME_H;
         out->bayer  = CAMERA_BAYER_RGGB;
         out->format = CAMERA_FORMAT_RAW10_PACKED;
+        /* Mock frame is hand-crafted MNIST-shape data (bright digit
+         * on dark background, full-frame). No vignette, no polarity
+         * flip needed. */
+        out->recommended_invert      = false;
+        out->recommended_center_crop = false;
         return 0;
     }
 
@@ -176,6 +183,8 @@ int camera_preprocess_mnist(const uint8_t *data,
                             uint32_t       height,
                             uint32_t       bayer,
                             uint32_t       format,
+                            bool           invert,
+                            bool           center_crop,
                             uint8_t       *out_bytes,
                             size_t         out_capacity)
 {
@@ -199,29 +208,55 @@ int camera_preprocess_mnist(const uint8_t *data,
     }
     if (data_len < min_bytes) return -1;
 
+    /* Crop geometry is selected by center_crop. Full-frame mode
+     * matches the legacy contract: cover the whole 1232-tall frame
+     * (Y-offset 0) with 28 × 44-pixel blocks. Centre-crop mode uses
+     * 28 × 22-pixel blocks over a 616×616 region centred on the
+     * sensor — the half-area is needed because IMX219's wide-angle
+     * lens has heavy vignette in the corners (see camera_heatmap
+     * blank-paper trace, this PR), and the L4T `nvarguscamerasrc`
+     * ISP path that would normally apply lens-shading correction
+     * isn't reachable from SLM-OS. */
+    const uint32_t mnist_block      = center_crop ? MNIST_BLOCK_HALF
+                                                  : MNIST_BLOCK_FULL;
+    const uint32_t mnist_crop       = MNIST_DIM * mnist_block;
+    const uint32_t crop_x_off       = (MOCK_FRAME_W - mnist_crop) / 2u;
+    const uint32_t crop_y_off       = (MOCK_FRAME_H - mnist_crop) / 2u;
+    const uint32_t green_per_block  = (mnist_block * mnist_block) / 2u;
+    const uint32_t denom            = green_per_block * 255u;
+
     for (uint32_t i = 0; i < MNIST_DIM; i++) {
-        uint32_t r0 = i * MNIST_BLOCK;
+        uint32_t r0 = i * mnist_block + crop_y_off;
         for (uint32_t j = 0; j < MNIST_DIM; j++) {
-            uint32_t c0 = j * MNIST_BLOCK + MNIST_CROP_X_OFF;
+            uint32_t c0 = j * mnist_block + crop_x_off;
             uint32_t sum = 0;
 
-            for (uint32_t dy = 0; dy < MNIST_BLOCK; dy++) {
+            for (uint32_t dy = 0; dy < mnist_block; dy++) {
                 uint32_t r = r0 + dy;
                 /* RGGB green pixels: (r%2 == 0, c%2 == 1) ∪
                  *                    (r%2 == 1, c%2 == 0). Pick the
                  * starting column phase based on r's parity, then
                  * stride by 2. */
                 uint32_t c_start = c0 + ((r & 1u) ? 0u : 1u);
-                for (uint32_t c = c_start; c < c0 + MNIST_BLOCK; c += 2u) {
+                for (uint32_t c = c_start; c < c0 + mnist_block; c += 2u) {
                     sum += pixel_hi8(data, r * MOCK_FRAME_W + c, format);
                 }
             }
 
-            /* avg = sum / 968 ∈ [0, 255]; normalise to [0, 1] by
-             * dividing by 968*255. Integer-only IEEE 754 build because
-             * -mgeneral-regs-only forbids float/NEON in kernel C. */
-            uint32_t bits = fp32_div_bits(sum,
-                                          MNIST_GREEN_PER_BLOCK * 255u);
+            /* avg = sum / green_per_block ∈ [0, 255]; normalise to
+             * [0, 1] by dividing by green_per_block*255. Integer-only
+             * IEEE 754 build because -mgeneral-regs-only forbids
+             * float/NEON in kernel C.
+             *
+             * Polarity (see camera_preprocess_mnist docstring): MNIST
+             * trains on bright-stroke-on-dark-background, but raw
+             * sensor data of a black-on-white drawing produces the
+             * opposite. The invert path flips the polarity at the
+             * integer-numerator step before fp32 division so we never
+             * touch fp arithmetic — denom is unchanged, only the
+             * numerator becomes (denom_byte_total − sum). */
+            uint32_t num = invert ? (denom - sum) : sum;
+            uint32_t bits = fp32_div_bits(num, denom);
             uint8_t *dst = out_bytes + (i * MNIST_DIM + j) * 4u;
             __builtin_memcpy(dst, &bits, sizeof(bits));
         }

--- a/kernel/src/demo_init.c
+++ b/kernel/src/demo_init.c
@@ -41,6 +41,8 @@ extern const unsigned char demo_imx219_mnist_lua_start[];
 extern const unsigned char demo_imx219_mnist_lua_end[];
 extern const unsigned char demo_camera_heatmap_lua_start[];
 extern const unsigned char demo_camera_heatmap_lua_end[];
+extern const unsigned char demo_camera_sweep_lua_start[];
+extern const unsigned char demo_camera_sweep_lua_end[];
 
 int demo_init(void)
 {
@@ -134,6 +136,17 @@ int demo_init(void)
                             (size_t)(demo_camera_heatmap_lua_end -
                                      demo_camera_heatmap_lua_start));
         littlefs_file_close(mnt, fch);
+    }
+
+    /* IMX219 gain/exposure sweep — iterate a small grid and
+     * summarise per-trial pixel range + MNIST inference. */
+    int fcs = littlefs_file_open(mnt, "/camera_sweep.lua",
+                                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fcs >= 0) {
+        littlefs_file_write(mnt, fcs, demo_camera_sweep_lua_start,
+                            (size_t)(demo_camera_sweep_lua_end -
+                                     demo_camera_sweep_lua_start));
+        littlefs_file_close(mnt, fcs);
     }
 
     /* #64: boot-time model preload config. One model name per line.

--- a/kernel/src/demo_scripts.S
+++ b/kernel/src/demo_scripts.S
@@ -19,11 +19,13 @@
     !defined(DEMO_AUTO_LUA_PATH) || !defined(DEMO_MULTIPROC_LUA_PATH) || \
     !defined(DEMO_HAILO_LUA_PATH) || !defined(DEMO_ADMIN_LUA_PATH) || \
     !defined(DEMO_IMX219_MNIST_LUA_PATH) || \
-    !defined(DEMO_CAMERA_HEATMAP_LUA_PATH)
+    !defined(DEMO_CAMERA_HEATMAP_LUA_PATH) || \
+    !defined(DEMO_CAMERA_SWEEP_LUA_PATH)
 # error "DEMO_LUA_PATH, DEMO_MENU_LUA_PATH, DEMO_AUTO_LUA_PATH, "\
         "DEMO_MULTIPROC_LUA_PATH, DEMO_HAILO_LUA_PATH, "\
-        "DEMO_ADMIN_LUA_PATH, DEMO_IMX219_MNIST_LUA_PATH, and "\
-        "DEMO_CAMERA_HEATMAP_LUA_PATH must be supplied by the build system"
+        "DEMO_ADMIN_LUA_PATH, DEMO_IMX219_MNIST_LUA_PATH, "\
+        "DEMO_CAMERA_HEATMAP_LUA_PATH, and "\
+        "DEMO_CAMERA_SWEEP_LUA_PATH must be supplied by the build system"
 #endif
 
 #define xstr(s) str(s)
@@ -107,6 +109,17 @@ demo_imx219_mnist_lua_end:
 demo_camera_heatmap_lua_start:
     .incbin xstr(DEMO_CAMERA_HEATMAP_LUA_PATH)
 demo_camera_heatmap_lua_end:
+
+    /* IMX219 gain/exposure sweep — iterate a small grid of
+     * (analog, digital, exposure) combos and report pixel range +
+     * MNIST argmax + top-1 margin for each. Operator picks the
+     * row that looks best, applies it from the REPL. */
+    .global demo_camera_sweep_lua_start
+    .global demo_camera_sweep_lua_end
+    .align 4
+demo_camera_sweep_lua_start:
+    .incbin xstr(DEMO_CAMERA_SWEEP_LUA_PATH)
+demo_camera_sweep_lua_end:
 
 #if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__))
     .section .note.GNU-stack, "", @progbits

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -8,6 +8,7 @@
 #include "lua_slm.h"
 #include "build_info.h"
 #include "camera.h"
+#include "imx219.h"   /* imx219_set/get_runtime_gain, _exposure */
 #include "debug.h"
 #include "timer.h"
 #include "pmm.h"
@@ -4038,6 +4039,29 @@ static int l_camera_preprocess_mnist(lua_State *L) {
      * — see follow-up issue. */
     const char *name = luaL_optstring(L, 5, "mock");
 
+    /* Optional `invert` (6th arg) — flips output polarity so raw
+     * photographic data (black ink on white paper) matches MNIST's
+     * trained convention (bright stroke on dark background). When
+     * omitted, the per-backend recommendation from
+     * `camera_frame.recommended_invert` is used (mock: false, imx219:
+     * true). Pass an explicit boolean to override.
+     *
+     * Optional `center_crop` (7th arg) — sample the central 616×616
+     * of the sensor instead of the full 1232×1232. Required for the
+     * IMX219 backend whose wide-angle lens has heavy vignette in the
+     * corners (the Tegra ISP that would normally apply lens-shading
+     * correction isn't reachable from SLM-OS). When omitted, the
+     * per-backend recommendation from
+     * `camera_frame.recommended_center_crop` is used.
+     *
+     * The defaults can only be resolved after camera_open populates
+     * the frame, so the explicit-pass cases are captured here and
+     * defaulted below. */
+    bool invert_explicit      = !lua_isnoneornil(L, 6);
+    bool center_crop_explicit = !lua_isnoneornil(L, 7);
+    int  invert_arg            = invert_explicit      ? lua_toboolean(L, 6) : 0;
+    int  center_crop_arg       = center_crop_explicit ? lua_toboolean(L, 7) : 0;
+
     if (frame_id != 0) {
         lua_pushnil(L);
         lua_pushinteger(L, -1);
@@ -4056,6 +4080,10 @@ static int l_camera_preprocess_mnist(lua_State *L) {
         lua_pushinteger(L, -3);
         return 2;
     }
+    bool invert      = invert_explicit      ? (bool)invert_arg
+                                            : frame.recommended_invert;
+    bool center_crop = center_crop_explicit ? (bool)center_crop_arg
+                                            : frame.recommended_center_crop;
 
     /* 3,136 bytes on the kernel-task stack — STACK_SIZE is 64 KB
      * (kernel/include/config.h), so this is ~5% of budget. Stack
@@ -4067,6 +4095,7 @@ static int l_camera_preprocess_mnist(lua_State *L) {
     int rc = camera_preprocess_mnist(frame.data, frame.size,
                                      frame.width, frame.height,
                                      frame.bayer, frame.format,
+                                     invert, center_crop,
                                      out, sizeof(out));
     if (rc != 0) {
         lua_pushnil(L);
@@ -4082,6 +4111,88 @@ static const luaL_Reg slm_camera_lib[] = {
     {"capture",          l_camera_capture},
     {"close",            l_camera_close},
     {"preprocess_mnist", l_camera_preprocess_mnist},
+    {NULL, NULL}
+};
+
+/* ========================================================================
+ * slm.camera.imx219_* — operator tuning surface (admin-only)
+ *
+ * The IMX219's analog gain, digital gain, and exposure live as
+ * file-scope statics in kernel/drivers/camera/imx219.c and are
+ * written to the sensor on every mode-init (i.e. every capture).
+ * These four bindings let an operator sweep them from Lua to find
+ * a usable combo for the current scene without rebuilding.
+ *
+ *   imx219_set_gain(analog, digital)  - analog ∈ [0, 255],
+ *                                       digital ∈ [0, 0x0FFF]
+ *                                       (datasheet cap). Returns 0
+ *                                       on success.
+ *   imx219_get_gain()                 - returns (analog, digital).
+ *   imx219_set_exposure(lines)        - lines ∈ [0, 0xFFFF].
+ *                                       Returns 0 on success.
+ *   imx219_get_exposure()             - returns lines.
+ *
+ * QEMU / non-Jetson builds return -1 from the setters and 0 from
+ * the getters (sensor not present). The change is staged in the
+ * runtime statics and takes effect on the next capture's mode-init
+ * — the running sensor doesn't latch them mid-frame. See the
+ * `imx219_runtime_*` block in imx219.c for the iteration history
+ * that motivated the defaults.
+ * ======================================================================== */
+
+static int l_camera_imx219_set_gain(lua_State *L) {
+    if (!L) return 0;
+    lua_Integer analog  = luaL_checkinteger(L, 1);
+    lua_Integer digital = luaL_checkinteger(L, 2);
+    if (analog < 0 || analog > UINT8_MAX) {
+        return luaL_error(L, "analog gain out of range [0, %d]",
+                          (int)UINT8_MAX);
+    }
+    if (digital < 0 || digital > UINT16_MAX) {
+        return luaL_error(L, "digital gain out of range [0, %d]",
+                          (int)UINT16_MAX);
+    }
+    int rc = imx219_set_runtime_gain((uint8_t)analog, (uint16_t)digital);
+    lua_pushinteger(L, rc);
+    return 1;
+}
+
+static int l_camera_imx219_get_gain(lua_State *L) {
+    if (!L) return 0;
+    uint8_t  analog  = 0u;
+    uint16_t digital = 0u;
+    imx219_get_runtime_gain(&analog, &digital);
+    lua_pushinteger(L, (lua_Integer)analog);
+    lua_pushinteger(L, (lua_Integer)digital);
+    return 2;
+}
+
+static int l_camera_imx219_set_exposure(lua_State *L) {
+    if (!L) return 0;
+    lua_Integer lines = luaL_checkinteger(L, 1);
+    if (lines < 0 || lines > UINT16_MAX) {
+        return luaL_error(L, "exposure lines out of range [0, %d]",
+                          (int)UINT16_MAX);
+    }
+    int rc = imx219_set_runtime_exposure((uint16_t)lines);
+    lua_pushinteger(L, rc);
+    return 1;
+}
+
+static int l_camera_imx219_get_exposure(lua_State *L) {
+    if (!L) return 0;
+    uint16_t lines = imx219_get_runtime_exposure();
+    lua_pushinteger(L, (lua_Integer)lines);
+    return 1;
+}
+
+/* Admin-only camera bindings appended onto the slm.camera namespace
+ * when the Lua state is opened in admin mode. */
+static const luaL_Reg slm_camera_lib_admin[] = {
+    {"imx219_set_gain",     l_camera_imx219_set_gain},
+    {"imx219_get_gain",     l_camera_imx219_get_gain},
+    {"imx219_set_exposure", l_camera_imx219_set_exposure},
+    {"imx219_get_exposure", l_camera_imx219_get_exposure},
     {NULL, NULL}
 };
 
@@ -4236,10 +4347,17 @@ static void lua_push_slm_library(lua_State *L, bool admin)
     lua_pushstring(L, SLMOS_BUILD_SHA);
     lua_setfield(L, -2, "BUILD_SHA");
 
-    /* slm.camera — read-only backend (mock-only today); fine on the safe
-     * surface. Real hardware backends with side effects can move to admin
-     * when they land. */
+    /* slm.camera — read-only backend on the safe surface. Admin
+     * builds get the operator-tuning IMX219 register bindings
+     * (imx219_set/get_gain, imx219_set/get_exposure) appended onto
+     * the same namespace before the table is sealed onto slm.*. */
     luaL_newlib(L, slm_camera_lib);
+    if (admin) {
+        for (const luaL_Reg *r = slm_camera_lib_admin; r->name; r++) {
+            lua_pushcfunction(L, r->func);
+            lua_setfield(L, -2, r->name);
+        }
+    }
     lua_setfield(L, -2, "camera");
 
     if (admin) {

--- a/kernel/tests/test_camera.c
+++ b/kernel/tests/test_camera.c
@@ -115,33 +115,34 @@ static void test_camera_preprocess_bad_args(void)
     /* NULL guards. */
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         NULL, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, false, false,
+        dummy_out, sizeof(dummy_out)));
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        CAMERA_FORMAT_RAW10_PACKED, NULL, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, false, false, NULL, sizeof(dummy_out)));
 
     /* out_capacity too small. */
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        CAMERA_FORMAT_RAW10_PACKED, dummy_out, CAMERA_MNIST_OUT_BYTES - 1u));
+        CAMERA_FORMAT_RAW10_PACKED, false, false, dummy_out, CAMERA_MNIST_OUT_BYTES - 1u));
 
     /* Wrong geometry — only 1640x1232 supported today. */
     TEST_ASSERT_EQUAL_INT(-2, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 640u, 480u, CAMERA_BAYER_RGGB,
-        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, false, false, dummy_out, sizeof(dummy_out)));
     TEST_ASSERT_EQUAL_INT(-2, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_GRBG,
-        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, false, false, dummy_out, sizeof(dummy_out)));
 
     /* Unknown format — must reject before reading data. */
     TEST_ASSERT_EQUAL_INT(-2, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        99u, dummy_out, sizeof(dummy_out)));
+        99u, false, false, dummy_out, sizeof(dummy_out)));
 
     /* Right geometry but data_len smaller than the frame requires. */
     TEST_ASSERT_EQUAL_INT(-1, camera_preprocess_mnist(
         dummy_in, sizeof(dummy_in), 1640u, 1232u, CAMERA_BAYER_RGGB,
-        CAMERA_FORMAT_RAW10_PACKED, dummy_out, sizeof(dummy_out)));
+        CAMERA_FORMAT_RAW10_PACKED, false, false, dummy_out, sizeof(dummy_out)));
 }
 
 /*
@@ -163,6 +164,8 @@ static void test_camera_preprocess_mock_first_pixel(void)
     int rc = camera_preprocess_mnist(frame.data, frame.size,
                                      frame.width, frame.height,
                                      frame.bayer, frame.format,
+                                     /*invert=*/false,
+                                     /*center_crop=*/false,
                                      out, sizeof(out));
     TEST_ASSERT_EQUAL_INT(0, rc);
 
@@ -213,15 +216,186 @@ static void test_camera_preprocess_t_r16_matches_raw10(void)
     TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
         frame.data, frame.size, frame.width, frame.height,
         frame.bayer, CAMERA_FORMAT_RAW10_PACKED,
+        /*invert=*/false, /*center_crop=*/false,
         out_raw10, sizeof(out_raw10)));
     TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
         t_r16_synth_buffer, sizeof(t_r16_synth_buffer),
         frame.width, frame.height, frame.bayer,
-        CAMERA_FORMAT_T_R16, out_t_r16, sizeof(out_t_r16)));
+        CAMERA_FORMAT_T_R16,
+        /*invert=*/false, /*center_crop=*/false,
+        out_t_r16, sizeof(out_t_r16)));
 
     for (uint32_t i = 0; i < CAMERA_MNIST_OUT_BYTES; i++) {
         TEST_ASSERT_EQUAL_UINT8(out_raw10[i], out_t_r16[i]);
     }
+}
+
+/*
+ * Test: invert=true must produce a complemented output relative to
+ * invert=false for the same input. The math is num' = denom - num,
+ * so for every cell, out[i] (invert=true) and out[i] (invert=false)
+ * are fp32 values whose pre-division numerators sum to denom. After
+ * fp32_div_bits, that round-trips to fp32 values that sum to ~1.0.
+ *
+ * Mock frame is partially black (numerator 0 → fp32 0.0) and partially
+ * bright (numerator near denom → fp32 near 1.0). With invert=true the
+ * mapping swaps. The test picks a couple of pixels at known positions
+ * (one bright, one dark in the mock) and asserts the swap.
+ */
+static void test_camera_preprocess_invert_flips_polarity(void)
+{
+    if (!mock_frame_embedded()) {
+        TEST_IGNORE_MESSAGE("MOCK_CAMERA_FRAME=OFF — mock backend skipped");
+    }
+    struct camera_frame frame;
+    TEST_ASSERT_EQUAL_INT(0, camera_open("mock", &frame));
+
+    uint8_t out_norm[CAMERA_MNIST_OUT_BYTES];
+    uint8_t out_inv [CAMERA_MNIST_OUT_BYTES];
+
+    TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
+        frame.data, frame.size, frame.width, frame.height,
+        frame.bayer, frame.format,
+        /*invert=*/false, /*center_crop=*/false,
+        out_norm, sizeof(out_norm)));
+    TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
+        frame.data, frame.size, frame.width, frame.height,
+        frame.bayer, frame.format,
+        /*invert=*/true,  /*center_crop=*/false,
+        out_inv,  sizeof(out_inv)));
+
+    /* For every cell, normal_fp32 + inverted_fp32 ≈ 1.0. Decode the
+     * fp32 by reinterpreting the four bytes — kernel build is
+     * little-endian with no float regs (-mgeneral-regs-only), so
+     * use the integer bit pattern + a software comparison. The
+     * sum-to-1 invariant collapses to: the two numerators sum to
+     * denom = 968*255 = 246840 at full-frame block size. A simpler
+     * stricter check works: cells that are 0.0 normal must be ~1.0
+     * inverted, and cells that are ~1.0 normal must be 0.0 inverted.
+     * Use the bit pattern: 0x00000000 == 0.0f, 0x3f800000 == 1.0f. */
+    uint32_t saw_complement_pair = 0;
+    for (uint32_t i = 0; i < CAMERA_MNIST_OUT_BYTES; i += 4) {
+        uint32_t n, v;
+        __builtin_memcpy(&n, out_norm + i, sizeof(n));
+        __builtin_memcpy(&v, out_inv  + i, sizeof(v));
+        if (n == 0u && v == 0x3f800000u) {
+            saw_complement_pair++;
+        }
+        if (n == 0x3f800000u && v == 0u) {
+            saw_complement_pair++;
+        }
+    }
+    /* The mock contains both fully-dark and fully-bright cells, so
+     * we should see at least one of each complement direction. */
+    TEST_ASSERT_TRUE(saw_complement_pair >= 2u);
+}
+
+/*
+ * Test: center_crop=true must produce different output than
+ * center_crop=false for a frame whose content differs between the
+ * full-frame and the centred 616×616 region. The mock frame is
+ * MNIST-shaped digit centred in the source, so the center-crop
+ * region has noticeably different green-channel statistics from
+ * the full frame. Any nonzero difference proves the new arg path
+ * is actually live (regression-catches the case where the arg is
+ * accidentally dropped or hard-coded).
+ */
+static void test_camera_preprocess_center_crop_changes_output(void)
+{
+    if (!mock_frame_embedded()) {
+        TEST_IGNORE_MESSAGE("MOCK_CAMERA_FRAME=OFF — mock backend skipped");
+    }
+    struct camera_frame frame;
+    TEST_ASSERT_EQUAL_INT(0, camera_open("mock", &frame));
+
+    uint8_t out_full[CAMERA_MNIST_OUT_BYTES];
+    uint8_t out_crop[CAMERA_MNIST_OUT_BYTES];
+    TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
+        frame.data, frame.size, frame.width, frame.height,
+        frame.bayer, frame.format,
+        /*invert=*/false, /*center_crop=*/false,
+        out_full, sizeof(out_full)));
+    TEST_ASSERT_EQUAL_INT(0, camera_preprocess_mnist(
+        frame.data, frame.size, frame.width, frame.height,
+        frame.bayer, frame.format,
+        /*invert=*/false, /*center_crop=*/true,
+        out_crop, sizeof(out_crop)));
+
+    bool any_differ = false;
+    for (uint32_t i = 0; i < CAMERA_MNIST_OUT_BYTES; i++) {
+        if (out_full[i] != out_crop[i]) {
+            any_differ = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_differ);
+}
+
+/*
+ * Test: camera_open populates the per-backend defaults.
+ *   mock     → both false (MNIST-shape, full frame)
+ *   imx219-0 → both true (raw photo data, wide-angle vignette)
+ *
+ * On QEMU only the mock branch is reachable; the imx219 branch
+ * needs a Jetson build to capture, so it's not asserted here.
+ */
+static void test_camera_open_populates_recommended_defaults(void)
+{
+    if (!mock_frame_embedded()) {
+        TEST_IGNORE_MESSAGE("MOCK_CAMERA_FRAME=OFF — mock backend skipped");
+    }
+    struct camera_frame frame = {0};
+    TEST_ASSERT_EQUAL_INT(0, camera_open("mock", &frame));
+    TEST_ASSERT_FALSE(frame.recommended_invert);
+    TEST_ASSERT_FALSE(frame.recommended_center_crop);
+}
+
+/* ---- IMX219 runtime gain/exposure (admin bindings) ----
+ *
+ * On QEMU the imx219_*_runtime_* surface is stubbed: setters return
+ * -1, getters return 0 / write 0 through out-params. The tests below
+ * pin that contract so the stub linkage stays correct across builds.
+ * On Jetson the real implementation owns the value and we'd need a
+ * mock sensor to test round-trip behavior; not in scope here.
+ */
+static void test_imx219_runtime_gain_exposure_stubs(void)
+{
+#if defined(PLATFORM_JETSON_ORIN_NANO)
+    /* Jetson real impl: round-trip set → get must observe the new
+     * value (stored in module-scope statics; no I²C touch since the
+     * test isn't running a real capture session). */
+    imx219_set_runtime_gain(192u, 0x0100u);
+    uint8_t  a = 0u;
+    uint16_t d = 0u;
+    imx219_get_runtime_gain(&a, &d);
+    TEST_ASSERT_EQUAL_HEX8(192u, a);
+    TEST_ASSERT_EQUAL_HEX16(0x0100u, d);
+
+    TEST_ASSERT_EQUAL_INT(0, imx219_set_runtime_exposure(0x0123u));
+    TEST_ASSERT_EQUAL_HEX16(0x0123u, imx219_get_runtime_exposure());
+
+    /* Restore the shipped defaults so any later test capture sees
+     * the values the rest of the driver assumes. */
+    imx219_set_runtime_gain(232u, 0x0200u);
+    imx219_set_runtime_exposure(0x0640u);
+#else
+    /* Non-Jetson stubs: setters report -1, getters yield 0. */
+    TEST_ASSERT_EQUAL_INT(-1, imx219_set_runtime_gain(0u, 0u));
+    uint8_t  a = 0xAAu;
+    uint16_t d = 0xBBBBu;
+    imx219_get_runtime_gain(&a, &d);
+    TEST_ASSERT_EQUAL_HEX8(0u, a);
+    TEST_ASSERT_EQUAL_HEX16(0u, d);
+
+    /* NULL-safe: both NULL must be a no-op, neither NULL must work. */
+    imx219_get_runtime_gain(NULL, NULL);
+    a = 0xAAu;
+    imx219_get_runtime_gain(&a, NULL);
+    TEST_ASSERT_EQUAL_HEX8(0u, a);
+
+    TEST_ASSERT_EQUAL_INT(-1, imx219_set_runtime_exposure(0u));
+    TEST_ASSERT_EQUAL_HEX16(0u, imx219_get_runtime_exposure());
+#endif
 }
 
 /* ---- Tegra HSI2C driver ----
@@ -963,6 +1137,10 @@ int test_suite_camera(void)
     RUN_TEST(test_camera_preprocess_bad_args);
     RUN_TEST(test_camera_preprocess_mock_first_pixel);
     RUN_TEST(test_camera_preprocess_t_r16_matches_raw10);
+    RUN_TEST(test_camera_preprocess_invert_flips_polarity);
+    RUN_TEST(test_camera_preprocess_center_crop_changes_output);
+    RUN_TEST(test_camera_open_populates_recommended_defaults);
+    RUN_TEST(test_imx219_runtime_gain_exposure_stubs);
     RUN_TEST(test_tegra_i2c_stubs_return_minus_one);
     RUN_TEST(test_tegra_i2c_cam_bus_wiring);
     RUN_TEST(test_tegra_i2c_api_arg_validation);

--- a/scripts/camera_sweep.lua
+++ b/scripts/camera_sweep.lua
@@ -1,0 +1,161 @@
+-- camera_sweep.lua — sweep IMX219 gain + exposure to find a good
+-- MNIST setting for the current scene.
+--
+-- For each (analog, digital, exposure) combo, the script:
+--   1. Programmes the runtime registers via slm.camera.imx219_set_*
+--   2. Captures one frame
+--   3. Runs MNIST preprocess + inference
+--   4. Prints a one-line summary: pixel range, argmax, top-1
+--      margin over second-best (the larger, the more confident
+--      the classifier is)
+--
+-- The user reads the table, decides which combo looks best, and
+-- either applies it from the REPL with imx219_set_gain/exposure
+-- or edits the IMX219 driver defaults to ship them.
+--
+-- Usage:  lua-admin /mnt/files/camera_sweep.lua [expected-digit]
+--
+-- expected-digit  optional 0..9. If given, marks each row with
+--                 MATCH or (expected N) so the right answer is
+--                 obvious at a glance.
+
+local P = slm.print
+local expected = tonumber(arg and arg[1])
+
+-- ------------------------------------------------------------------
+-- Trial table. Two regimes worth comparing: an EXPOSURE sweep at
+-- the shipping low-gain default (4× analog, 1× digital — empirically
+-- best for MNIST on the Jetson IMX219 + center-crop pipeline),
+-- followed by a couple of high-gain entries for contrast. Re-run
+-- with a custom grid if you need to drill in further.
+-- ------------------------------------------------------------------
+local grid = {
+    -- analog, digital, exposure(lines)
+    -- Independent A × D sweep at fixed E=1600.
+    -- A encodes via 256/(256-A): 192=4×, 224=8×, 232=10.67× (max).
+    -- D is fixed-point: 0x0100=1.0×, 0x0200=2.0×, 0x0400=4.0×.
+    { 192, 0x0100, 0x0640 },   -- A=4×   D=1×    (baseline)
+    { 192, 0x0200, 0x0640 },   -- A=4×   D=2×
+    { 192, 0x0400, 0x0640 },   -- A=4×   D=4×
+    { 232, 0x0100, 0x0640 },   -- A=11×  D=1×
+    { 232, 0x0200, 0x0640 },   -- A=11×  D=2×    (prior shipping default)
+    { 232, 0x0400, 0x0640 },   -- A=11×  D=4×
+}
+
+-- ------------------------------------------------------------------
+-- Per-trial work
+-- ------------------------------------------------------------------
+local function trial(idx, analog, digital, exp_lines)
+    slm.camera.imx219_set_gain(analog, digital)
+    slm.camera.imx219_set_exposure(exp_lines)
+
+    local cam = slm.camera.open("imx219-0")
+    if cam == nil then
+        P(string.format("[%d] camera open failed", idx))
+        return
+    end
+
+    local frame_id, w, h, bayer = cam:capture()
+    if frame_id == nil then
+        P(string.format("[%d] capture failed", idx))
+        cam:close()
+        return
+    end
+
+    local bytes, rc = slm.camera.preprocess_mnist(frame_id, w, h, bayer,
+                                                  "imx219-0")
+    if bytes == nil then
+        P(string.format("[%d] preprocess failed rc=%d", idx, rc or 0))
+        cam:close()
+        return
+    end
+
+    -- Pixel range across the 28×28 input
+    local pmin, pmax = math.huge, -math.huge
+    for j = 0, 783 do
+        local v = string.unpack("<f", bytes, 1 + j * 4)
+        if v < pmin then pmin = v end
+        if v > pmax then pmax = v end
+    end
+
+    -- Inference
+    local mid = slm.model_load_mnist()
+    if mid == nil or mid < 0 then
+        P(string.format("[%d] model_load_mnist failed (mid=%s)",
+                        idx, tostring(mid)))
+        cam:close()
+        return
+    end
+    local logits, argmax = slm.model_infer_bytes(mid, bytes)
+    if logits == nil then
+        P(string.format("[%d] infer failed", idx))
+        cam:close()
+        return
+    end
+
+    -- Top-1 margin = top - second-top. A clear winner has margin
+    -- > ~0.3; ambiguous predictions (close runners-up) read small.
+    local top, second = -math.huge, -math.huge
+    for j = 0, 9 do
+        local v = string.unpack("<f", logits, 1 + j * 4)
+        if v > top then
+            second = top
+            top = v
+        elseif v > second then
+            second = v
+        end
+    end
+    local margin = top - second
+
+    local mark = ""
+    if expected then
+        if argmax == expected then
+            mark = "  MATCH"
+        else
+            mark = string.format("  (expected %d)", expected)
+        end
+    end
+
+    P(string.format("[%d] A=%3d D=0x%04x E=%4d  px=[%.3f..%.3f] "
+                    .. "argmax=%d margin=%.3f%s",
+                    idx, analog, digital, exp_lines,
+                    pmin, pmax, argmax, margin, mark))
+
+    cam:close()
+end
+
+-- ------------------------------------------------------------------
+-- Run
+-- ------------------------------------------------------------------
+P("IMX219 gain/exposure sweep — " .. #grid .. " trials")
+if expected then
+    P(string.format("Expected digit: %d", expected))
+end
+P("")
+P("     A=analog gain  D=digital gain (fixed-point)  E=exposure lines")
+P("     px[min..max]   = preprocess-output pixel range (closer to [0,1]")
+P("                      = closer to MNIST's training distribution)")
+P("     margin         = top logit − second-top  (larger = more confident)")
+P("")
+
+-- Remember the operator's starting values so the sweep doesn't
+-- silently leave the sensor stuck on the last grid entry's setting.
+local start_a, start_d = slm.camera.imx219_get_gain()
+local start_e = slm.camera.imx219_get_exposure()
+
+for i, t in ipairs(grid) do
+    trial(i, t[1], t[2], t[3])
+end
+
+-- Restore the gain/exposure that were in effect before the sweep.
+slm.camera.imx219_set_gain(start_a, start_d)
+slm.camera.imx219_set_exposure(start_e)
+
+P("")
+P(string.format("Sweep complete. Gain/exposure restored to "
+                .. "(A=%d D=0x%04x E=%d).",
+                start_a, start_d, start_e))
+P("To apply a specific row from the REPL:")
+P("  slm.camera.imx219_set_gain(<analog>, <digital>)")
+P("  slm.camera.imx219_set_exposure(<lines>)")
+P("then run /mnt/files/camera_heatmap.lua to see the resulting image.")


### PR DESCRIPTION
## Summary

End-to-end IMX219 → MNIST classification on the Jetson Orin Nano J20 connector now produces meaningful argmax across multiple test digits instead of the previous \"always 5\". Three independent changes, all needed before any digit was correctly classified:

1. **Runtime-tunable gain + exposure** — operator can sweep ANALOG_GAIN/DIGITAL_GAIN/EXPOSURE from \`lua-admin\` between captures via \`slm.camera.imx219_set_{gain,exposure}\` instead of rebuilding the kernel.
2. **MNIST polarity invert** — IMX219 produces photographic-positive frames (paper bright, ink dark); MNIST trained on the inverse. New \`invert\` arg on \`camera_preprocess_mnist\` flips the per-pixel normalize at the integer numerator step.
3. **Center crop** — wide-angle IMX219 has 30-50% corner light fall-off that the Tegra ISP normally fixes via lens-shading correction; the ISP is unreachable from SLM-OS. New \`center_crop\` arg uses a 616×616 centered region (block 22) instead of the full 1232×1232 (block 44) to skirt the worst of the vignette.

Plus \`scripts/camera_sweep.lua\` — a 6-entry A×D matrix at fixed exposure that captures, preprocesses, infers, and prints argmax + top-1 margin per trial. Embedded at \`/mnt/files/camera_sweep.lua\`.

## Iteration history

Tested on jetson-nano-1 looking at hand-drawn digits on white paper:
- A=0/D=0x0100 → degenerate (always 5)
- A=192/D=0x0100 → degenerate (input pinned near saturation, always 4)
- A=224/D=0x0100 → model begins responding
- **A=232/D=0x0200** → meaningful discrimination on multiple digits (3, 4); ships as default

Still misclassifies some digits (e.g. 8) — residual vignette and stroke-thickness asymmetry. Flat-field calibration is the next investigation (separate branch).

## Test plan

- [x] \`make test\` (QEMU) passes — pinned mock-frame outputs preserved by passing \`invert=false, center_crop=false\` from existing test callers
- [ ] Hardware verification: \`lua-admin /mnt/files/camera_sweep.lua <expected-digit>\` on jetson-nano-1 shows MATCH for at least one row of the A×D grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)