### PR TITLE
ga10b: log shader_phys + shader_size in v7 per-op DBG dump

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2705,13 +2705,15 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
         const struct ga10b_pipeline_op_v7 *opdbg = &ops_v7[i];
         uart_printf("[GA10B-P8-v7-DBG]   op[%lu] shader_gpu_va=0x%lx "
                     "cbuf_gpu_va=0x%lx qmd_gpu_va=0x%lx output_phys=0x%lx "
-                    "reg_v=%lu\n",
+                    "reg_v=%lu shader_phys=0x%lx shader_size=%lu\n",
                     (unsigned long)i,
                     (unsigned long)opdbg->shader_gpu_va,
                     (unsigned long)opdbg->cbuf_gpu_va,
                     (unsigned long)opdbg->qmd_gpu_va,
                     (unsigned long)opdbg->output_phys,
-                    (unsigned long)opdbg->register_count_v);
+                    (unsigned long)opdbg->register_count_v,
+                    (unsigned long)opdbg->shader_phys,
+                    (unsigned long)opdbg->shader_size_bytes);
     }
 
     /* Phase 1: queue all N kernel-dispatch entries. */


### PR DESCRIPTION
## Summary

Adds `shader_phys` + `shader_size_bytes` to the existing `[GA10B-P8-v7-DBG]` per-op log line. Both fields are populated by the helper (per the v7.1 / #788 Mode B fix) and exist in the v7 op struct — they just weren't being printed.

## Why

Two diagnostic signals that previously required kernel patches every time:

- **`shader_size_bytes`** makes helper-tier selection visible at runtime:
  - 8192 bytes = page-rounded HMMA SASS (7552 B raw)
  - 4096 bytes = page-rounded SIMT FP32 SASS (3712 B raw)

  This lets an operator confirm `SLMOS_GEMM_TIER=hmma` actually took effect without disassembling shader bytes.

- **`shader_phys`** lets the operator `peek <phys+offset>` for byte-level shader verification against the on-disk `.sass` file — e.g., for the tensor-core-dispatch verification work this PR enabled.

## Context

Used in the #658 HMMA verification (2026-05-14): confirmed that `gpu use inference on` with `SLMOS_GEMM_TIER=hmma` actually loads `gemm_hmma_fp32a_fp16w_shader.sass` (HMMA WMMA path), not silently falling back to `gemm_fp32_shader.sass` (SIMT FP32). The only kernel patch needed was these 4 lines + a shell `peek`. Keeping the line in tree means the same investigation 6 months from now doesn't need a recompile.

## Test plan

- [x] Clean build (`make kernel PLATFORM=JETSON_ORIN_NANO`)
- [x] Deploy via `scripts/jetson-deploy-retry.sh` (3/5 attempts, normal kexec rate)
- [x] Verified the new fields appear in `[GA10B-P8-v7-DBG]` output for all 8 MNIST ops on hardware
- [x] Verified `shader_size = 8192` in HMMA mode, `4096` in SIMT mode (helper restarted with `SLMOS_GEMM_TIER=simt`)
- [x] Verified `peek shader_phys+0x400` returns the right bytes for each .sass file byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)