### PR TITLE
hailo-re-driver: make corpus loader/append order-agnostic

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
@@ -274,6 +274,11 @@ class Corpus:
     # dataclass would be dead weight here. Stored so callers that DO care
     # (e.g. inspection tools) can introspect without re-parsing the file.
     regions: list[dict] = field(default_factory=list)
+    # O(1) seq -> OpEntry index, kept in sync with `ops` by load and
+    # append_op. Avoids the O(N) linear scan find_op() used to do, which
+    # showed up in profiles once a single append_op started doing a
+    # uniqueness check on every captured seq.
+    _by_seq: dict[int, OpEntry] = field(default_factory=dict, repr=False)
 
     @property
     def next_seq(self) -> int:
@@ -290,10 +295,7 @@ class Corpus:
         return last
 
     def find_op(self, seq: int) -> Optional[OpEntry]:
-        for op in self.ops:
-            if op.seq == seq:
-                return op
-        return None
+        return self._by_seq.get(seq)
 
 
 def load(path: os.PathLike | str) -> Corpus:
@@ -354,7 +356,9 @@ def load(path: os.PathLike | str) -> Corpus:
     # Sort ops by seq so callers iterating Corpus.ops get them in order
     # regardless of file order. Uniqueness was checked above.
     ops.sort(key=lambda o: o.seq)
-    return Corpus(path=p, header=header, ops=ops, trailer=trailer, regions=regions)
+    by_seq = {op.seq: op for op in ops}
+    return Corpus(path=p, header=header, ops=ops, trailer=trailer,
+                  regions=regions, _by_seq=by_seq)
 
 
 def init(path: os.PathLike | str, header: Header) -> Corpus:
@@ -391,6 +395,7 @@ def append_op(corpus: Corpus, op: OpEntry) -> None:
         f.write("\n")
     # Keep corpus.ops sorted by seq so iteration order matches load order.
     bisect.insort(corpus.ops, op, key=lambda o: o.seq)
+    corpus._by_seq[op.seq] = op
 
 
 def append_trailer(corpus: Corpus, trailer: Trailer) -> None:

--- a/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/corpus.py
@@ -6,6 +6,7 @@ an optional trailer. The driver script (this package) is the single writer.
 
 from __future__ import annotations
 
+import bisect
 import contextlib
 import json
 import os
@@ -307,9 +308,9 @@ def load(path: os.PathLike | str) -> Corpus:
         raise CorpusError(f"{p}: header is not valid JSON: {e}") from e
     header = _validate_header(header_obj)
     ops: list[OpEntry] = []
+    op_line_by_seq: dict[int, int] = {}  # seq -> file line number, for diagnostics
     regions: list[dict] = []
     trailer: Optional[Trailer] = None
-    prev_seq = 0
     for i, raw in enumerate(lines[1:], start=2):
         try:
             obj = json.loads(raw)
@@ -318,20 +319,21 @@ def load(path: os.PathLike | str) -> Corpus:
         kind = obj.get("type")
         if kind == "op":
             op = _validate_op(obj)
-            # Op entries must be strictly increasing in seq, but NOT
-            # necessarily contiguous. Phase 4 region rules cover a
-            # contiguous BAR range with a single entry; the seq counter
-            # still ticks for every region-served access inside that
-            # range, so the next captured op naturally has a seq several
-            # hundred (or thousand) past the prior one. The +1 invariant
-            # held pre-Phase 4 only because every access generated an op.
-            if op.seq <= prev_seq:
+            # File order is unconstrained — the C-side QEMU stub appends
+            # at EOF in capture time order, which is monotonic within a
+            # single run but not necessarily across runs (e.g. when a
+            # later run captures a write at a seq the earlier run didn't
+            # reach, then a still-later run uncovers a hole at a smaller
+            # seq). The invariant we DO enforce: every seq appears at
+            # most once. Strict ordering is checked on the sorted view
+            # below.
+            if op.seq in op_line_by_seq:
                 raise CorpusError(
-                    f"{p}:{i}: seq went backwards {prev_seq} -> {op.seq} "
-                    "(must be strictly increasing)"
+                    f"{p}:{i}: duplicate seq={op.seq} "
+                    f"(first seen at line {op_line_by_seq[op.seq]})"
                 )
+            op_line_by_seq[op.seq] = i
             ops.append(op)
-            prev_seq = op.seq
         elif kind == "region":
             # Tolerance per docs/hailo-re-corpus-format.md §"Backward
             # compatibility": tools that don't author regions still load
@@ -349,6 +351,9 @@ def load(path: os.PathLike | str) -> Corpus:
             raise CorpusError(
                 f"{p}:{i}: trailer must be the final non-empty line"
             )
+    # Sort ops by seq so callers iterating Corpus.ops get them in order
+    # regardless of file order. Uniqueness was checked above.
+    ops.sort(key=lambda o: o.seq)
     return Corpus(path=p, header=header, ops=ops, trailer=trailer, regions=regions)
 
 
@@ -365,29 +370,27 @@ def init(path: os.PathLike | str, header: Header) -> Corpus:
 
 
 def append_op(corpus: Corpus, op: OpEntry) -> None:
-    """Append a new op, enforcing strict +1 seq.
+    """Append a new op, enforcing seq uniqueness.
 
-    Unlike ``load``, which accepts gaps (region-served accesses don't
-    produce op entries), this function is only ever called to record
-    the immediately-next captured read — the seq the QEMU stub halted
-    at, one past its own most-recent C-side auto-append. So +1 is the
-    right invariant here, and a non-+1 seq indicates a caller bug.
+    The seq just needs to be unique within the corpus; gaps and
+    out-of-file-order appends are both allowed. The file may end up
+    with op lines in non-seq order — ``load`` sorts on the way in.
     """
     if corpus.trailer is not None:
         raise CorpusError(
             f"{corpus.path}: cannot append after trailer is written"
         )
-    if op.seq != corpus.next_seq:
+    if corpus.find_op(op.seq) is not None:
         raise CorpusError(
-            f"{corpus.path}: appended seq={op.seq} but expected "
-            f"{corpus.next_seq}"
+            f"{corpus.path}: appended seq={op.seq} already exists in corpus"
         )
     # Validate the entry round-tripped through the same gate `load` uses.
     _validate_op(op.to_json_obj())
     with corpus.path.open("a", encoding="utf-8") as f, _exclusive(f):
         f.write(json.dumps(op.to_json_obj(), separators=(",", ":")))
         f.write("\n")
-    corpus.ops.append(op)
+    # Keep corpus.ops sorted by seq so iteration order matches load order.
+    bisect.insort(corpus.ops, op, key=lambda o: o.seq)
 
 
 def append_trailer(corpus: Corpus, trailer: Trailer) -> None:

--- a/host-tools/hailo-re-driver/tests/test_corpus.py
+++ b/host-tools/hailo-re-driver/tests/test_corpus.py
@@ -76,22 +76,37 @@ class CorpusRoundTripTests(unittest.TestCase):
 
 
 class CorpusValidationTests(unittest.TestCase):
-    def test_seq_must_start_at_one(self) -> None:
+    def test_seq_must_be_positive(self) -> None:
+        # seq >= 1 is a schema invariant (the stub's seq counter
+        # starts at 1). The +1-from-empty rule we used to have was
+        # dropped when out-of-order appends became legal — a corpus
+        # legitimately can have its first op at any seq if earlier
+        # seqs were region-served.
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "corpus.jsonl"
             corpus = corpus_mod.init(p, make_header())
             with self.assertRaises(CorpusError):
-                corpus_mod.append_op(corpus, make_write(2))
+                bad = OpEntry(
+                    seq=0, bar=4, offset=0, size=4, dir="write",
+                    value="00000000", source="qemu_capture",
+                    validated_at_commit=None, validated_at=None,
+                )
+                corpus_mod.append_op(corpus, bad)
 
-    def test_seq_must_be_monotonic(self) -> None:
+    def test_seq_must_be_unique(self) -> None:
+        # Append now allows gaps and out-of-order writes (the C-side
+        # QEMU stub appends in capture time order, which may not match
+        # seq order across runs); only duplicates are rejected.
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "corpus.jsonl"
             corpus = corpus_mod.init(p, make_header())
             corpus_mod.append_op(corpus, make_write(1))
-            with self.assertRaises(CorpusError):
-                corpus_mod.append_op(corpus, make_write(3))  # skipped 2
+            corpus_mod.append_op(corpus, make_write(3))  # gap is OK
+            corpus_mod.append_op(corpus, make_write(2))  # filling the gap is OK
             with self.assertRaises(CorpusError):
                 corpus_mod.append_op(corpus, make_write(1))  # duplicate
+            # ops stay sorted regardless of insertion order
+            self.assertEqual([o.seq for o in corpus.ops], [1, 2, 3])
 
     def test_value_length_must_match_size(self) -> None:
         bad = OpEntry(
@@ -134,17 +149,20 @@ class CorpusValidationTests(unittest.TestCase):
             self.assertEqual(corpus.ops[0].seq, 1)
             self.assertEqual(corpus.ops[1].seq, 100)
 
-    def test_load_rejects_seq_decrease(self) -> None:
-        # Strictly-increasing is still enforced — seqs that go backwards
-        # or repeat indicate file corruption / concurrent-writer bugs.
+    def test_load_accepts_unordered_file(self) -> None:
+        # File order is unconstrained — the C-side stub appends in
+        # capture-time order, which may not be seq order across runs.
+        # load() sorts internally; duplicate seqs are still rejected.
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "corpus.jsonl"
             with p.open("w") as f:
                 f.write(json.dumps(make_header().to_json_obj()) + "\n")
                 f.write(json.dumps(make_write(5).to_json_obj()) + "\n")
-                f.write(json.dumps(make_write(3).to_json_obj()) + "\n")  # backwards
-            with self.assertRaises(CorpusError):
-                corpus_mod.load(p)
+                f.write(json.dumps(make_write(3).to_json_obj()) + "\n")
+                f.write(json.dumps(make_write(7).to_json_obj()) + "\n")
+                f.write(json.dumps(make_write(1).to_json_obj()) + "\n")
+            corpus = corpus_mod.load(p)
+            self.assertEqual([o.seq for o in corpus.ops], [1, 3, 5, 7])
 
     def test_load_rejects_seq_duplicate(self) -> None:
         with tempfile.TemporaryDirectory() as d:

--- a/host-tools/hailo-re-driver/tests/test_corpus.py
+++ b/host-tools/hailo-re-driver/tests/test_corpus.py
@@ -108,6 +108,33 @@ class CorpusValidationTests(unittest.TestCase):
             # ops stay sorted regardless of insertion order
             self.assertEqual([o.seq for o in corpus.ops], [1, 2, 3])
 
+    def test_append_op_writes_at_eof_in_call_order(self) -> None:
+        # Lock in the on-disk semantics: append_op always writes at the
+        # end of the file, in the order it's called. The in-memory
+        # Corpus.ops list is kept sorted by seq, but the file is NOT —
+        # load() handles unsorted files. This is load-bearing because
+        # the C-side QEMU stub does the same EOF-append; co-mingling
+        # disagreeing on-disk orderings would corrupt the corpus.
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "corpus.jsonl"
+            corpus = corpus_mod.init(p, make_header())
+            corpus_mod.append_op(corpus, make_write(5))
+            corpus_mod.append_op(corpus, make_write(3))
+            corpus_mod.append_op(corpus, make_write(7))
+            # Raw on-disk order should be header, 5, 3, 7.
+            with p.open() as f:
+                disk_seqs = []
+                for line in f:
+                    obj = json.loads(line)
+                    if obj.get("type") == "op":
+                        disk_seqs.append(obj["seq"])
+            self.assertEqual(disk_seqs, [5, 3, 7])
+            # But Corpus.ops is sorted.
+            self.assertEqual([o.seq for o in corpus.ops], [3, 5, 7])
+            # And a fresh load sorts the unsorted file.
+            reloaded = corpus_mod.load(p)
+            self.assertEqual([o.seq for o in reloaded.ops], [3, 5, 7])
+
     def test_value_length_must_match_size(self) -> None:
         bad = OpEntry(
             seq=1, bar=4, offset=0, size=4, dir="write",


### PR DESCRIPTION
## Summary

Follow-up to #824. The Python loader enforced "file order == seq order" via a `prev_seq` tracker. That invariant was always implicit but brittle: the C-side QEMU stub auto-appends unknown writes at EOF in capture-time order, which is monotonic within a single run but **not** necessarily across runs.

**Concrete failure mode** (encountered during #795 Phase 2 grind tonight): a region-bulk-install run captured BAR0 control ops up to seq=51812. After dropping the speculative pass-26+ regions, the next grind run encountered seq=51510 (previously region-served, now uncovered) and auto-appended it at EOF — placing seq=51510 in the file *after* seq=51812. Reload then fails with `seq went backwards`. The same issue would have recurred on every future capture of a write in the no-region zone.

## Fix

- **`corpus.load`**: detect duplicate seqs during the scan (precise diagnostic with both line numbers), then sort `Corpus.ops` by seq before returning. File order is now unconstrained; the only seq invariant is uniqueness.
- **`corpus.append_op`**: replace the strict-`+1` `next_seq` check with a uniqueness check via `find_op`. Use `bisect.insort` to keep `Corpus.ops` sorted across appends.
- **Tests**: 
  - `test_seq_must_be_monotonic` → `test_seq_must_be_unique` (covers gap, out-of-order fill, duplicate rejection, sorted invariant)
  - `test_load_rejects_seq_decrease` → `test_load_accepts_unordered_file` (positive assertion on sorted output)
  - `test_seq_must_start_at_one` → `test_seq_must_be_positive` (the +1-from-empty rule is gone; only `seq >= 1` schema invariant remains)

15/15 tests pass. Verified the actually-broken corpus from tonight's grind loads cleanly under the new loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)