### PR TITLE
hailo-re-driver: accept gap-fill EXTENDs at seq < corpus.next_seq

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -176,12 +176,18 @@ def _extend_corpus(
     slmos: SlmosRunner,
     cfg: LoopConfig,
 ) -> "_StepOutcome":
-    if request.seq != corpus.next_seq:
+    # The QEMU stub may halt on EXTEND at any seq that isn't already
+    # covered by the corpus — that's typically max_seq+1, but with
+    # Phase 4 region rules (#824) plus order-agnostic appends (#829),
+    # a region drop or per-seq grind can leave gaps in the captured
+    # ops, and a subsequent run halts on the LOWEST uncovered seq.
+    # The only invariant we need is: this seq isn't already captured.
+    if corpus.find_op(request.seq) is not None:
         return _StepOutcome(
             status="error",
             detail=(
-                f"EXTEND seq={request.seq} but corpus next_seq="
-                f"{corpus.next_seq} — corpus and stub disagree"
+                f"EXTEND seq={request.seq} but corpus already has an "
+                f"entry at that seq — stub and corpus disagree"
             ),
         )
 

--- a/host-tools/hailo-re-driver/tests/test_loop_mocked.py
+++ b/host-tools/hailo-re-driver/tests/test_loop_mocked.py
@@ -278,6 +278,116 @@ class StubAppendDuringRunTests(unittest.TestCase):
             self.assertEqual(reloaded.ops[-1].seq, 8)
             self.assertEqual(reloaded.ops[-1].value, "42424242")
 
+    def test_extend_accepts_gap_fill_below_max_seq(self) -> None:
+        """When the corpus has gaps (e.g. a region was dropped, exposing
+        previously-region-served seqs), the QEMU stub halts on the LOWEST
+        uncovered seq, which may be below corpus.next_seq. The loop must
+        accept that EXTEND, not bail with 'corpus and stub disagree'.
+        """
+        from hailo_re_driver.line_protocols import ExtendRequest
+        from hailo_re_driver.qemu_runner import ExtendEvent
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = Path(d) / "c.jsonl"
+            corpus_mod.init(corpus_path, self._header())
+            c = corpus_mod.load(corpus_path)
+            # Seed corpus with seqs 1, 2, 3, 5, 6, 7 — gap at seq=4.
+            # next_seq is 8, but the stub will EXTEND at the gap (seq=4).
+            for s in (1, 2, 3, 5, 6, 7):
+                corpus_mod.append_op(c, OpEntry(
+                    seq=s, bar=4, offset=0x100 + s, size=4, dir="read",
+                    value="00000000", source="slmos_observed",
+                    validated_at_commit=self.SHA,
+                    validated_at="2026-05-12T19:00:00Z",
+                ))
+
+            class _GapExtendRunner:
+                def __init__(self):
+                    self.calls = 0
+
+                def run(self, path: Path):
+                    self.calls += 1
+                    if self.calls == 1:
+                        return ExtendEvent(
+                            kind="extend",
+                            request=ExtendRequest(
+                                seq=4, bar=4, offset=0x104, size=4,
+                                reason="unknown_read",
+                            ),
+                            raw_line=(
+                                "HAILO_RE_CORPUS_EXTEND seq=4 bar=4 "
+                                "offset=260 size=4 reason=unknown_read"
+                            ),
+                        )
+                    return ConfigureCompleteEvent()
+
+            slmos = _ScriptedSlmosRunner([
+                ExtendResponse(seq=4, bar=4, offset=0x104, size=4,
+                               value="cafef00d", slmos_sha=self.SHA),
+            ])
+
+            outcome = loop_mod.run_loop(
+                corpus_path,
+                _GapExtendRunner(),  # type: ignore[arg-type]
+                slmos,  # type: ignore[arg-type]
+                loop_mod.LoopConfig(
+                    max_iterations=5,
+                    reachable=lambda _sha: True,
+                ),
+            )
+            self.assertEqual(
+                outcome.status, "complete",
+                f"gap-fill EXTEND must be accepted; got status="
+                f"{outcome.status} detail={outcome.detail}",
+            )
+            reloaded = corpus_mod.load(corpus_path)
+            filled = reloaded.find_op(4)
+            self.assertIsNotNone(filled)
+            self.assertEqual(filled.value, "cafef00d")
+
+    def test_extend_rejects_already_captured_seq(self) -> None:
+        """If the stub somehow EXTENDs at a seq the corpus already has
+        a captured entry for, that's a real disagreement — bail loud.
+        """
+        from hailo_re_driver.line_protocols import ExtendRequest
+        from hailo_re_driver.qemu_runner import ExtendEvent
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = Path(d) / "c.jsonl"
+            corpus_mod.init(corpus_path, self._header())
+            c = corpus_mod.load(corpus_path)
+            corpus_mod.append_op(c, OpEntry(
+                seq=5, bar=4, offset=0x100, size=4, dir="read",
+                value="00000000", source="slmos_observed",
+                validated_at_commit=self.SHA,
+                validated_at="2026-05-12T19:00:00Z",
+            ))
+
+            class _DuplicateExtendRunner:
+                def run(self, path: Path):
+                    return ExtendEvent(
+                        kind="extend",
+                        request=ExtendRequest(
+                            seq=5, bar=4, offset=0x100, size=4,
+                            reason="unknown_read",
+                        ),
+                        raw_line=("HAILO_RE_CORPUS_EXTEND seq=5 ..."),
+                    )
+
+            slmos = _ScriptedSlmosRunner([])
+
+            outcome = loop_mod.run_loop(
+                corpus_path,
+                _DuplicateExtendRunner(),  # type: ignore[arg-type]
+                slmos,  # type: ignore[arg-type]
+                loop_mod.LoopConfig(
+                    max_iterations=2,
+                    reachable=lambda _sha: True,
+                ),
+            )
+            self.assertEqual(outcome.status, "error")
+            self.assertIn("already has an entry", outcome.detail or "")
+
 
 class WritePendingCorpusCleanupTests(unittest.TestCase):
     """Regression coverage for the resource-cleanup contract on

--- a/host-tools/hailo-re-driver/tests/test_loop_mocked.py
+++ b/host-tools/hailo-re-driver/tests/test_loop_mocked.py
@@ -364,7 +364,18 @@ class StubAppendDuringRunTests(unittest.TestCase):
             ))
 
             class _DuplicateExtendRunner:
+                def __init__(self):
+                    self.calls = 0
+
                 def run(self, path: Path):
+                    self.calls += 1
+                    # Loop should bail with status=error on the first
+                    # call's response; the counter guards against silent
+                    # infinite loops if that early-out ever regresses.
+                    assert self.calls == 1, (
+                        "loop should error out before re-invoking the "
+                        "runner on a duplicate-seq EXTEND"
+                    )
                     return ExtendEvent(
                         kind="extend",
                         request=ExtendRequest(


### PR DESCRIPTION
## Summary

Follow-up to #829. That PR made the corpus loader order-agnostic, but missed the parallel assumption in \`loop._extend_corpus\`, which still required \`request.seq == corpus.next_seq\` (= max_seq + 1).

With gaps in the captured ops (e.g., dropping a region exposes previously-region-served seqs, or a bulk-grind run terminates early), the QEMU stub legitimately halts on the **lowest uncovered seq** — which can be far below \`corpus.next_seq\`. The driver was bailing with "corpus and stub disagree" on every such EXTEND.

**Fix:** replace the strict-+1 check with a uniqueness check via \`find_op\`. Any seq not already captured is accepted; duplicates still error (rare, indicates real disagreement).

Surfaced tonight when the grind resumed after #829 landed, encountered seq=51511 (a previously-region-served BAR0 read in the gap between captured BAR0 control ops at 51500-51509 and 51803-51812), and bailed.

## Test plan

- [x] \`test_extend_accepts_gap_fill_below_max_seq\` — seed corpus with seqs {1,2,3,5,6,7}, stub EXTENDs at seq=4, loop accepts and captures
- [x] \`test_extend_rejects_already_captured_seq\` — stub EXTENDs at a seq already in corpus, loop bails with the new error message
- [x] \`test_extend_seq_matches_post_run_next_seq\` (pre-existing) still passes — the original post-run + reload + new-seq scenario remains supported
- [x] 23/23 driver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)