### PR TITLE
hailo-re: kernel corpus parser — order-agnostic, like the Python loader

### DIFF
--- a/kernel/ai_accel/hailo/hailo_re_corpus.c
+++ b/kernel/ai_accel/hailo/hailo_re_corpus.c
@@ -206,7 +206,7 @@ static int parse_header_line(const char *line, size_t len,
 }
 
 static int parse_op_line(const char *line, size_t len,
-                         struct hailo_re_corpus *c, uint32_t *last_seq)
+                         struct hailo_re_corpus *c)
 {
     if (c->op_count >= c->op_capacity) {
         return HAILO_RE_CORPUS_E_OVERFLOW;
@@ -222,9 +222,11 @@ static int parse_op_line(const char *line, size_t len,
         return HAILO_RE_CORPUS_E_BAD_FIELD;
     }
     op.seq = (uint32_t)seq;
-    if (c->op_count > 0 && op.seq <= *last_seq) {
-        return HAILO_RE_CORPUS_E_NONMONOTONIC;
-    }
+    /* File order is unconstrained — the QEMU stub auto-appends writes
+     * at EOF in capture time order, which is monotonic within one run
+     * but not necessarily across runs. The post-parse pass sorts the
+     * ops array and rejects duplicates. See PR #829 for the matching
+     * fix on the host-side Python loader. */
 
     v = find_value_after_key(line, len, "bar");
     if (!v) return HAILO_RE_CORPUS_E_BAD_FIELD;
@@ -283,7 +285,31 @@ static int parse_op_line(const char *line, size_t len,
     }
 
     c->ops[c->op_count++] = op;
-    *last_seq = op.seq;
+    return HAILO_RE_CORPUS_OK;
+}
+
+/* Insertion sort the ops array by seq, then detect duplicates in one
+ * pass. Insertion sort is fine here: typical corpora have N≈2k ops and
+ * most are already in seq order (the C-side QEMU stub appends each run
+ * monotonically; only cross-run gap-fills land out of place). Worst
+ * case is O(N²) but practical workload is O(N + K) where K is the
+ * count of out-of-order entries. Returns OK or E_DUPLICATE. */
+static int sort_ops_and_check_unique(struct hailo_re_corpus *c)
+{
+    for (uint32_t i = 1; i < c->op_count; i++) {
+        struct hailo_re_op key = c->ops[i];
+        uint32_t j = i;
+        while (j > 0 && c->ops[j - 1].seq > key.seq) {
+            c->ops[j] = c->ops[j - 1];
+            j--;
+        }
+        c->ops[j] = key;
+    }
+    for (uint32_t i = 1; i < c->op_count; i++) {
+        if (c->ops[i].seq == c->ops[i - 1].seq) {
+            return HAILO_RE_CORPUS_E_DUPLICATE;
+        }
+    }
     return HAILO_RE_CORPUS_OK;
 }
 
@@ -304,7 +330,6 @@ int hailo_re_corpus_parse(const char *text, size_t len,
     c->has_trailer = false;
     c->skipped_unknown = 0;
 
-    uint32_t last_seq = 0;
     bool saw_first_nonempty = false;
     const char *p = text;
     const char *end = text + len;
@@ -345,7 +370,7 @@ int hailo_re_corpus_parse(const char *text, size_t len,
             int hrc = parse_header_line(line, line_len, c);
             if (hrc != HAILO_RE_CORPUS_OK) return hrc;
         } else if (strcmp(type_buf, "op") == 0) {
-            int orc = parse_op_line(line, line_len, c, &last_seq);
+            int orc = parse_op_line(line, line_len, c);
             if (orc != HAILO_RE_CORPUS_OK) return orc;
         } else if (strcmp(type_buf, "trailer") == 0) {
             c->has_trailer = true;
@@ -357,6 +382,10 @@ int hailo_re_corpus_parse(const char *text, size_t len,
     }
 
     if (!c->has_header) return HAILO_RE_CORPUS_E_NO_HEADER;
+    /* Post-parse: sort by seq so the binary search in
+     * hailo_re_corpus_find_seq stays correct, and reject duplicates. */
+    int src = sort_ops_and_check_unique(c);
+    if (src != HAILO_RE_CORPUS_OK) return src;
     return HAILO_RE_CORPUS_OK;
 }
 

--- a/kernel/ai_accel/hailo/hailo_re_corpus.h
+++ b/kernel/ai_accel/hailo/hailo_re_corpus.h
@@ -57,12 +57,12 @@ struct hailo_re_op {
 };
 
 enum hailo_re_corpus_error {
-    HAILO_RE_CORPUS_OK            =  0,
-    HAILO_RE_CORPUS_E_PARSE       = -1,   /* malformed JSON line shape */
-    HAILO_RE_CORPUS_E_NO_HEADER   = -2,   /* line 1 missing/wrong type */
-    HAILO_RE_CORPUS_E_NONMONOTONIC = -3,  /* seq did not strictly increase */
-    HAILO_RE_CORPUS_E_OVERFLOW    = -4,   /* op_capacity exhausted */
-    HAILO_RE_CORPUS_E_BAD_FIELD   = -5,   /* required field missing or bad value */
+    HAILO_RE_CORPUS_OK             =  0,
+    HAILO_RE_CORPUS_E_PARSE        = -1,   /* malformed JSON line shape */
+    HAILO_RE_CORPUS_E_NO_HEADER    = -2,   /* line 1 missing/wrong type */
+    HAILO_RE_CORPUS_E_DUPLICATE    = -3,   /* same seq appeared twice */
+    HAILO_RE_CORPUS_E_OVERFLOW     = -4,   /* op_capacity exhausted */
+    HAILO_RE_CORPUS_E_BAD_FIELD    = -5,   /* required field missing or bad value */
 };
 
 /* Parsed corpus state. The op buffer is caller-owned (typically a

--- a/kernel/tests/test_hailo_replay.c
+++ b/kernel/tests/test_hailo_replay.c
@@ -193,7 +193,7 @@ static void test_parse_op_read_validated_sha(void)
     TEST_ASSERT_EQUAL_UINT8(1u, c.ops[0].validated);
 }
 
-static void test_parse_rejects_nonmonotonic(void)
+static void test_parse_rejects_duplicate_seq(void)
 {
     struct hailo_re_op ops[8];
     struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
@@ -204,9 +204,46 @@ static void test_parse_rejects_nonmonotonic(void)
         "{\"type\":\"op\",\"seq\":2,\"bar\":4,\"offset\":4,\"size\":4,"
         "\"dir\":\"write\",\"value\":\"02000000\"}\n";
     int rc = hailo_re_corpus_parse(text, strlen(text), &c);
-    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_E_NONMONOTONIC, rc);
-    /* op_count should reflect what was parsed before the failure (1). */
-    TEST_ASSERT_EQUAL_UINT32(1u, c.op_count);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_E_DUPLICATE, rc);
+    /* Both ops were stored before the post-parse uniqueness check
+     * caught the duplicate; op_count reflects all parsed entries. */
+    TEST_ASSERT_EQUAL_UINT32(2u, c.op_count);
+}
+
+static void test_parse_accepts_unordered_ops(void)
+{
+    /* The QEMU stub's C-side appends are monotonic within one run but
+     * NOT necessarily across runs (a later run can fill a gap left by
+     * an earlier run with a smaller seq). The kernel parser must sort
+     * the ops array after parsing so the find_seq binary search
+     * downstream keeps working. */
+    struct hailo_re_op ops[8];
+    struct hailo_re_corpus c = { .ops = ops, .op_capacity = 8 };
+    const char *text =
+        "{\"type\":\"header\",\"format_version\":1}\n"
+        "{\"type\":\"op\",\"seq\":5,\"bar\":4,\"offset\":0,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"05000000\"}\n"
+        "{\"type\":\"op\",\"seq\":3,\"bar\":4,\"offset\":4,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"03000000\"}\n"
+        "{\"type\":\"op\",\"seq\":7,\"bar\":4,\"offset\":8,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"07000000\"}\n"
+        "{\"type\":\"op\",\"seq\":1,\"bar\":4,\"offset\":12,\"size\":4,"
+        "\"dir\":\"write\",\"value\":\"01000000\"}\n";
+    int rc = hailo_re_corpus_parse(text, strlen(text), &c);
+    TEST_ASSERT_EQUAL_INT(HAILO_RE_CORPUS_OK, rc);
+    TEST_ASSERT_EQUAL_UINT32(4u, c.op_count);
+    /* After sort: 1, 3, 5, 7. */
+    TEST_ASSERT_EQUAL_UINT32(1u, c.ops[0].seq);
+    TEST_ASSERT_EQUAL_UINT32(3u, c.ops[1].seq);
+    TEST_ASSERT_EQUAL_UINT32(5u, c.ops[2].seq);
+    TEST_ASSERT_EQUAL_UINT32(7u, c.ops[3].seq);
+    /* Binary search on the sorted array must find each seq. */
+    TEST_ASSERT_TRUE(hailo_re_corpus_find_seq(&c, 1) != NULL);
+    TEST_ASSERT_TRUE(hailo_re_corpus_find_seq(&c, 5) != NULL);
+    TEST_ASSERT_TRUE(hailo_re_corpus_find_seq(&c, 7) != NULL);
+    /* And gaps are not found. */
+    TEST_ASSERT_TRUE(hailo_re_corpus_find_seq(&c, 2) == NULL);
+    TEST_ASSERT_TRUE(hailo_re_corpus_find_seq(&c, 6) == NULL);
 }
 
 static void test_parse_tolerates_unknown_type(void)
@@ -428,7 +465,8 @@ int test_suite_hailo_replay(void)
     RUN_TEST(test_parse_op_read_marks_unvalidated);
     RUN_TEST(test_parse_validated_at_commit_string_not_misread_as_null);
     RUN_TEST(test_parse_op_read_validated_sha);
-    RUN_TEST(test_parse_rejects_nonmonotonic);
+    RUN_TEST(test_parse_rejects_duplicate_seq);
+    RUN_TEST(test_parse_accepts_unordered_ops);
     RUN_TEST(test_parse_tolerates_unknown_type);
     RUN_TEST(test_parse_tolerates_trailer);
     RUN_TEST(test_parse_note_with_embedded_keylike_string);


### PR DESCRIPTION
## Summary

After #829 (Python loader) and #830 (driver EXTEND handler) made the host side order-agnostic, a Phase 2 grind iteration that re-flashed an unsorted corpus to pi-5-1 surfaced the parallel bug in the SLM-OS kernel parser:

\`\`\`
hailo: replay-step: corpus parse failed (rc=-3, ops_parsed=2056)
\`\`\`

\`parse_op_line\` enforced \`op.seq > last_seq\` strictly within file order. The QEMU stub's C-side \`hailo_corpus_append_write\` appends at EOF in capture-time order — monotonic within one run, **not** necessarily across runs (a later run can fill a gap left by an earlier one with a smaller seq, e.g. when a Phase 4 region is dropped and previously-region-served seqs become per-seq captures).

## Fix

- Drop the in-line monotonic check in \`parse_op_line\`; parse all ops into the buffer regardless of file order.
- Add \`sort_ops_and_check_unique\`: insertion-sort by seq (O(N+K) for K out-of-place entries; practical corpora have K ≪ N) followed by a single adjacent-duplicate scan. Returns \`OK\` or \`E_DUPLICATE\`.
- Rename \`HAILO_RE_CORPUS_E_NONMONOTONIC\` (rc=-3) → \`HAILO_RE_CORPUS_E_DUPLICATE\`. Same numeric value; the new name describes what we actually reject now.
- \`hailo_re_corpus_find_seq\`'s binary search is still correct — the array is sorted after parse, just not by file-arrival order.

## Test plan

- [x] \`test_parse_rejects_duplicate_seq\` (renamed from \`_nonmonotonic\`) — duplicate seq=2 rejected with new enum; both ops stored before sort-check, so \`op_count == 2\` now.
- [x] \`test_parse_accepts_unordered_ops\` (new) — seqs 5,3,7,1 in file order → sorted to [1,3,5,7] → binary search finds each, gaps return NULL.
- [x] \`make kernel\` (ARM64 QEMU): clean.
- [x] \`make test\`: PASS.
- [ ] Follow-up: re-flash to pi-5-1 and confirm the running grind picks up at seq=51511 (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)