### PR TITLE
oplib: self-allocated 256 KB pool + 4 KB cbuf (#832 fix, option B)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -950,6 +950,63 @@ int ga10b_gmmu_alloc(uint64_t inst_block_phys,
     return 0;
 }
 
+int ga10b_gmmu_map(uint64_t inst_block_phys,
+                   uint64_t target_phys,
+                   uint32_t n_pages,
+                   uint32_t flags,
+                   uint64_t *out_gpu_va_base)
+{
+    if (out_gpu_va_base == NULL) return -1;
+    if (n_pages == 0 || n_pages > GA10B_GMMU_MAX_ALLOC_PAGES) {
+        return -1;
+    }
+    /* target_phys must be 4 KB-aligned — the GMMU's smallest PTE
+     * granularity. A non-aligned base would cause every per-page
+     * PTE write to be off by some fraction of a page, which the
+     * GPU would happily fetch from before silently producing
+     * garbage. */
+    if ((target_phys & 4095ull) != 0u) return -1;
+
+    uint64_t pdb_phys = read_pdb_phys(inst_block_phys);
+    if (pdb_phys == 0) return -1;
+
+    /* Reserve a contiguous GPU VA range — same shape as
+     * ga10b_gmmu_alloc, but skip the per-page PMM allocation step
+     * because the caller already owns the physical buffer. */
+    uint64_t va_span = (uint64_t)n_pages * 4096ull;
+    uint64_t va_base = pop_free_extent(n_pages);
+    if (va_base == 0) {
+        if (g_va_cursor + va_span > GA10B_GMMU_VA_LIMIT) {
+            return -1;
+        }
+        va_base = g_va_cursor;
+        g_va_cursor += va_span;
+    }
+
+    /* Per page: emit a PTE pointing at the caller's contiguous
+     * physical buffer. Since target_phys is contiguous, page i's
+     * physical address is just target_phys + i*4096 — no walking
+     * needed. */
+    for (uint32_t i = 0; i < n_pages; i++) {
+        uint64_t va_i   = va_base   + (uint64_t)i * 4096ull;
+        uint64_t phys_i = target_phys + (uint64_t)i * 4096ull;
+        if (map_one_page(pdb_phys, va_i, phys_i, flags) < 0) {
+            /* PT-page allocation can fail mid-walk. We have no
+             * rollback for the PTEs already written (same gap as
+             * ga10b_gmmu_alloc; #825 tracks). Caller treats it
+             * as fatal. */
+            return -1;
+        }
+    }
+
+    /* Single dsb sy at the end — amortizes across all N pages,
+     * matches ga10b_gmmu_alloc's pattern. */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    *out_gpu_va_base = va_base;
+    return 0;
+}
+
 int ga10b_gmmu_free(uint64_t inst_block_phys,
                     uint64_t gpu_va,
                     uint32_t n_pages)

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -283,6 +283,32 @@ int ga10b_gmmu_alloc(uint64_t inst_block_phys,
                      void    **out_first_cpu_va,
                      uint64_t *out_first_phys);
 
+/* Map an EXISTING contiguous physical buffer into the channel's
+ * GMMU at a fresh GPU VA. Mirrors `ga10b_gmmu_alloc` but skips the
+ * per-page PMM allocation step — caller already owns the buffer.
+ *
+ * `target_phys` must be 4 KB-aligned and refer to `n_pages`
+ * contiguous physical pages (i.e. typically the return of
+ * `pmm_alloc_pages(n_pages)`). `flags` is forwarded to
+ * `map_one_page` (GA10B_GMMU_FLAG_RO / etc.). Output GPU VA is
+ * page-aligned and covers `[gpu_va, gpu_va + n_pages*4096)`.
+ *
+ * Returns 0 on success or -1 on any failure (bad args, VA range
+ * exhausted, PT-page alloc failed mid-walk). Same partial-failure
+ * semantics as `ga10b_gmmu_alloc`: if any per-page PTE write
+ * fails, the previously-written PTEs stay in place — no rollback.
+ *
+ * Used by `oplib_pool_stage_to_gpu`'s slow path (#832) to map a
+ * SLM-OS-allocated 256 KB scratch region into the inherited
+ * channel when the helper's v6/v7 handoff publish zeros the v4
+ * single-shader fields.
+ */
+int ga10b_gmmu_map(uint64_t inst_block_phys,
+                   uint64_t target_phys,
+                   uint32_t n_pages,
+                   uint32_t flags,
+                   uint64_t *out_gpu_va_base);
+
 /* Free N contiguous pages previously returned by `ga10b_gmmu_alloc`
  * (or `ga10b_gmmu_alloc_page` with n_pages=1). Per page:
  *   - Walk the existing leaf PTE.

--- a/kernel/gpu/oplib_dispatch.c
+++ b/kernel/gpu/oplib_dispatch.c
@@ -120,11 +120,33 @@ int slm_oplib_prepare_dispatch(uint64_t inst_block_phys,
             cbuf_phys = hp->cbuf_phys;
             cbuf_cpu = (void *)(uintptr_t)hp->cbuf_phys;
         } else {
-            rc = ga10b_gmmu_alloc(inst_block_phys, 1u, 0u,
-                                  &cbuf_va, &cbuf_cpu, &cbuf_phys);
-            if (rc < 0) {
-                uart_printf("[oplib-dispatch] cbuf alloc failed: rc=%d\n", rc);
-                return -1;
+            /* #832 path: fall back to `oplib_pool`'s pre-allocated
+             * cbuf — populated during `oplib_pool_stage_to_gpu` (so
+             * `nvgpu oplib stage` must have run first). Avoids the
+             * old per-dispatch `ga10b_gmmu_alloc` slow path which
+             * (a) leaks a page per dispatch and (b) is unreliable
+             * post-kexec because the W-series FFI passes
+             * inst_block_phys=0 anyway. */
+            uint64_t pool_cbuf_va  = oplib_pool_cbuf_gpu_va();
+            uint64_t pool_cbuf_phys = oplib_pool_cbuf_phys();
+            if (pool_cbuf_va != 0 && pool_cbuf_phys != 0) {
+                cbuf_va   = pool_cbuf_va;
+                cbuf_phys = pool_cbuf_phys;
+                cbuf_cpu  = (void *)(uintptr_t)pool_cbuf_phys;
+            } else {
+                /* Last-resort slow path: ga10b_gmmu_alloc. Requires a
+                 * valid inst_block_phys, which the W-series FFI
+                 * doesn't pass today — kept for diag verbs that
+                 * supply one. */
+                rc = ga10b_gmmu_alloc(inst_block_phys, 1u, 0u,
+                                      &cbuf_va, &cbuf_cpu, &cbuf_phys);
+                if (rc < 0) {
+                    uart_printf("[oplib-dispatch] cbuf alloc failed: "
+                                "rc=%d (no helper cbuf, no oplib_pool "
+                                "cbuf, inst_block_phys=0x%lx)\n",
+                                rc, (unsigned long)inst_block_phys);
+                    return -1;
+                }
             }
         }
     }

--- a/kernel/gpu/oplib_pool.c
+++ b/kernel/gpu/oplib_pool.c
@@ -18,6 +18,7 @@
 
 #if defined(PLATFORM_JETSON_ORIN_NANO)
 #include "../include/cache.h"
+#include "../include/pmm.h"  /* pmm_alloc_pages / pmm_free_pages */
 #include "nvidia/ga10b_gmmu.h"
 #include "nvidia/ga10b_bringup.h"          /* ga10b_bringup_handoff */
 #include "nvidia/ga10b_channel_handoff.h"  /* struct ga10b_channel_handoff */
@@ -44,6 +45,25 @@ static bool g_staged;
 static int g_stage_rc = OPERATOR_LIBRARY_ERR_NULL;
 static uint64_t g_sass_pool_gpu_va;
 static size_t g_sass_pool_n_pages;
+
+/* #832: physical base of the pool — i.e. the CPU phys at slot 0
+ * (SASS). Required by the W-series dispatch FFI for per-call
+ * scratch-slot CPU↔GPU memcpys when the helper handoff doesn't
+ * expose `h->shader_phys` (post-v6/v7 publish paths zero those
+ * fields). Set in both fast path (from `h->shader_phys`) and slow
+ * path (from `pmm_alloc_pages` return). Stays 0 if neither path
+ * yields a contiguous-phys-mappable buffer. */
+static uint64_t g_sass_pool_base_phys;
+
+/* #832: cbuf is a separate 4 KB page in the channel's GMMU,
+ * populated per-dispatch by `slm_oplib_prepare_dispatch` with the
+ * shader's cbuf[0] argument layout. Set by `oplib_pool_stage_to_gpu`
+ * — fast path takes `h->cbuf_*`, slow path allocates a fresh PMM
+ * page and maps it. Same v6/v7-publish-zeros story as shader_*; the
+ * helper-published `h->cbuf_*` is the original design but isn't
+ * populated by the current MNIST helper. */
+static uint64_t g_cbuf_phys;
+static uint64_t g_cbuf_gpu_va;
 
 size_t oplib_pool_blob_size(void)
 {
@@ -153,7 +173,81 @@ uint64_t oplib_pool_gpu_va_base(void)
     return g_sass_pool_gpu_va;
 }
 
+uint64_t oplib_pool_base_phys(void)
+{
+    return g_sass_pool_base_phys;
+}
+
+uint64_t oplib_pool_cbuf_phys(void)
+{
+    return g_cbuf_phys;
+}
+
+uint64_t oplib_pool_cbuf_gpu_va(void)
+{
+    return g_cbuf_gpu_va;
+}
+
 #if defined(PLATFORM_JETSON_ORIN_NANO)
+
+/* #832: ensure a cbuf page is mapped into the channel's GMMU and
+ * recorded in g_cbuf_phys / g_cbuf_gpu_va. Called by both fast and
+ * slow paths of `oplib_pool_stage_to_gpu` after SASS staging — the
+ * helper may have published cbuf_* (h->cbuf_*) but the current
+ * MNIST helper's v6/v7 paths zero those fields, so we fall back to
+ * a SLM-OS-allocated 4 KB page.
+ *
+ * Idempotent: if g_cbuf_phys is already non-zero (set earlier by
+ * the fast path's helper-cbuf check), returns 0 without allocating.
+ *
+ * Returns 0 on success or a negative error. On error, the caller
+ * still treats SASS staging as successful — cbuf failure makes the
+ * W-series dispatch FFI return -1 (CPU fallback) but doesn't
+ * invalidate the SASS pool itself. */
+static int stage_cbuf(uint64_t inst_block_phys)
+{
+    if (g_cbuf_phys != 0 && g_cbuf_gpu_va != 0) {
+        return 0;  /* helper-published path; nothing to do */
+    }
+
+    void *cbuf_cpu = pmm_alloc_pages(1u);
+    if (cbuf_cpu == NULL) {
+        uart_puts("[oplib] stage_cbuf: pmm_alloc_pages(1) failed — "
+                  "W-series dispatches will fall back to CPU\n");
+        return -1;
+    }
+    uint64_t cbuf_phys = (uint64_t)(uintptr_t)cbuf_cpu;
+
+    uint64_t cbuf_gva = 0;
+    int rc = ga10b_gmmu_map(inst_block_phys, cbuf_phys, 1u, 0u, &cbuf_gva);
+    if (rc < 0) {
+        pmm_free_pages(cbuf_cpu, 1u);
+        uart_printf("[oplib] stage_cbuf: ga10b_gmmu_map(phys=0x%llx) "
+                    "failed rc=%d\n",
+                    (unsigned long long)cbuf_phys, rc);
+        return rc;
+    }
+
+    /* Zero the cbuf — each dispatch writes a fresh layout, but
+     * keeping uninitialized bytes deterministic helps diagnostic
+     * dumps. */
+    {
+        volatile uint8_t *p = (volatile uint8_t *)cbuf_cpu;
+        for (size_t i = 0; i < 4096; i++) {
+            p[i] = 0;
+        }
+        cache_clean_range(cbuf_cpu, 4096);
+        __asm__ volatile("dsb sy" ::: "memory");
+    }
+
+    g_cbuf_phys   = cbuf_phys;
+    g_cbuf_gpu_va = cbuf_gva;
+    uart_printf("[oplib] stage_cbuf: allocated 4 KB cbuf at "
+                "gpu_va=0x%llx (phys=0x%llx)\n",
+                (unsigned long long)cbuf_gva,
+                (unsigned long long)cbuf_phys);
+    return 0;
+}
 
 int oplib_pool_stage_to_gpu(uint64_t inst_block_phys)
 {
@@ -221,6 +315,22 @@ int oplib_pool_stage_to_gpu(uint64_t inst_block_phys)
             __asm__ volatile("dsb sy" ::: "memory");
             g_sass_pool_gpu_va = sass_gva;
             g_sass_pool_n_pages = (sass_len + 4095) / 4096;
+            /* #832: record pool base so W-series dispatch FFIs can
+             * compute scratch slot phys without re-reading
+             * `h->shader_phys`. SASS is slot 0 (OPLIB_POOL_OFF_SASS == 0),
+             * so the pool base IS the SASS base. */
+            g_sass_pool_base_phys = h->shader_phys;
+            /* If the helper also published cbuf_*, record it.
+             * Otherwise fall through to the cbuf-allocation step
+             * below — the v6/v7 publish paths zero cbuf_* the same
+             * way they zero shader_*. */
+            if (h->cbuf_phys != 0 && h->cbuf_gpu_va != 0) {
+                g_cbuf_phys   = h->cbuf_phys;
+                g_cbuf_gpu_va = h->cbuf_gpu_va;
+            }
+            /* Ensure cbuf is mapped. Returns 0 if helper published
+             * h->cbuf_*, otherwise allocates a fresh 4 KB page. */
+            (void)stage_cbuf(inst_block_phys);
             g_stage_rc = 0;
             g_staged = true;
             uart_printf("[oplib] stage_to_gpu: %zu B copied into helper-"
@@ -234,94 +344,104 @@ int oplib_pool_stage_to_gpu(uint64_t inst_block_phys)
         }
     }
 
-    /* Slow path: no pre-staged region — allocate via the post-kexec
-     * GMMU walker. Only viable when inst_block_phys is correct AND
-     * the walker can place mappings (small-page region). */
-    size_t n_pages  = (sass_len + 4095) / 4096;
+    /* Slow path (#832): the helper's v6/v7 publish path zeros
+     * `h->shader_*`, so there's no pre-staged scratch region for
+     * the W-series dispatch FFI to use. Allocate the FULL pool
+     * (SASS + 3 scratch slots = OPLIB_POOL_MIN_BYTES) as one
+     * contiguous physical buffer via PMM and map it into the
+     * inherited channel's GMMU via the new `ga10b_gmmu_map`.
+     *
+     * Contiguous-phys is load-bearing: each dispatch FFI does
+     * `pool_base_phys + OPLIB_POOL_OFF_SCRATCH<N>` to find its
+     * per-call CPU↔GPU staging slot. The prior slow path that used
+     * `ga10b_gmmu_alloc` got per-page-discontig PMM and couldn't
+     * satisfy that math.
+     *
+     * SASS must fit in slot 0 (64 KB). All seven W-series shipped
+     * kernels combine to ~40 KB today — fits comfortably. If a
+     * future operator library exceeds this, the assertion below
+     * fires before any GMMU mapping is attempted. */
+    if (sass_len > OPLIB_POOL_SLOT_BYTES) {
+        g_staged = true;
+        g_stage_rc = -1;
+        uart_printf("[oplib] stage_to_gpu: SASS region %zu B exceeds "
+                    "slot 0 capacity %u B — pool layout assumes "
+                    "SASS fits in slot 0. Rework slot sizing or "
+                    "split the library.\n",
+                    sass_len, (unsigned)OPLIB_POOL_SLOT_BYTES);
+        return -1;
+    }
 
+    /* OPLIB_POOL_MIN_BYTES = 256 KB rounds to 64 pages → order 6
+     * in the buddy allocator. Plenty of headroom on Jetson's
+     * ~6.7 GB usable. */
+    const size_t pool_pages = OPLIB_POOL_MIN_BYTES / 4096u;
+    void *pool_cpu = pmm_alloc_pages(pool_pages);
+    if (pool_cpu == NULL) {
+        g_staged = true;
+        g_stage_rc = -1;
+        uart_printf("[oplib] stage_to_gpu: pmm_alloc_pages(%zu) for "
+                    "256 KB scratch pool failed\n", pool_pages);
+        return -1;
+    }
+    uint64_t pool_phys = (uint64_t)(uintptr_t)pool_cpu;
+
+    /* Map the whole pool into the channel's GMMU at a fresh GPU VA.
+     * Read-write because per-call staging writes activations into
+     * SCRATCH0/1/2; the SASS slot is also writable today (no
+     * separate RO flag per slot — fix once we add slot-granular
+     * mapping). */
     uint64_t gpu_va = 0;
-    uint64_t phys   = 0;
-    void    *cpu_va = NULL;
-    /* Read-only mapping — the GPU only fetches instructions from the
-     * SASS pool; no writes from the GPU side. PRIV bit unset (sass
-     * runs in user privilege from the channel's perspective). */
-    int rc = ga10b_gmmu_alloc(inst_block_phys, (uint32_t)n_pages,
-                               GA10B_GMMU_FLAG_RO,
-                               &gpu_va, &cpu_va, &phys);
+    int rc = ga10b_gmmu_map(inst_block_phys, pool_phys,
+                             (uint32_t)pool_pages,
+                             /* flags */ 0,
+                             &gpu_va);
     if (rc < 0) {
+        /* Free the PMM pages — they'd otherwise leak until reboot. */
+        pmm_free_pages(pool_cpu, pool_pages);
         g_staged = true;
         g_stage_rc = rc;
-        uart_printf("[oplib] stage_to_gpu: ga10b_gmmu_alloc(n_pages=%zu) "
-                    "failed: rc=%d\n", n_pages, rc);
+        uart_printf("[oplib] stage_to_gpu: ga10b_gmmu_map(phys=0x%llx, "
+                    "n_pages=%zu) failed: rc=%d\n",
+                    (unsigned long long)pool_phys, pool_pages, rc);
         return rc;
     }
 
-    /* Copy the SASS region. ga10b_gmmu_alloc returns the kernel VA of
-     * the FIRST page only — subsequent pages are PMM-allocated
-     * individually and are NOT contiguous in CPU virtual address
-     * space. Walk per-page using the per-page GPU VAs and the walker.
-     *
-     * Cheaper alternative: alloc all the PMM pages ourselves and
-     * copy into them before mapping. But that requires re-implementing
-     * map_one_page in this TU. Sticking with the per-page walk-after-
-     * alloc keeps the code small.
-     *
-     * For the first page, cpu_va points at the right CPU VA already;
-     * memcpy the first 4 KB. For pages [1..n_pages) we walk each
-     * GPU VA, get its leaf phys (== CPU phys via Jetson identity
-     * map), and memcpy from the SASS region into that page. */
+    /* Copy SASS into slot 0. The pool is physically contiguous so
+     * we can write through the kernel-VA alias (`pool_cpu`) in one
+     * pass, and a single cache_clean_range covers slot 0. */
     {
         const uint8_t *src = g_handle.sass_region;
-        size_t remaining = sass_len;
-
-        /* Page 0: cpu_va is the kernel-VA alias of `phys`. */
-        size_t copy0 = remaining > 4096 ? 4096 : remaining;
-        for (size_t b = 0; b < copy0; b++) {
-            ((volatile uint8_t *)cpu_va)[b] = src[b];
+        volatile uint8_t *dst =
+            (volatile uint8_t *)pool_cpu + OPLIB_POOL_OFF_SASS;
+        for (size_t i = 0; i < sass_len; i++) {
+            dst[i] = src[i];
         }
-        cache_clean_range(cpu_va, copy0);
-        src       += copy0;
-        remaining -= copy0;
-
-        /* Pages [1..n_pages): walk each one to find its leaf phys,
-         * which doubles as the kernel VA on Jetson. */
-        for (size_t i = 1; i < n_pages && remaining > 0; i++) {
-            uint64_t va_i = gpu_va + (uint64_t)i * 4096ull;
-            struct ga10b_gmmu_walk_result wr;
-            int wrc = ga10b_gmmu_walk(inst_block_phys, va_i, &wr);
-            if (wrc != 0 || wr.status != GA10B_GMMU_WALK_OK) {
-                g_staged = true;
-                g_stage_rc = -1;
-                uart_printf("[oplib] stage_to_gpu: post-alloc walk failed "
-                            "page %zu, rc=%d status=%d\n",
-                            i, wrc, (int)wr.status);
-                return -1;
-            }
-            volatile uint8_t *dst = (volatile uint8_t *)(uintptr_t)wr.leaf_phys;
-            size_t copy_n = remaining > 4096 ? 4096 : remaining;
-            for (size_t b = 0; b < copy_n; b++) {
-                dst[b] = src[b];
-            }
-            cache_clean_range((void *)(uintptr_t)wr.leaf_phys, copy_n);
-            src       += copy_n;
-            remaining -= copy_n;
-        }
+        cache_clean_range((void *)((uintptr_t)pool_cpu + OPLIB_POOL_OFF_SASS),
+                          sass_len);
     }
 
     /* DSB SY so the GPU sees the populated SASS pages from PoC on
-     * its first dispatch. ga10b_gmmu_alloc already issued one for
-     * the page-table publication; this one orders the data writes. */
+     * its first dispatch. ga10b_gmmu_map already issued one for the
+     * page-table publication; this one orders the SASS data writes. */
     __asm__ volatile("dsb sy" ::: "memory");
 
-    g_sass_pool_gpu_va = gpu_va;
-    g_sass_pool_n_pages = n_pages;
+    g_sass_pool_gpu_va    = gpu_va + OPLIB_POOL_OFF_SASS;
+    g_sass_pool_n_pages   = (sass_len + 4095) / 4096;
+    g_sass_pool_base_phys = pool_phys;
+
+    /* Cbuf gets its own 4 KB page, separately allocated and mapped.
+     * Same v6/v7-publish-zeros story as shader_*. */
+    (void)stage_cbuf(inst_block_phys);
+
     g_stage_rc = 0;
-    g_staged = true;
+    g_staged   = true;
 
     uart_printf("[oplib] stage_to_gpu: %zu B SASS staged at gpu_va=0x%llx "
-                "(%zu pages, first phys=0x%llx)\n",
-                sass_len, (unsigned long long)gpu_va,
-                n_pages, (unsigned long long)phys);
+                "(self-allocated 256 KB pool, base phys=0x%llx, "
+                "scratch slots mapped)\n",
+                sass_len, (unsigned long long)g_sass_pool_gpu_va,
+                (unsigned long long)pool_phys);
     return 0;
 }
 

--- a/kernel/include/oplib_pool.h
+++ b/kernel/include/oplib_pool.h
@@ -141,4 +141,37 @@ int oplib_pool_get_sass_gpu_va(uint32_t op_kind, uint32_t tier, uint32_t dtype,
  * staged. Used by the status verb. */
 uint64_t oplib_pool_gpu_va_base(void);
 
+/* Inspector: physical address (CPU side) of the pool's base — i.e.
+ * the start of the SASS slot. Returns 0 if the pool isn't staged
+ * yet, or if `oplib_pool_stage_to_gpu` took a slow path that
+ * couldn't expose contiguous CPU phys (older slow path that
+ * allocated non-contig PMM pages — kept as a fallback when the new
+ * contig path fails).
+ *
+ * Layered with `oplib_pool_gpu_va_base`, this gives the W-series
+ * dispatch FFI (#832) a single source of truth for per-call scratch
+ * slots: `(base_phys|base_gpu_va) + OPLIB_POOL_OFF_SCRATCH<N>`.
+ *
+ * Fast path (helper-published v4 shader region exists): returns
+ * `h->shader_phys`. Slow path (this PR): returns the
+ * `pmm_alloc_pages`-returned contiguous phys.
+ */
+uint64_t oplib_pool_base_phys(void);
+
+/* Inspector: 4 KB cbuf page used by `slm_oplib_prepare_dispatch` to
+ * stage the per-dispatch cbuf[0] argument layout. Pre-allocated and
+ * mapped during `oplib_pool_stage_to_gpu`:
+ *
+ *   - Fast path: if the helper handoff publishes `h->cbuf_*`,
+ *     accessors return those addresses.
+ *   - Slow path: oplib_pool allocates a 4 KB PMM page and maps it
+ *     into the channel's GMMU via `ga10b_gmmu_map`.
+ *
+ * Returns 0 if no cbuf is available (helper didn't publish + slow
+ * path allocation failed). Callers translate that into a CPU
+ * fallback in the dispatch FFI.
+ */
+uint64_t oplib_pool_cbuf_phys(void);
+uint64_t oplib_pool_cbuf_gpu_va(void);
+
 #endif /* OPLIB_POOL_H */

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -30,6 +30,7 @@
 #include "../gpu/nvidia/ga10b_channel_handoff.h"  /* GA10B_PIPELINE_KIND_* */
 #include "operator_dispatch.h"      /* struct operator_dispatch_args */
 #include "oplib_dispatch.h"         /* slm_oplib_dispatch */
+#include "oplib_pool.h"             /* oplib_pool_base_phys / _gpu_va_base */
 #include "oplib_pool.h"             /* OPLIB_POOL_* slot offsets */
 #include "oplib_weights_pool.h"     /* W2 weight staging */
 /* cache_clean_range / cache_invalidate_range come from gpu.h above
@@ -1266,6 +1267,48 @@ void slm_runtime_dispatch_stats_reset(void)
     }
 }
 
+/* #832: resolve the (phys, gpu_va) base addresses the W-series
+ * dispatch FFIs use to compute their per-call scratch slots.
+ *
+ * Two sources, in preference order:
+ *
+ *   1. **Helper-published v4 shader region** — `h->shader_*` set
+ *      by `gpu_write_handoff_v4` (or any future handoff producer
+ *      that publishes a contiguous 256 KB scratch area). This is
+ *      the original design; the current MNIST helper's v6/v7
+ *      publish paths zero these fields ("v3 dispatch fields stay
+ *      zero" per gpu-launch-common.c).
+ *
+ *   2. **oplib_pool self-allocated scratch** — `oplib_pool_stage_to_gpu`'s
+ *      slow path (also added in this PR) allocates a 256 KB
+ *      contiguous PMM buffer, maps it into the inherited channel's
+ *      GMMU via `ga10b_gmmu_map`, and exposes the base addresses
+ *      via `oplib_pool_base_phys` / `oplib_pool_gpu_va_base`.
+ *
+ * Returns 0 on success or -1 if neither source has scratch (no
+ * helper handoff + `nvgpu oplib stage` was never called or
+ * failed). Callers translate -1 into a dispatch FFI -1 return,
+ * which forward.rs's hybrid wrappers turn into CPU fallback. */
+static int slm_ffi_resolve_scratch_base(uint64_t *out_phys,
+                                         uint64_t *out_gva)
+{
+    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
+    if (h != NULL && h->shader_phys != 0 && h->shader_gpu_va != 0 &&
+        h->shader_size >= OPLIB_POOL_MIN_BYTES) {
+        *out_phys = h->shader_phys;
+        *out_gva  = h->shader_gpu_va;
+        return 0;
+    }
+    uint64_t pool_phys = oplib_pool_base_phys();
+    uint64_t pool_gva  = oplib_pool_gpu_va_base();
+    if (pool_phys != 0 && pool_gva != 0) {
+        *out_phys = pool_phys;
+        *out_gva  = pool_gva;
+        return 0;
+    }
+    return -1;
+}
+
 int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
                                        const void *gamma_cpu_in,
                                        void *out_cpu_out,
@@ -1311,9 +1354,12 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
      * race. The lock is cleared on every return path. */
     irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
 
-    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
-    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
-        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+    /* #832: prefer the helper-published shader region; fall back to
+     * oplib_pool's self-allocated 256 KB scratch when the helper's
+     * v6/v7 handoff zeros the v4 shader_* fields. */
+    uint64_t base_phys = 0;
+    uint64_t base_gva  = 0;
+    if (slm_ffi_resolve_scratch_base(&base_phys, &base_gva) < 0) {
         spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
         return -1;
     }
@@ -1324,12 +1370,12 @@ int slm_runtime_dispatch_rmsnorm_simt(const void *x_cpu_in,
     }
 
     /* Scratch addresses: same slot layout as the smoke verb. */
-    uint64_t in_phys  = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t in_va    = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t gam_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH1;
-    uint64_t gam_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH1;
-    uint64_t out_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH2;
-    uint64_t out_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t in_phys  = base_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t in_va    = base_gva  + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t gam_phys = base_phys + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t gam_va   = base_gva  + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t out_phys = base_phys + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t out_va   = base_gva  + OPLIB_POOL_OFF_SCRATCH2;
 
     /* Stage CPU input + gamma into GPU scratch. Jetson's 1:1
      * phys/virt mapping for DRAM lets the kernel-side phys pointer
@@ -1393,9 +1439,9 @@ int slm_runtime_dispatch_swiglu_simt(const void *gate_cpu_in,
     op_dispatch_record_attempt(SLM_GPU_OP_SWIGLU);
     irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
 
-    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
-    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
-        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+    uint64_t base_phys = 0;
+    uint64_t base_gva  = 0;
+    if (slm_ffi_resolve_scratch_base(&base_phys, &base_gva) < 0) {
         spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
         return -1;
     }
@@ -1405,12 +1451,12 @@ int slm_runtime_dispatch_swiglu_simt(const void *gate_cpu_in,
         return -1;
     }
 
-    uint64_t gate_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t gate_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t up_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH1;
-    uint64_t up_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH1;
-    uint64_t out_phys  = h->shader_phys + OPLIB_POOL_OFF_SCRATCH2;
-    uint64_t out_va    = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t gate_phys = base_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t gate_va   = base_gva  + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t up_phys   = base_phys + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t up_va     = base_gva  + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t out_phys  = base_phys + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t out_va    = base_gva  + OPLIB_POOL_OFF_SCRATCH2;
 
     memcpy((void *)(uintptr_t)gate_phys, gate_cpu_in, (size_t)bytes);
     memcpy((void *)(uintptr_t)up_phys,   up_cpu_in,   (size_t)bytes);
@@ -1485,9 +1531,9 @@ int slm_runtime_dispatch_gqa_attn_simt(const void *q_cpu_in,
     op_dispatch_record_attempt(SLM_GPU_OP_GQA_ATTN);
     irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
 
-    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
-    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
-        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+    uint64_t base_phys = 0;
+    uint64_t base_gva  = 0;
+    if (slm_ffi_resolve_scratch_base(&base_phys, &base_gva) < 0) {
         spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
         return -1;
     }
@@ -1497,15 +1543,15 @@ int slm_runtime_dispatch_gqa_attn_simt(const void *q_cpu_in,
         return -1;
     }
 
-    uint64_t q_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t q_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t k_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH1;
-    uint64_t k_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH1;
-    uint64_t v_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH2;
-    uint64_t v_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t q_phys   = base_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t q_va     = base_gva  + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t k_phys   = base_phys + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t k_va     = base_gva  + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t v_phys   = base_phys + OPLIB_POOL_OFF_SCRATCH2;
+    uint64_t v_va     = base_gva  + OPLIB_POOL_OFF_SCRATCH2;
     /* out lives in SCRATCH0's second 4 KB sub-page. */
-    uint64_t out_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0 + 0x1000ull;
-    uint64_t out_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0 + 0x1000ull;
+    uint64_t out_phys = base_phys + OPLIB_POOL_OFF_SCRATCH0 + 0x1000ull;
+    uint64_t out_va   = base_gva  + OPLIB_POOL_OFF_SCRATCH0 + 0x1000ull;
 
     memcpy((void *)(uintptr_t)q_phys, q_cpu_in, (size_t)q_bytes);
     memcpy((void *)(uintptr_t)k_phys, k_cpu_in, (size_t)kv_bytes);
@@ -1576,9 +1622,9 @@ int slm_runtime_dispatch_q4k_dot_simt(const void *x_cpu_in,
     op_dispatch_record_attempt(SLM_GPU_OP_Q4K_DOT);
     irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
 
-    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
-    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
-        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+    uint64_t base_phys = 0;
+    uint64_t base_gva  = 0;
+    if (slm_ffi_resolve_scratch_base(&base_phys, &base_gva) < 0) {
         spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
         return -1;
     }
@@ -1588,10 +1634,10 @@ int slm_runtime_dispatch_q4k_dot_simt(const void *x_cpu_in,
         return -1;
     }
 
-    uint64_t x_phys   = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t x_va     = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t out_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH1;
-    uint64_t out_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t x_phys   = base_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t x_va     = base_gva  + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t out_phys = base_phys + OPLIB_POOL_OFF_SCRATCH1;
+    uint64_t out_va   = base_gva  + OPLIB_POOL_OFF_SCRATCH1;
 
     memcpy((void *)(uintptr_t)x_phys, x_cpu_in, (size_t)x_bytes);
     cache_clean_range((void *)(uintptr_t)x_phys,
@@ -1653,9 +1699,9 @@ int slm_runtime_dispatch_embedding_simt(uint64_t table_gpu_va,
     op_dispatch_record_attempt(SLM_GPU_OP_EMBEDDING);
     irq_flags_t irq = spin_lock_irqsave(&g_gpu_dispatch_lock);
 
-    const struct ga10b_channel_handoff *h = ga10b_bringup_handoff();
-    if (h == NULL || h->shader_gpu_va == 0 || h->shader_phys == 0 ||
-        h->shader_size < OPLIB_POOL_MIN_BYTES) {
+    uint64_t base_phys = 0;
+    uint64_t base_gva  = 0;
+    if (slm_ffi_resolve_scratch_base(&base_phys, &base_gva) < 0) {
         spin_unlock_irqrestore(&g_gpu_dispatch_lock, irq);
         return -1;
     }
@@ -1667,8 +1713,8 @@ int slm_runtime_dispatch_embedding_simt(uint64_t table_gpu_va,
 
     /* Output slot in the existing scratch carve-out. SCRATCH0 has
      * worked for every smoke verb; reuse it. */
-    uint64_t out_phys = h->shader_phys + OPLIB_POOL_OFF_SCRATCH0;
-    uint64_t out_va   = h->shader_gpu_va + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t out_phys = base_phys + OPLIB_POOL_OFF_SCRATCH0;
+    uint64_t out_va   = base_gva  + OPLIB_POOL_OFF_SCRATCH0;
 
     struct operator_dispatch_args args = {
         .op_kind = SLM_GPU_OP_EMBEDDING,

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -30,8 +30,7 @@
 #include "../gpu/nvidia/ga10b_channel_handoff.h"  /* GA10B_PIPELINE_KIND_* */
 #include "operator_dispatch.h"      /* struct operator_dispatch_args */
 #include "oplib_dispatch.h"         /* slm_oplib_dispatch */
-#include "oplib_pool.h"             /* oplib_pool_base_phys / _gpu_va_base */
-#include "oplib_pool.h"             /* OPLIB_POOL_* slot offsets */
+#include "oplib_pool.h"             /* OPLIB_POOL_* slot offsets + accessors */
 #include "oplib_weights_pool.h"     /* W2 weight staging */
 /* cache_clean_range / cache_invalidate_range come from gpu.h above
  * (already included on the non-Jetson side). The kernel/include/cache.h


### PR DESCRIPTION
## Summary

Fixes the entry-guard half of #832. The W-series dispatch FFI no longer silently falls back to CPU because of zero `h->shader_*` / `h->cbuf_*` fields. A separate downstream failure surfaces (`ga10b_dispatch_v7_pipeline_inline` returns -1) — tracked as #834.

Net effect: **dispatch FFI gets past its early-exit guards on the toggle-respecting path. Real GPU work doesn't happen yet (blocked on #834), but the structural blocker on #832 is cleared.**

## What this PR does (Option B from #832)

Approach: oplib_pool owns its own scratch + cbuf when the helper's v6/v7 handoff zeros the v4-era fields the dispatch FFI was originally written against.

### New: `ga10b_gmmu_map`

Sibling to `ga10b_gmmu_alloc` (kernel/gpu/nvidia/ga10b_gmmu.{c,h}). Takes a caller-provided contiguous physical buffer (typically from `pmm_alloc_pages`) and maps it into the inherited channel's GMMU at a fresh GPU VA. Skips the per-page PMM allocation step.

### Extended: `oplib_pool_stage_to_gpu` slow path

- Allocates `OPLIB_POOL_MIN_BYTES` = 256 KB contiguous via `pmm_alloc_pages(64)` (order 6 — plenty of headroom on Jetson)
- Maps via `ga10b_gmmu_map` at a fresh GPU VA (typically `0x4000000000`)
- Copies SASS into slot 0; scratch slots 1/2/3 are mapped but unpopulated until per-call dispatch

### New: `stage_cbuf`

Called by both fast and slow SASS paths. Pre-allocates a 4 KB cbuf page (helper-published `h->cbuf_*` if available; PMM+gmmu_map otherwise). Eliminates the per-dispatch ga10b_gmmu_alloc leak in the prior slow path.

### New accessors

`kernel/include/oplib_pool.h`:
- `uint64_t oplib_pool_base_phys(void)` — pool's CPU phys base
- `uint64_t oplib_pool_cbuf_phys(void)` / `oplib_pool_cbuf_gpu_va(void)` — cbuf addresses

### Rewritten: 5 W-series dispatch FFIs

`kernel/src/slm_ffi.c` `slm_runtime_dispatch_<rmsnorm|swiglu|gqa_attn|q4k_dot|embedding>_simt` now resolve scratch base via a shared helper:

```c
static int slm_ffi_resolve_scratch_base(uint64_t *out_phys,
                                         uint64_t *out_gva) {
    /* Prefer helper-published h->shader_*; fall back to oplib_pool. */
    ...
}
```

Net change: dispatch FFI returns -1 from this resolver only when **neither** helper nor pool has scratch — strict superset of the prior "h->shader_*==0 → -1" gate, but with a working second source.

### Updated: `slm_oplib_prepare_dispatch` cbuf logic

Falls through to `oplib_pool_cbuf_*` accessors before reaching the last-resort `ga10b_gmmu_alloc(inst_block_phys, ...)` path. The W-series FFI passes `inst_block_phys=0` so that path was always failing; now it's unreachable from the W-series.

## Hardware verification

After deploy on jetson-nano-2:

```
[oplib] stage_cbuf: allocated 4 KB cbuf at gpu_va=0x4000040000 (phys=0x13cf61000)
[oplib] stage_to_gpu: 34560 B SASS staged at gpu_va=0x4000000000 (self-allocated 256 KB pool, base phys=0x13cf80000, scratch slots mapped)
```

Both staging steps fire. The W-series dispatch FFI gets past its early-exit guards. The next failure mode is `ga10b_dispatch_v7_pipeline_inline` returning -1 — out of scope for #832, captured as #834.

## Test plan

- [x] `make test` (QEMU_VIRT): "PASSED - All tests passed (exit code 0)" — no regressions
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO`: clean build, 0 non-Lua warnings
- [x] Hardware deploy via `scripts/jetson-deploy-retry.sh` (3/5 attempts, normal rate)
- [x] xload SmolLM2-135M Q4_K_M (~100 MB)
- [x] `nvgpu oplib stage` logs `self-allocated 256 KB pool` + `allocated 4 KB cbuf`
- [x] Verify `slm prompt 0 Hello` no longer hits the `h->shader_phys==0` early return path
- [ ] (Pending #834) `slm gpu` shows `ok > 0` for W-series ops

## Related

- #832 — entry-guard blocker this fixes (close on merge)
- #834 — downstream v7 pipeline failure that surfaces after this fix
- #764 — SLM-GPU-end-to-end rollup; blocks on both #832 and #834
- PR #831 — counter infrastructure that made this debuggable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
