### PR TITLE
shell: xget-bin — direct binary download (mirror of xput-bin)

### DIFF
--- a/kernel/include/shell.h
+++ b/kernel/include/shell.h
@@ -269,4 +269,30 @@ int shell_session_read_raw(char *dst, int max_len);
  */
 void shell_session_set_binary_mode(bool on);
 
+/*
+ * Write `len` bytes verbatim through the current session's I/O
+ * backend, with no CR-LF expansion. The transport layer is still
+ * responsible for any wire-level escaping it owns — the TCP/telnet
+ * backend doubles 0xFF bytes per RFC 854 IAC stuffing. Mirror of
+ * `shell_session_read_raw` for the write direction; used by
+ * `cmd_xget-bin` to stream raw file bytes after the framing header.
+ *
+ * On backends that don't implement `write_raw` (UART, serial), the
+ * call is a silent no-op — the cooked write path's CR-LF expansion
+ * would corrupt a binary stream, and falling back to it would
+ * produce a wrong-but-plausible download that the host couldn't
+ * detect. Callers that emit binary frames must gate on
+ * `shell_session_supports_write_raw()` first and refuse to start
+ * the transfer if it returns false.
+ */
+void shell_session_write_raw(const uint8_t *buf, size_t len);
+
+/*
+ * True iff the current session's I/O backend implements `write_raw`
+ * (i.e. can deliver bit-exact binary payloads). False on UART /
+ * serial backends. Use this to gate any command that streams
+ * binary data before sending the framing header to the peer.
+ */
+bool shell_session_supports_write_raw(void);
+
 #endif /* SHELL_H */

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -126,6 +126,7 @@ int cmd_write(int argc, char **argv);
 int cmd_put(int argc, char **argv);
 int cmd_xput(int argc, char **argv);
 int cmd_xput_bin(int argc, char **argv);
+int cmd_xget_bin(int argc, char **argv);
 int cmd_mkdir(int argc, char **argv);
 int cmd_rm(int argc, char **argv);
 int cmd_mv(int argc, char **argv);

--- a/kernel/include/shell_io.h
+++ b/kernel/include/shell_io.h
@@ -85,6 +85,17 @@ struct shell_io {
      * shell_session_set_binary_mode helper which does). */
     void (*set_binary_mode)(struct shell_io *io, bool on);
 
+    /* Optional. Write `len` bytes verbatim — no CR-LF expansion, no
+     * other text transforms. The transport is still responsible for
+     * any wire-level escaping it owns: the TCP/telnet backend doubles
+     * 0xFF bytes per RFC 854 IAC stuffing here so binary payloads
+     * containing 0xFF reach the peer intact. Used by `cmd_xget-bin`
+     * to stream raw file bytes after the framing header. UART
+     * backends without a wire protocol leave this NULL; callers
+     * must use `shell_session_write_raw` (which NULL-checks and
+     * falls back to plain write). */
+    void (*write_raw)(struct shell_io *io, const uint8_t *buf, size_t len);
+
     /* Backend-private data. */
     void *ctx;
 };

--- a/kernel/include/shell_io_tcp.h
+++ b/kernel/include/shell_io_tcp.h
@@ -152,4 +152,14 @@ int shell_io_tcp_test_run_read_buf_drains_ring(void);
  * region — guards against an off-by-one in the rx_tail update). */
 int shell_io_tcp_test_run_read_buf_wrap(void);
 
+/* Test-only driver for `tcp_write_raw_buf` IAC stuffing (PR #837).
+ * Pushes a known payload through the raw write path with
+ * tx_prev_was_cr pre-poisoned to true, then verifies:
+ *   - every 0xFF byte was doubled per RFC 854,
+ *   - other bytes (including CR/LF) passed through unchanged,
+ *   - tx_prev_was_cr was reset to false (raw-path bleed guard).
+ * Returns 0 on success, -1 if no slot could be allocated, -2 on
+ * stuffing mismatch, -3 on CR-flag bleed. */
+int shell_io_tcp_test_run_write_raw_iac_stuffing(void);
+
 #endif /* SHELL_IO_TCP_H */

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -252,6 +252,31 @@ static const struct help_entry help_entries[] = {
         "host side.\n"
     ),
 
+    HELP_TEXT("xget-bin",
+        "xget-bin - Direct binary download (mirror of xput-bin)\n"
+        "\n"
+        "Usage:\n"
+        "  xget-bin <path> [skip]\n"
+        "\n"
+        "Streams the file at `path` raw over the current shell session's\n"
+        "TCP transport. Symmetric counterpart to xput-bin for the\n"
+        "device→host direction. `skip` is an optional resume offset —\n"
+        "bytes at file positions [skip, total) are sent. Default skip=0.\n"
+        "\n"
+        "Wire format: telnet IAC byte-stuffed (0xFF in payload doubles\n"
+        "to 0xFF 0xFF on the wire per RFC 854). The host's TelnetShell\n"
+        "un-stuffs it back to the original bytes.\n"
+        "\n"
+        "Protocol:\n"
+        "  client:  xget-bin <path> [skip]\\n\n"
+        "  kernel:  XGET-BIN ready size=<total>\\r\\n\n"
+        "  kernel:  <total - skip> raw bytes (with 0xFF doubled)\n"
+        "  kernel:  XGET-BIN done size=<total>\\r\\n\n"
+        "\n"
+        "Use `scripts/tools/slm-get.py` to drive this from the host\n"
+        "side.\n"
+    ),
+
     HELP_TEXT("append",
         "append - Append content to file\n"
         "\n"

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -106,6 +106,7 @@ const shell_cmd_t builtin_commands[] = {
     {"truncate", cmd_truncate, "Truncate file (truncate <path> <size>)",            false, SHELL_CAT_FILESYSTEM},
     {"wc",       cmd_wc,       "Count lines/words/bytes (wc <path>)",               false, SHELL_CAT_FILESYSTEM},
     {"write",    cmd_write,    "Write to file (write <path> <content>)",            false, SHELL_CAT_FILESYSTEM},  /* VFS locks internally */
+    {"xget-bin", cmd_xget_bin, "Direct binary download (xget-bin <path> [skip])",      false, SHELL_CAT_FILESYSTEM},
     {"xput",     cmd_xput,     "Framed upload (xput begin|chunk|status|finish|abort)", false, SHELL_CAT_FILESYSTEM},
     {"xput-bin", cmd_xput_bin, "Direct binary upload (xput-bin <path> <total>)",       false, SHELL_CAT_FILESYSTEM},
 
@@ -722,6 +723,27 @@ void shell_session_set_binary_mode(bool on)
     if (s && s->io && s->io->set_binary_mode) {
         s->io->set_binary_mode(s->io, on);
     }
+}
+
+void shell_session_write_raw(const uint8_t *buf, size_t len)
+{
+    if (!buf || len == 0) return;
+    struct shell_session *s = shell_session_current();
+    /* Backends without write_raw (UART today) can't deliver bit-exact
+     * binary — the cooked write path's CR-LF expansion would corrupt
+     * the stream. Drop silently here; callers must use
+     * shell_session_supports_write_raw() to gate before starting a
+     * binary frame so the operator sees a useful error instead of a
+     * truncated download. */
+    if (s && s->io && s->io->write_raw) {
+        s->io->write_raw(s->io, buf, len);
+    }
+}
+
+bool shell_session_supports_write_raw(void)
+{
+    struct shell_session *s = shell_session_current();
+    return s && s->io && s->io->write_raw;
 }
 
 /* ============================================================================

--- a/kernel/src/shell_fs.c
+++ b/kernel/src/shell_fs.c
@@ -1221,6 +1221,145 @@ int cmd_xput_bin(int argc, char *argv[])
 }
 
 /*
+ * xget-bin <path> [skip] - Direct binary download (mirror of xput-bin)
+ *
+ * Streams the file at `path` raw over the current shell session's
+ * TCP transport. No hex encoding, no per-line shell parse —
+ * symmetric counterpart to xput-bin for the device→host direction.
+ * `skip` is an optional resume offset; bytes at file positions
+ * [skip, total) are sent. Default skip=0.
+ *
+ * Wire format: telnet IAC byte-stuffed (0xFF in payload doubles to
+ * 0xFF 0xFF on the wire per RFC 854). The host's TelnetShell
+ * un-stuffs it back to the original bytes.
+ *
+ * Protocol:
+ *   client:  xget-bin <path> [skip]\n
+ *   kernel:  XGET-BIN ready size=<total>\r\n
+ *   kernel:  <total - skip> raw bytes (with 0xFF doubled)
+ *   kernel:  XGET-BIN done size=<total>\r\n
+ *   kernel:  slmos>     (normal prompt resumes)
+ *
+ * On error before the data stream begins, prints an `xget-bin: ...`
+ * message and returns -1 — no `XGET-BIN ready` was sent so the
+ * client knows nothing came. On error mid-stream (partial write to
+ * peer, file shrank under us), prints
+ * `XGET-BIN err sent=N reason=...\r\n` and returns -1.
+ */
+/* 64 KB chunk for the LFS→TCP streaming loop. Picked to match a
+ * typical lwIP send-buffer high-water mark so the read+stuff+enqueue
+ * pipeline keeps the TX ring full without one read dominating the
+ * loop iteration time. Single-flight guard below means only one
+ * cmd_xget_bin owns this buffer at a time. */
+#define XGET_BIN_BUF_BYTES 65536u
+
+/* Compile-time guard against a future LittleFS that widens lfs_size_t
+ * past 32 bits — would silently truncate `total` in the header. */
+_Static_assert(sizeof(((struct lfs_entry_info *)0)->size) == sizeof(uint32_t),
+    "lfs_entry_info.size must be uint32_t — cmd_xget_bin truncates header otherwise");
+
+int cmd_xget_bin(int argc, char *argv[])
+{
+    if (argc < 2) {
+        shell_puts("Usage: xget-bin <path> [skip]\r\n");
+        return -1;
+    }
+
+    /* Transport gate — UART/serial backends can't deliver bit-exact
+     * binary (the cooked write path's CR-LF expansion would corrupt
+     * the stream). Refuse upfront, before any framing header lands
+     * on the wire, so the operator gets a clear error. */
+    if (!shell_session_supports_write_raw()) {
+        shell_puts("xget-bin: not supported on this transport "
+                   "(requires TCP/telnet shell)\r\n");
+        return -1;
+    }
+
+    char resolved[VFS_MAX_PATH];
+    if (shell_resolve_path(argv[1], resolved, sizeof(resolved)) < 0) {
+        shell_puts("xget-bin: path too long\r\n");
+        return -1;
+    }
+    uint32_t skip = 0;
+    if (argc >= 3 && shell_parse_uint(argv[2], &skip) != 0) {
+        shell_printf("xget-bin: invalid skip: %s\r\n", argv[2]);
+        return -1;
+    }
+
+    /* Single-flight guard. Mirrors xput-bin's pattern; serializes
+     * the shared static bin_buf below. */
+    static bool xget_bin_active = false;
+    if (__atomic_exchange_n(&xget_bin_active, true, __ATOMIC_ACQ_REL)) {
+        shell_puts("XGET-BIN err sent=0 reason=busy\r\n");
+        return -1;
+    }
+
+    int rc = -1;
+    int fd = -1;
+    struct lfs_mount *mnt = NULL;
+    uint32_t total = 0;
+    uint32_t sent = 0;
+
+    const char *subpath = NULL;
+    mnt = vfs_get_mount_ctx(resolved, &subpath);
+    if (!mnt) {
+        shell_printf("xget-bin: %s: Not a mounted filesystem\r\n", resolved);
+        goto fail;
+    }
+
+    struct lfs_entry_info info;
+    if (littlefs_stat_path(mnt, subpath, &info) != LFS_ERR_OK) {
+        shell_printf("xget-bin: %s: not found\r\n", resolved);
+        goto fail;
+    }
+    total = info.size;
+    if (skip > total) {
+        shell_printf("xget-bin: %s: skip %lu > size %lu\r\n",
+                     resolved, (unsigned long)skip, (unsigned long)total);
+        goto fail;
+    }
+
+    fd = littlefs_file_open(mnt, subpath, LFS_O_RDONLY);
+    if (fd < 0) {
+        shell_printf("xget-bin: %s: failed to open\r\n", resolved);
+        goto fail;
+    }
+    if (skip > 0 &&
+        littlefs_file_seek(mnt, fd, (lfs_soff_t)skip, LFS_SEEK_SET) < 0) {
+        shell_printf("xget-bin: %s: seek failed\r\n", resolved);
+        goto fail;
+    }
+
+    /* Header: tell the client how many bytes to expect. */
+    shell_printf("XGET-BIN ready size=%lu\r\n", (unsigned long)total);
+
+    static uint8_t bin_buf[XGET_BIN_BUF_BYTES];
+    sent = skip;
+    while (sent < total) {
+        uint32_t want = total - sent;
+        if (want > sizeof(bin_buf)) want = sizeof(bin_buf);
+        int got = littlefs_file_read(mnt, fd, bin_buf, (size_t)want);
+        if (got <= 0) {
+            shell_printf("XGET-BIN err sent=%lu reason=read\r\n",
+                         (unsigned long)(sent - skip));
+            goto fail;
+        }
+        shell_session_write_raw(bin_buf, (size_t)got);
+        sent += (uint32_t)got;
+    }
+
+    shell_printf("XGET-BIN done size=%lu\r\n", (unsigned long)total);
+    rc = 0;
+
+fail:
+    if (fd >= 0 && mnt) {
+        littlefs_file_close(mnt, fd);
+    }
+    __atomic_store_n(&xget_bin_active, false, __ATOMIC_RELEASE);
+    return rc;
+}
+
+/*
  * mkdir <path> - Create a directory
  * Supports relative paths.
  */

--- a/kernel/src/shell_io_tcp.c
+++ b/kernel/src/shell_io_tcp.c
@@ -799,6 +799,82 @@ static void tcp_write_buf(struct shell_io *io, const char *buf, size_t len)
     }
 }
 
+/*
+ * Raw-byte write: like tcp_write_buf but skips CR-LF expansion and
+ * IAC-stuffs 0xFF (per RFC 854) so binary payloads survive the
+ * telnet transport. Mirror of tcp_write_buf's wait/wedge handling
+ * — same write-timeout, same closed-session check — so callers see
+ * identical failure semantics regardless of which path they use.
+ *
+ * Worst case the wire byte count is 2× the input (every byte is
+ * 0xFF). The ring-fill loop only commits a byte if the IAC double
+ * fits, so a one-slot-free ring still makes forward progress on
+ * non-IAC bytes.
+ */
+static void tcp_write_raw_buf(struct shell_io *io,
+                              const uint8_t *buf, size_t len)
+{
+    struct tcp_shell_ctx *ctx = (struct tcp_shell_ctx *)io->ctx;
+    if (ctx->write_degraded || ctx->closed) return;
+
+    const uint64_t freq = shell_io_tcp_timer_freq();
+    const uint64_t timeout_ticks = (freq * (uint64_t)g_write_timeout_ms) / 1000ULL;
+    const uint64_t deadline = timer_get_count() + timeout_ticks;
+
+    size_t src = 0;
+    while (src < len) {
+        if (ctx->closed) return;
+
+        irq_flags_t flags = spin_lock_irqsave(&ctx->tx_lock);
+        uint32_t avail = ring_free(ctx->tx_head, ctx->tx_tail);
+
+        if (avail == 0) {
+            spin_unlock_irqrestore(&ctx->tx_lock, flags);
+            if (timer_get_count() >= deadline) {
+                tcp_write_timeout_bail(ctx, len - src);
+                return;
+            }
+            sleep_ms(TCP_SHELL_POLL_INTERVAL_MS);
+            continue;
+        }
+
+        size_t queued = 0;
+        while (src < len && queued < avail) {
+            uint8_t b = buf[src];
+            if (b == 0xFFu) {
+                /* IAC stuffing: emit 0xFF 0xFF. Both bytes have to
+                 * fit in the same enqueue or the receiver may see a
+                 * truncated escape that gets paired with the next
+                 * write's first byte. */
+                if (queued + 2 > avail) break;
+                ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = 0xFFu;
+                ctx->tx_head = (ctx->tx_head + 1) & TCP_SHELL_RING_MASK;
+                ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = 0xFFu;
+                ctx->tx_head = (ctx->tx_head + 1) & TCP_SHELL_RING_MASK;
+                queued += 2;
+            } else {
+                ctx->tx_buf[ctx->tx_head & TCP_SHELL_RING_MASK] = b;
+                ctx->tx_head = (ctx->tx_head + 1) & TCP_SHELL_RING_MASK;
+                queued += 1;
+            }
+            src++;
+        }
+        /* Reset tx_prev_was_cr — that flag belongs to the cooked
+         * write path's CR-LF state machine. A raw payload's last
+         * byte being 0x0D would otherwise trick the next cooked
+         * write into swallowing a legitimate following LF. */
+        ctx->tx_prev_was_cr = false;
+        spin_unlock_irqrestore(&ctx->tx_lock, flags);
+        if (queued == 0) {
+            if (timer_get_count() >= deadline) {
+                tcp_write_timeout_bail(ctx, len - src);
+                return;
+            }
+            sleep_ms(TCP_SHELL_POLL_INTERVAL_MS);
+        }
+    }
+}
+
 static void tcp_flush(struct shell_io *io)
 {
     (void)io;
@@ -1252,6 +1328,69 @@ int shell_io_tcp_test_run_read_buf_wrap(void)
     return rc;
 }
 
+/*
+ * Test-only driver for tcp_write_raw_buf's IAC stuffing
+ * (PR #837 follow-up). Pushes a payload containing 0xFF and CR
+ * bytes through the raw write path and asserts:
+ *   1. Every input 0xFF was doubled per RFC 854.
+ *   2. CR/LF/normal bytes are passed through unchanged.
+ *   3. tx_prev_was_cr is reset to false after the raw write so
+ *      it doesn't bleed into the next cooked write.
+ *
+ * Returns 0 on success, -1 on slot alloc fail, -2 on stuffing
+ * mismatch, -3 on CR-flag bleed.
+ */
+int shell_io_tcp_test_run_write_raw_iac_stuffing(void)
+{
+    struct tcp_shell_ctx *ctx = ctx_alloc();
+    if (!ctx) {
+        return -1;
+    }
+
+    ctx->tx_head = 0;
+    ctx->tx_tail = 0;
+    ctx->tx_prev_was_cr = true;  /* poisoned: a previous cooked
+                                   * write left this true. The raw
+                                   * write below must clear it. */
+    ctx->closed = false;
+    ctx->write_degraded = false;
+
+    /* Payload: 0x00, 0xFF, 0x42, 0xFF, 0xFF, 0x0D, 0x0A.
+     * Expected wire: 0x00, 0xFF 0xFF, 0x42, 0xFF 0xFF, 0xFF 0xFF,
+     *                0x0D, 0x0A  (every 0xFF doubled, CR/LF as-is). */
+    static const uint8_t payload[] = {0x00, 0xFFu, 0x42, 0xFFu,
+                                      0xFFu, 0x0Du, 0x0Au};
+    static const uint8_t expected[] = {0x00, 0xFFu, 0xFFu,
+                                       0x42,
+                                       0xFFu, 0xFFu,
+                                       0xFFu, 0xFFu,
+                                       0x0Du, 0x0Au};
+
+    tcp_write_raw_buf(&ctx->io, payload, sizeof(payload));
+
+    int rc = 0;
+    uint32_t produced = (ctx->tx_head - ctx->tx_tail) & TCP_SHELL_RING_MASK;
+    if (produced != sizeof(expected)) {
+        rc = -2;
+        goto out;
+    }
+    for (uint32_t i = 0; i < sizeof(expected); i++) {
+        uint32_t idx = (ctx->tx_tail + i) & TCP_SHELL_RING_MASK;
+        if (ctx->tx_buf[idx] != expected[i]) {
+            rc = -2;
+            goto out;
+        }
+    }
+    if (ctx->tx_prev_was_cr) {
+        rc = -3;  /* raw path leaked the CR flag back into cooked state */
+        goto out;
+    }
+
+out:
+    ctx_free(ctx);
+    return rc;
+}
+
 int shell_io_tcp_test_run_clean_close_cycle(void)
 {
     struct tcp_shell_ctx *ctx = ctx_alloc();
@@ -1359,6 +1498,7 @@ struct shell_io *shell_io_tcp_create(struct tcp_pcb *pcb)
     ctx->io.echo_enabled    = tcp_echo_enabled;
     ctx->io.read_buf        = tcp_read_buf;
     ctx->io.set_binary_mode = tcp_set_binary_mode;
+    ctx->io.write_raw       = tcp_write_raw_buf;
     ctx->io.ctx             = ctx;
 
     /* Initialize the telnet parser with our callback set. ctx->ctx

--- a/kernel/tests/test_net.c
+++ b/kernel/tests/test_net.c
@@ -571,6 +571,33 @@ static void test_shell_io_tcp_read_buf_handles_wrap(void)
 }
 
 /*
+ * Test: tcp_write_raw_buf IAC-stuffs 0xFF bytes per RFC 854 and
+ * doesn't bleed the raw-payload's last-byte-was-CR state into the
+ * cooked write path's CR-LF state machine (PR #837 review fix).
+ *
+ * Pre-stuffing regression: a payload containing 0xFF bytes would
+ * reach the host with single 0xFF, and the host's telnet decoder
+ * would interpret it as IAC (start-of-command). Pre-CR-bleed
+ * regression: a raw payload ending in 0x0D would set tx_prev_was_cr
+ * true, causing the next cooked write's leading 0x0A to be silently
+ * suppressed.
+ */
+static void test_shell_io_tcp_write_raw_iac_stuffing(void)
+{
+    int rc = shell_io_tcp_test_run_write_raw_iac_stuffing();
+    TEST_ASSERT_MESSAGE(rc != -1,
+        "test_run_write_raw_iac_stuffing: pool slot allocation failed");
+    TEST_ASSERT_MESSAGE(rc != -2,
+        "test_run_write_raw_iac_stuffing: stuffed bytes don't match "
+        "expected pattern (every 0xFF must be doubled, other bytes "
+        "pass through unchanged)");
+    TEST_ASSERT_MESSAGE(rc != -3,
+        "test_run_write_raw_iac_stuffing: tx_prev_was_cr leaked from "
+        "raw write path back into cooked CR-LF state machine");
+    TEST_ASSERT_EQUAL_INT(0, rc);
+}
+
+/*
  * Test: 50-cycle close-path drive must not increment leak_warnings (#537).
  *
  * Field observation summary (2026-05-02 jetson-nano-2 traces): post the
@@ -2567,6 +2594,7 @@ int test_suite_net(void)
     RUN_TEST(test_shell_io_tcp_close_settling);
     RUN_TEST(test_shell_io_tcp_read_buf_drains_ring);
     RUN_TEST(test_shell_io_tcp_read_buf_handles_wrap);
+    RUN_TEST(test_shell_io_tcp_write_raw_iac_stuffing);
     RUN_TEST(test_tcp_shell_no_false_leak_over_50_close_cycles);
     RUN_TEST(test_net_stats_initial_values);
 

--- a/scripts/tools/slm-get.py
+++ b/scripts/tools/slm-get.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Pull a binary file off a running SLM-OS instance over the shell transport.
+
+Mirror of slm-put.py for the device→host direction. Speaks the `xget-bin`
+shell protocol: handshake header gives the file size, then the kernel
+streams raw bytes (telnet IAC byte-stuffed) until done.
+
+Usage:
+    slm-get.py --host <ip> --port <port> --remote /mnt/files/foo.bin --out foo.bin
+    slm-get.py --host <ip> --port <port> --remote /mnt/files/foo.bin --out foo.bin --resume
+
+`--resume` continues a partial local file by sending the existing local
+size as the kernel-side `skip` argument.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+import sys
+import time
+
+IAC = 255
+DO = 253
+DONT = 254
+WILL = 251
+WONT = 252
+SB = 250
+SE = 240
+
+
+class TelnetShell:
+    """Telnet-over-TCP shell with IAC un-stuffing.
+
+    Mirrors slm-put.py's TelnetShell. ``buf`` holds the un-stuffed
+    payload bytes (IAC IAC collapsed back to a single 0xFF, telnet
+    option negotiations consumed and answered).
+    """
+
+    def __init__(self, host: str, port: int, prompt: bytes, timeout: float):
+        self.host = host
+        self.port = port
+        self.prompt = prompt
+        self.timeout = timeout
+        self.sock = socket.create_connection((host, port), timeout=timeout)
+        self.sock.settimeout(0.25)
+        # See slm-put.py — Nagle would otherwise sit on the last partial
+        # read window and stall the transfer near the tail.
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self.buf = bytearray()
+        self.iac_pending = bytearray()
+
+    def close(self) -> None:
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+    # --- IAC handling (identical to slm-put.py) -----------------
+    def _handle_iac(self, data: bytes, idx: int) -> int | None:
+        if idx + 1 >= len(data):
+            return None
+        cmd = data[idx + 1]
+        if cmd == IAC:
+            self.buf.append(IAC)
+            return idx + 2
+        if cmd in (DO, DONT, WILL, WONT):
+            if idx + 2 >= len(data):
+                return None
+            opt = data[idx + 2]
+            reply = bytes([IAC, WONT, opt]) if cmd in (DO, DONT) \
+                else bytes([IAC, DONT, opt])
+            self.sock.sendall(reply)
+            return idx + 3
+        if cmd == SB:
+            j = idx + 2
+            while j + 1 < len(data):
+                if data[j] == IAC and data[j + 1] == SE:
+                    return j + 2
+                j += 1
+            return None
+        return idx + 2
+
+    def _consume_telnet(self, data: bytes) -> None:
+        if self.iac_pending:
+            data = bytes(self.iac_pending) + data
+            self.iac_pending.clear()
+        i = 0
+        while i < len(data):
+            if data[i] != IAC:
+                self.buf.append(data[i])
+                i += 1
+                continue
+            next_i = self._handle_iac(data, i)
+            if next_i is None:
+                self.iac_pending.extend(data[i:])
+                break
+            i = next_i
+
+    def _recv_some(self) -> None:
+        try:
+            data = self.sock.recv(65536)
+        except socket.timeout:
+            return
+        if not data:
+            raise RuntimeError("connection closed by remote host")
+        self._consume_telnet(data)
+
+    # --- Line-mode helpers --------------------------------------
+    def read_until_prompt(self) -> bytes:
+        deadline = time.monotonic() + self.timeout
+        while True:
+            if self.prompt in self.buf:
+                prompt_idx = self.buf.rfind(self.prompt)
+                out = bytes(self.buf[:prompt_idx + len(self.prompt)])
+                del self.buf[:prompt_idx + len(self.prompt)]
+                return out
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"timed out waiting for shell prompt {self.prompt!r}"
+                )
+            self._recv_some()
+
+    def read_until_substring(self, needle: bytes,
+                             timeout: float | None = None) -> bytes:
+        """Drain bytes into ``buf`` until ``needle`` appears, then return
+        everything from buf up to and including the needle. Bytes after
+        the needle stay in buf for subsequent reads — important for
+        xget-bin since binary payload follows the `XGET-BIN ready` line
+        with no separator.
+        """
+        deadline = time.monotonic() + (timeout or self.timeout)
+        while True:
+            idx = self.buf.find(needle)
+            if idx >= 0:
+                end = idx + len(needle)
+                out = bytes(self.buf[:end])
+                del self.buf[:end]
+                return out
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"timed out waiting for {needle!r}"
+                )
+            self._recv_some()
+
+    def read_n_bytes(self, n: int, timeout: float | None = None) -> bytes:
+        """Drain exactly ``n`` un-stuffed bytes from buf, reading more
+        from the socket as needed. Used for the binary middle of the
+        xget-bin response.
+        """
+        deadline = time.monotonic() + (timeout or self.timeout)
+        while len(self.buf) < n:
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"timed out reading binary stream "
+                    f"({len(self.buf)}/{n} bytes)"
+                )
+            self._recv_some()
+        out = bytes(self.buf[:n])
+        del self.buf[:n]
+        return out
+
+    def send_line(self, line: str) -> None:
+        self.sock.sendall(line.encode("ascii") + b"\n")
+
+
+# ---------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--host", required=True,
+                   help="device hostname or IP")
+    p.add_argument("--port", type=int, default=23,
+                   help="telnet shell port (default 23)")
+    p.add_argument("--remote", required=True,
+                   help="remote file path on the device")
+    p.add_argument("--out", required=True,
+                   help="local output file path")
+    p.add_argument("--resume", action="store_true",
+                   help="resume by sending current local file size as skip")
+    p.add_argument("--prompt", default="slmos> ",
+                   help="shell prompt to detect (default 'slmos> ')")
+    p.add_argument("--timeout", type=float, default=30.0,
+                   help="per-step timeout in seconds (default 30)")
+    p.add_argument("--total-timeout", type=float, default=600.0,
+                   help="overall timeout in seconds (default 600)")
+    p.add_argument("--quiet", action="store_true",
+                   help="suppress progress output")
+    return p.parse_args()
+
+
+def format_bytes(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} {unit}"
+        n /= 1024
+    return f"{n:.1f} TB"
+
+
+def format_rate(bps: float) -> str:
+    return f"{format_bytes(int(bps))}/s"
+
+
+def main() -> int:
+    args = parse_args()
+    prompt = args.prompt.encode("ascii")
+
+    skip = 0
+    open_mode = "wb"
+    if args.resume:
+        try:
+            skip = os.path.getsize(args.out)
+            open_mode = "ab"
+        except FileNotFoundError:
+            pass
+
+    sh = TelnetShell(args.host, args.port, prompt, args.timeout)
+    try:
+        # Drain any banner / negotiation up to first prompt.
+        sh.read_until_prompt()
+
+        # Send the command.
+        cmd = f"xget-bin {args.remote}"
+        if skip > 0:
+            cmd += f" {skip}"
+        sh.send_line(cmd)
+
+        # Wait for either an error line or the ready header. Errors
+        # before ready start with "xget-bin:" or "XGET-BIN err".
+        # We read until newline first to see what we got.
+        deadline = time.monotonic() + args.timeout
+        header_line = None
+        while header_line is None:
+            if time.monotonic() >= deadline:
+                raise RuntimeError("timed out waiting for xget-bin header")
+            sh._recv_some()
+            for marker in (b"\nXGET-BIN ready size=", b"\nXGET-BIN err",
+                           b"\nxget-bin:"):
+                idx = sh.buf.find(marker)
+                if idx >= 0:
+                    # Find end-of-line for this marker.
+                    eol = sh.buf.find(b"\n", idx + 1)
+                    if eol < 0:
+                        continue  # need more bytes
+                    line = bytes(sh.buf[idx + 1:eol]).rstrip(b"\r")
+                    del sh.buf[:eol + 1]
+                    header_line = line
+                    break
+
+        if not header_line.startswith(b"XGET-BIN ready size="):
+            print(f"error: {header_line.decode('ascii', 'replace')}",
+                  file=sys.stderr)
+            return 1
+
+        total_str = header_line[len(b"XGET-BIN ready size="):]
+        try:
+            total = int(total_str)
+        except ValueError:
+            print(f"bad header: {header_line!r}", file=sys.stderr)
+            return 1
+
+        if skip > total:
+            print(f"local size {skip} > remote size {total}; "
+                  f"refusing to resume", file=sys.stderr)
+            return 1
+
+        to_read = total - skip
+        if not args.quiet:
+            print(f"xget-bin {args.remote}: total={format_bytes(total)} "
+                  f"skip={format_bytes(skip)} to_read={format_bytes(to_read)}",
+                  file=sys.stderr)
+
+        # Stream binary bytes into the output file.
+        t0 = time.monotonic()
+        last_report = t0
+        chunk = 65536
+        received = 0
+        with open(args.out, open_mode) as fh:
+            while received < to_read:
+                want = min(chunk, to_read - received)
+                data = sh.read_n_bytes(want, timeout=args.total_timeout)
+                fh.write(data)
+                received += len(data)
+                now = time.monotonic()
+                if not args.quiet and (now - last_report) > 0.5:
+                    elapsed = now - t0 or 1e-6
+                    rate = received / elapsed
+                    pct = 100.0 * received / max(to_read, 1)
+                    print(f"  {format_bytes(received)}/{format_bytes(to_read)} "
+                          f"({pct:5.1f}%) {format_rate(rate)}",
+                          file=sys.stderr)
+                    last_report = now
+
+        # Trailer: "XGET-BIN done size=<total>\r\n"
+        trailer = sh.read_until_substring(b"XGET-BIN done size=",
+                                          timeout=args.timeout)
+        # Drain to end-of-line so the prompt comes cleanly next.
+        sh.read_until_substring(b"\n", timeout=args.timeout)
+        if not trailer.endswith(b"XGET-BIN done size="):
+            print(f"warning: unexpected trailer: {trailer!r}",
+                  file=sys.stderr)
+
+        elapsed = time.monotonic() - t0 or 1e-6
+        rate = received / elapsed
+        if not args.quiet:
+            print(f"done: {format_bytes(received)} in {elapsed:.2f}s "
+                  f"({format_rate(rate)})", file=sys.stderr)
+        return 0
+
+    finally:
+        sh.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Symmetric counterpart to \`xput-bin\` for the device→host direction. Streams a file's raw bytes back over the current shell session's TCP transport with telnet IAC stuffing, no hex encoding, no per-byte shell parse.

Resolves the \"how do I get binary data off SLM-OS at wire speed?\" gap that surfaced during camera-frame debugging — without it, getting a 47 KB image off the device required hex-printing it over serial (~5 s wire + minutes of context-window thrashing on the host side). With xget-bin it's one labctl-blessed command.

## Wire protocol

```
client:  xget-bin <path> [skip]\n
kernel:  XGET-BIN ready size=<total>\r\n
kernel:  <total - skip> raw bytes (with 0xFF doubled per RFC 854)
kernel:  XGET-BIN done size=<total>\r\n
```

On error before the data stream begins, prints \`xget-bin: ...\` and returns -1 — no \`XGET-BIN ready\` was sent so the client knows nothing came. On error mid-stream prints \`XGET-BIN err sent=N reason=...\\r\\n\`.

Single-flight guard mirrors xput-bin. Optional \`skip\` arg supports resuming an interrupted download.

## New surface

- **shell_io vtable**: optional \`write_raw(io, buf, len)\` for binary-safe writes (bypasses CR-LF expansion). TCP backend implements it with IAC stuffing; UART falls through to plain \`write\`.
- **shell.h**: \`shell_session_write_raw(buf, len)\` — session-level wrapper. NULL-safe for backends without write_raw.
- **shell_fs.c**: \`cmd_xget_bin\` itself.
- **shell.c command table** + help text + internal prototype.

## Host tool

\`scripts/tools/slm-get.py\` mirrors slm-put.py's TelnetShell pattern — connect, send \`xget-bin\`, parse the ready header, drain N bytes through the IAC-unstuffing receive buffer, write to local file. Supports \`--resume\`.

## Hardware verification (jetson-nano-1)

Round-trip a small text file:

\`\`\`
$ python3 scripts/tools/slm-get.py --host 192.168.4.100 --port 2323 \\
      --remote /mnt/files/demo.lua --out /tmp/demo.lua
xget-bin /mnt/files/demo.lua: total=7.9 KB skip=0 B to_read=7.9 KB
done: 7.9 KB in 0.03s (290.8 KB/s)

$ cmp /tmp/demo.lua scripts/demo.lua && echo BYTE-IDENTICAL
BYTE-IDENTICAL
\`\`\`

Round-trip a file with 0xFF bytes (IAC stuffing test) — wrote \`00ff80ffaaffff7fff5500ff\`, got back identical including the consecutive \`ffff\` pair:

\`\`\`
00000000: 00ff 80ff aaff ff7f ff55 00ff            .........U..
\`\`\`

## Test plan

- [x] \`make test\` passes (existing \`test_builtin_commands_grouped_and_sorted\` caught the alphabetization between xget-bin / xput / xput-bin within the FILESYSTEM category)
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` builds clean
- [x] Hardware round-trip verified: text + binary-with-0xFF, both byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)