### PR TITLE
ga10b: post-kexec channel-inherit infrastructure for #834

### DIFF
--- a/host-tools/gsp-harness/test_ga10b_bringup.c
+++ b/host-tools/gsp-harness/test_ga10b_bringup.c
@@ -1072,6 +1072,28 @@ static void test_handoff_validate_missing_doorbell_token(void)
     REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
 }
 
+/* Stale handoffs left in DRAM by prior helper runs that hit one of
+ * the FECS-read failure modes (priv-locked, target=0, /dev/mem
+ * errors) have a zero `inst_block_phys`. The scanner used to return
+ * the first such match by phys address, masking newer fresh handoffs
+ * with a usable inst block written at a higher phys. The validator
+ * now rejects inst_block_phys=0 so the scanner skips past the stale
+ * candidate.
+ *
+ * Observed on jetson-nano-2 (2026-05-16): stale handoff at
+ * 0x1159fa000 (v6, magic GPUH, inst_block_phys=0) was found before
+ * the fresh handoff at 0x13adcc000, causing `nvgpu oplib stage`
+ * to fall all the way through to "no handoff and FECS_CURRENT_CTX
+ * read failed" even though the helper had successfully published. */
+static void test_handoff_validate_stale_zero_inst_block_rejected(void)
+{
+    printf("== test_handoff_validate_stale_zero_inst_block_rejected ==\n");
+    struct ga10b_channel_handoff h;
+    fill_valid_handoff(&h);
+    h.inst_block_phys = 0;
+    REQUIRE_EQ(ga10b_validate_handoff(&h), -1);
+}
+
 /* ======================================================================
  * Phase 7 SEMAPHORE_RELEASE pushbuffer builder
  *
@@ -1284,7 +1306,7 @@ static void test_compute_sema_release_pb_layout(void)
     uint32_t payload = 0x0000CAFEu;
 
     uint32_t dwords = ga10b_build_compute_sema_release_pushbuffer(
-        pb, sem_va, payload);
+        pb, sem_va, payload, /* flags */ 0u);
     REQUIRE_EQ(dwords, GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS);
 
     /* First pair: SET_OBJECT on subch 1 binding AMPERE_COMPUTE_B.
@@ -1329,7 +1351,8 @@ static void test_compute_sema_release_pb_truncates_va_upper(void)
      * the builder — else a 64-bit pointer with live upper bits would
      * get smuggled into the address register. */
     uint64_t sem_va = 0x1234567890000000ULL;
-    ga10b_build_compute_sema_release_pushbuffer(pb, sem_va, 0x11u);
+    ga10b_build_compute_sema_release_pushbuffer(pb, sem_va, 0x11u,
+                                                /* flags */ 0u);
 
     REQUIRE_EQ(pb[7], 0x90000000u);   /* ADDRESS_LOWER = VA[31:0] */
     REQUIRE_EQ(pb[9], 0x00000078u);   /* ADDRESS_UPPER = VA[39:32] only */
@@ -1341,13 +1364,46 @@ static void test_compute_sema_release_pb_zero_payload(void)
     uint32_t pb[GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS];
     memset(pb, 0xAB, sizeof(pb));
 
-    ga10b_build_compute_sema_release_pushbuffer(pb, 0x2000000000ULL, 0u);
+    ga10b_build_compute_sema_release_pushbuffer(pb, 0x2000000000ULL, 0u,
+                                                /* flags */ 0u);
     REQUIRE_EQ(pb[0],  EXPECT_INC_HDR(1, 1, 0x00u));    /* SET_OBJECT (subch 1) unchanged */
     REQUIRE_EQ(pb[1],  GA10B_AMPERE_COMPUTE_B_CLASS_ID); /* class unchanged */
     REQUIRE_EQ(pb[3],  0u);                             /* zero payload */
     REQUIRE_EQ(pb[7],  0x00000000u);                    /* VA[31:0] */
     REQUIRE_EQ(pb[9],  0x00000020u);                    /* VA[39:32] = 0x20 */
     REQUIRE_EQ(pb[11], 0x00000008u);                    /* EXECUTE unchanged */
+}
+
+/* #838: FLUSH_DISABLE flag flips bit 5 of the EXECUTE word. The
+ * pre-launch diagnostic sema in `ga10b_dispatch_v7_pipeline_inline`
+ * sets this so the host engine fires the release as soon as it
+ * processes the method (no GR-drain wait). All other PB bytes
+ * (SET_OBJECT, payload writes, address writes, EXECUTE-header) stay
+ * byte-identical to the default flags=0 encoding. */
+static void test_compute_sema_release_pb_flush_disable_flag(void)
+{
+    printf("== test_compute_sema_release_pb_flush_disable_flag ==\n");
+    uint32_t pb_default[GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS];
+    uint32_t pb_flush[GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS];
+
+    uint64_t sem_va  = 0x1ffc010000ULL;
+    uint32_t payload = 0xCAFEBABEu;
+
+    ga10b_build_compute_sema_release_pushbuffer(pb_default, sem_va, payload,
+                                                /* flags */ 0u);
+    ga10b_build_compute_sema_release_pushbuffer(pb_flush,   sem_va, payload,
+                                                GA10B_SEMA_FLUSH_DISABLE);
+
+    /* Every dword except pb[11] (EXECUTE bits) is identical. */
+    for (int i = 0; i < 11; i++) {
+        REQUIRE_EQ(pb_default[i], pb_flush[i]);
+    }
+
+    /* Default: OPERATION_RELEASE(0) | STRUCTURE_SIZE_ONE_WORD(1<<3)
+     *        = 0x08. */
+    REQUIRE_EQ(pb_default[11], 0x00000008u);
+    /* FLUSH_DISABLE: above bits + bit 5 (0x20) = 0x28. */
+    REQUIRE_EQ(pb_flush[11],   0x00000028u);
 }
 
 /* ======================================================================
@@ -3188,6 +3244,7 @@ int main(void)
     test_handoff_validate_null_addresses();
     test_handoff_validate_gpfifo_entries();
     test_handoff_validate_missing_doorbell_token();
+    test_handoff_validate_stale_zero_inst_block_rejected();
 
     test_next_gp_put_wraps_at_ring_boundary();
 
@@ -3200,6 +3257,7 @@ int main(void)
     test_compute_sema_release_pb_layout();
     test_compute_sema_release_pb_truncates_va_upper();
     test_compute_sema_release_pb_zero_payload();
+    test_compute_sema_release_pb_flush_disable_flag();
 
     test_launch_kernel_pb_layout();
     test_launch_kernel_pb_qmd_shift_lower();

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -253,8 +253,9 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 #define NVC7C0_REPORT_SEMAPHORE_EXECUTE             0x0168u
 
 /* REPORT_SEMAPHORE_EXECUTE fields */
-#define NVC7C0_SEM_EXECUTE_OP_RELEASE               0x0u   /* bits [1:0] */
+#define NVC7C0_SEM_EXECUTE_OP_RELEASE               0x0u       /* bits [1:0] */
 #define NVC7C0_SEM_EXECUTE_STRUCTURE_SIZE_ONE_WORD  (1u << 3)  /* bits [4:3] */
+#define NVC7C0_SEM_EXECUTE_FLUSH_DISABLE_TRUE       (1u << 5)  /* bit 5 */
 
 /* ---- COMPUTE_B compute-kernel launch methods --------------------
  * Used by ga10b_bringup_launch_kernel (Phase 8). Offsets from
@@ -1265,6 +1266,29 @@ int ga10b_validate_handoff(const struct ga10b_channel_handoff *h)
     if (h->userd_phys == 0 || h->gpfifo_phys == 0 ||
         h->pushbuf_phys == 0 || h->semaphore_phys == 0) return -1;
     if (h->work_submit_token == 0) return -1;
+    /* `inst_block_phys` must be non-zero. Every v2+ helper sets this
+     * via `gpu_read_fecs_inst_block_phys()` in gpu-launch-common.c;
+     * the field is 0 only when the helper's FECS read failed (priv-
+     * locked, target=0, /dev/mem open/mmap error). A handoff with
+     * inst_block_phys=0 carries no GMMU root, so SLM-OS's rebuild-
+     * gmmu path can't find Linux's page tables — `nvgpu oplib stage`
+     * gives up after falling through to a stale live FECS read.
+     *
+     * Crucially, this rejection also lets `ga10b_find_handoff_of_
+     * kind_in_range` skip past STALE handoffs left behind in DRAM by
+     * prior helper invocations. The scanner finds the first magic+
+     * kind match by address; if an older helper run wrote a struct
+     * at a lower physical address with inst_block_phys=0 (FECS read
+     * failed at that time, common on cold-boot races), and a newer
+     * run wrote a usable handoff at a higher address, the scanner
+     * used to return the stale one. With this check the validator
+     * rejects the stale candidate and the scanner advances to the
+     * fresh one. Observed on jetson-nano-2 (2026-05-16): stale
+     * handoff at 0x1159fa000 was masking the fresh helper handoff
+     * at 0x13adcc000, leaving SLM-OS unable to find any usable
+     * channel — `oplib stage` reported "no handoff and
+     * FECS_CURRENT_CTX read failed". */
+    if (h->inst_block_phys == 0) return -1;
     /* gpfifo_entries must be a non-zero power of two. */
     if (h->gpfifo_entries == 0 ||
         (h->gpfifo_entries & (h->gpfifo_entries - 1)) != 0) return -1;
@@ -1499,6 +1523,24 @@ int ga10b_bringup_channel_kind(struct ga10b_bringup *b, uint32_t wanted_kind)
                 (unsigned long)g_handoff.initial_gp_get);
 
     uart_puts("[GA10B-P6] channel handoff valid — inherited from Linux\n");
+
+    /* #834: an earlier iteration of this code (reverted) invoked
+     * `ga10b_fecs_method_push(STOP_CTXSW); _push(START_CTXSW);`
+     * here, based on a one-boot success that turned out to be
+     * unreliable. Multi-boot hardware testing (jetson-nano-2,
+     * 2026-05-16) showed the STOP/START sequence reports mb0=PASS
+     * on both methods but does NOT consistently unblock compute
+     * dispatch — about half of fresh kexec boots still hit the
+     * CTXSW_CHECKSUM_MISMATCH watchdog on first submit-compute
+     * even after the unstick.
+     *
+     * The probe still lives as `nvgpu fecs-stop-restart` for
+     * diagnostic use, but it is NOT a reliable automatic fix
+     * for the #834 W-series wedge. A deeper recovery sequence
+     * (likely involving runlist preempt + GR engine reset + the
+     * full channel-recovery path nvgpu uses) is needed before
+     * any auto-invocation here. */
+
     b->state = GA10B_BRINGUP_CHANNEL_OPEN;
     return 0;
 }
@@ -1597,7 +1639,8 @@ uint32_t ga10b_build_sema_release_pushbuffer(uint32_t *pb,
 
 uint32_t ga10b_build_compute_sema_release_pushbuffer(uint32_t *pb,
                                                      uint64_t sem_gpu_va,
-                                                     uint32_t payload)
+                                                     uint32_t payload,
+                                                     uint32_t flags)
 {
     /* First pair: SET_OBJECT binding AMPERE_COMPUTE_B to subch 1.
      *
@@ -1627,8 +1670,12 @@ uint32_t ga10b_build_compute_sema_release_pushbuffer(uint32_t *pb,
     pb[8]  = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_SET_REPORT_SEMAPHORE_ADDRESS_UPPER);
     pb[9]  = (uint32_t)((sem_gpu_va >> 32) & 0xFFu);
     pb[10] = NVC56F_METHOD_HEADER_INC(1, 1, NVC7C0_REPORT_SEMAPHORE_EXECUTE);
-    pb[11] = NVC7C0_SEM_EXECUTE_OP_RELEASE |
-             NVC7C0_SEM_EXECUTE_STRUCTURE_SIZE_ONE_WORD;
+    uint32_t execute_bits = NVC7C0_SEM_EXECUTE_OP_RELEASE |
+                            NVC7C0_SEM_EXECUTE_STRUCTURE_SIZE_ONE_WORD;
+    if (flags & GA10B_SEMA_FLUSH_DISABLE) {
+        execute_bits |= NVC7C0_SEM_EXECUTE_FLUSH_DISABLE_TRUE;
+    }
+    pb[11] = execute_bits;
     return GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS;
 }
 
@@ -2023,6 +2070,112 @@ static void dump_one_inst_block(const char *tag, uint64_t inst_phys)
     if (hits == 0) {
         uart_printf("[%s]  (no 0xc01000-encoded matches)\n", tag);
     }
+}
+
+/* Public wrapper around `dump_one_inst_block` for callers that
+ * already know the inst-block phys (e.g. ga10b_gmmu_rebuild_for_
+ * handoff post-write). Skips the FECS_CURRENT_CTX / fault-inst
+ * latch in `ga10b_dump_inst_blocks_atomic`. */
+void ga10b_dump_inst_block_at(const char *tag, uint64_t inst_phys)
+{
+    dump_one_inst_block(tag, inst_phys);
+}
+
+/* #834: submit a FECS method via the standard data+push protocol.
+ * Used for STOP_CTXSW / START_CTXSW / golden-image methods that
+ * Linux's nvgpu issues during ctxsw recovery.
+ *
+ * Protocol per gm20b_gr_falcon (the canonical reference; ga10b
+ * inherits the layout):
+ *   1. Clear mailbox 0 via `gr_fecs_ctxsw_mailbox_clear_r(0)`
+ *      (= 0x00409840 — gv11b/ga10b same offset). Writing
+ *      0xFFFFFFFF clears all bits of mailbox 0 to zero.
+ *   2. Write `data` to `gr_fecs_method_data_r()` (0x00409500).
+ *   3. Write `addr & 0xFFF` to `gr_fecs_method_push_r()`
+ *      (0x00409504). FECS picks up the method.
+ *   4. Poll mailbox 0 (0x00409800) for `expected_mb0` (typically
+ *      PASS = 0x1). Fail value 0x2 also exits early.
+ *
+ * Returns 0 on PASS match, -1 on timeout or FAIL. */
+int ga10b_fecs_method_push(uint32_t method_addr, uint32_t method_data,
+                           uint32_t expected_mb0)
+{
+    bar0_w32(0x00409840u, 0xFFFFFFFFu);  /* mailbox_clear_r(0) */
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    bar0_w32(0x00409500u, method_data);
+    bar0_w32(0x00409504u, method_addr & 0xFFFu);
+    __asm__ volatile("dsb sy" ::: "memory");
+
+    /* Empirical timeout: ~1 ms FECS round-trip for STOP_CTXSW per
+     * nvgpu source comments. 1M iterations is generous; tighten if
+     * needed later. Each iteration is one MMIO read (~100 ns on
+     * Tegra), so loop bound ≈ 100 ms wall time. */
+    uint32_t mb0 = 0;
+    int hit = 0;
+    for (uint32_t i = 0; i < 1000000u; i++) {
+        mb0 = bar0_r32(0x00409800u);
+        if (mb0 == expected_mb0) { hit = 1; break; }
+        if (mb0 == 0x2u) break;  /* FAIL */
+    }
+
+    uart_printf("[fecs-push] addr=0x%x data=0x%08lx mb0=0x%08lx %s\n",
+                (unsigned)method_addr,
+                (unsigned long)method_data,
+                (unsigned long)mb0,
+                hit ? "OK" : "TIMEOUT_OR_FAIL");
+    return hit ? 0 : -1;
+}
+
+/* #834 experiment: write our channel's inst block phys into
+ * `gr_fecs_new_ctx_r()` (0x00409b04) so FECS knows the "next"
+ * channel ahead of any submit-compute ctxsw.
+ *
+ * Background: on a post-kexec boot, FECS_CURRENT_CTX may point at
+ * an invalid (PDB=0) inst block left over from Linux's nvgpu
+ * tear-down. When PBDMA later schedules our channel for GR work,
+ * FECS tries to save the current (invalid) context first — which
+ * watchdogs out (gr_intr=0x80000, fecs_host_int=0x80001 watchdog +
+ * ctxsw_intr=1, ctxsw_mb6=0x21).
+ *
+ * Writing `gr_fecs_new_ctx` with our channel's inst phys is the
+ * Volta+/Ampere replacement for the gm20b BIND sequence — it tells
+ * FECS "the next channel to load is THIS one". Pre-ctxsw the
+ * arbiter latches this into CURRENT_CTX; post-ctxsw, the bad
+ * Linux state is gone.
+ *
+ * Returns 0 on success, -1 on bad input. Tegra GA10B PDB targets
+ * sys_mem_ncoh (encoded as target=3 in the new_ctx register's
+ * bits[29:28]; the valid bit is bit 31). */
+int ga10b_fecs_set_new_ctx(uint64_t inst_block_phys)
+{
+    if (inst_block_phys == 0) return -1;
+    if ((inst_block_phys & 0xFFFu) != 0) return -1;  /* page-aligned */
+
+    uint32_t inst_ptr_u32 = (uint32_t)(inst_block_phys >> 12);
+    /* bits[27:0]   = inst_phys[39:12]
+     * bits[29:28]  = target (3 = sys_mem_ncoh on Tegra)
+     * bit 31       = valid */
+    uint32_t new_ctx = inst_ptr_u32 | (3u << 28) | (1u << 31);
+
+    /* Latch current value for comparison + diagnostics. */
+    uint32_t before = bar0_r32(0x00409b04u);
+    bar0_w32(0x00409b04u, new_ctx);
+    __asm__ volatile("dsb sy" ::: "memory");
+    uint32_t after = bar0_r32(0x00409b04u);
+    uint32_t current_ctx = bar0_r32(0x00409b00u);
+
+    uart_printf("[fecs-newctx] new_ctx_r(0x409b04): 0x%08lx -> 0x%08lx "
+                "(want 0x%08x for inst=0x%lx)\n",
+                (unsigned long)before, (unsigned long)after,
+                (unsigned)new_ctx, (unsigned long)inst_block_phys);
+    uart_printf("[fecs-newctx] current_ctx_r(0x409b00) post-write: "
+                "0x%08lx (decode: inst=0x%lx target=%u valid=%u)\n",
+                (unsigned long)current_ctx,
+                ((unsigned long)(current_ctx & 0x0FFFFFFFu)) << 12,
+                (unsigned)((current_ctx >> 28) & 0x3u),
+                (unsigned)((current_ctx >> 31) & 1u));
+    return 0;
 }
 
 /* Decode FECS_CURRENT_CTX and fb_mmu_fault_inst into 40-bit
@@ -2473,7 +2626,8 @@ int ga10b_bringup_smoke_test_compute(struct ga10b_bringup *b)
      * IRAM upload. No NVK-style MME init needed. */
     uint32_t pb_buf[GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS];
     uint32_t pb_dwords = ga10b_build_compute_sema_release_pushbuffer(
-        pb_buf, g_handoff.semaphore_gpu_va, GA10B_SMOKETEST_SEM_PAYLOAD);
+        pb_buf, g_handoff.semaphore_gpu_va, GA10B_SMOKETEST_SEM_PAYLOAD,
+        /* flags */ 0u);
 
     /* Phase 7 COMPUTE_B also uses the fixed payload — the shader
      * is the SEMAPHORE_RELEASE method itself, not arbitrary code. */
@@ -2587,18 +2741,19 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
         b->last_error_phase = 8;
         return -1;
     }
-    /* Capacity check: N kernel-dispatch entries + 1 trailing sema
-     * entry must fit comfortably in the GPFIFO ring AND the
-     * pushbuffer area. nvgpu reserves 2 extra entries per submit
-     * (pre/post fence); we cap at half-ring as a safety margin
-     * mirroring `check_gpfifo_capacity` (`EXTRA_GPFIFO_ENTRIES`
-     * + headroom). With the post-#601 ring of 512, that allows up
-     * to 255 ops per chain — vastly more than the ~8 a typical
-     * MNIST or sched chain requires. */
-    uint32_t total_entries = n + 1u;
+    /* Capacity check: 1 pre-launch diagnostic sema (#838) + N kernel-
+     * dispatch entries + 1 trailing sema entry must fit comfortably
+     * in the GPFIFO ring AND the pushbuffer area. nvgpu reserves 2
+     * extra entries per submit (pre/post fence); we cap at half-ring
+     * as a safety margin mirroring `check_gpfifo_capacity`
+     * (`EXTRA_GPFIFO_ENTRIES` + headroom). With the post-#601 ring
+     * of 512, that allows up to 254 ops per chain — vastly more than
+     * the ~8 a typical MNIST or sched chain requires. */
+    uint32_t total_entries = n + 2u;
     if (total_entries > (g_handoff.gpfifo_entries / 2u)) {
-        uart_printf("[GA10B-P8-v7] %lu entries (%lu ops + 1 sema) "
-                    "exceeds half-ring budget %lu (gpfifo_entries=%lu)\n",
+        uart_printf("[GA10B-P8-v7] %lu entries (1 pre-sema + %lu ops "
+                    "+ 1 post-sema) exceeds half-ring budget %lu "
+                    "(gpfifo_entries=%lu)\n",
                     (unsigned long)total_entries,
                     (unsigned long)n,
                     (unsigned long)(g_handoff.gpfifo_entries / 2u),
@@ -2612,12 +2767,13 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
     uint32_t pb_sema_bytes =
         GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS * 4u;   /* 48 */
     uint64_t total_pb_bytes =
-        (uint64_t)n * pb_kernel_bytes + pb_sema_bytes;
+        (uint64_t)n * pb_kernel_bytes + 2u * (uint64_t)pb_sema_bytes;
     if (total_pb_bytes > g_handoff.pushbuf_size) {
         uart_printf("[GA10B-P8-v7] %llu pushbuf bytes "
-                    "(%lu ops × %u + %u sema) exceeds "
-                    "pushbuf_size=%lu\n",
+                    "(%u pre-sema + %lu ops × %u + %u post-sema) "
+                    "exceeds pushbuf_size=%lu\n",
                     (unsigned long long)total_pb_bytes,
+                    (unsigned)pb_sema_bytes,
                     (unsigned long)n,
                     (unsigned)pb_kernel_bytes,
                     (unsigned)pb_sema_bytes,
@@ -2686,8 +2842,8 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
     volatile uint64_t *gpfifo =
         (volatile uint64_t *)(uintptr_t)g_handoff.gpfifo_phys;
 
-    GA10B_DBG("[GA10B-P8-v7] BULK %lu ops + 1 sema — gp_put=%lu, "
-              "pushbuf_phys=0x%lx pool_phys=0x%lx\n",
+    GA10B_DBG("[GA10B-P8-v7] BULK 1 pre-sema + %lu ops + 1 post-sema "
+              "— gp_put=%lu, pushbuf_phys=0x%lx pool_phys=0x%lx\n",
               (unsigned long)n,
               (unsigned long)gp_put_start,
               (unsigned long)pushbuf_phys,
@@ -2716,7 +2872,47 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
                     (unsigned long)opdbg->shader_size_bytes);
     }
 
-    /* Phase 1: queue all N kernel-dispatch entries. */
+    /* Phase 0: queue a PRE-LAUNCH diagnostic sema (#838). Uses
+     * FLUSH_DISABLE=1 so the host engine fires the release as soon
+     * as it processes the method — without waiting for any compute
+     * to drain. Same `sema_gpu_va` target as the post-launch sema
+     * but a distinct payload (GA10B_SEMA_PRELAUNCH_PAYLOAD = BABE);
+     * the trailing sema's RELEASE_PAYLOAD (DEAD) will overwrite it
+     * on success. The CPU poll loop below reads the final value
+     * and discriminates three cases (poll == 0 → PBDMA never
+     * reached the semas; poll == BABE → host engine alive but GR
+     * never drained; poll == DEAD → success). Removes the "did the
+     * kernel hang or did PBDMA never get there" ambiguity #844
+     * needs to advance. */
+    uint64_t pb_pre_sema_phys = pushbuf_phys;
+    uint64_t pb_pre_sema_gpu_va = pushbuf_gpu_va;
+    uint32_t *pb_pre_sema_cpu = (uint32_t *)(uintptr_t)pb_pre_sema_phys;
+    uint32_t pre_sema_pb_dwords =
+        ga10b_build_compute_sema_release_pushbuffer(
+            pb_pre_sema_cpu, sema_gpu_va,
+            GA10B_SEMA_PRELAUNCH_PAYLOAD,
+            GA10B_SEMA_FLUSH_DISABLE);
+
+    uint32_t pre_e0 = (uint32_t)(pb_pre_sema_gpu_va & 0xFFFFFFFCu);
+    uint32_t pre_e1 = (uint32_t)((pb_pre_sema_gpu_va >> 32) & 0xFFu) |
+                      (pre_sema_pb_dwords << 10);
+    uint64_t pre_sema_entry = ((uint64_t)pre_e1 << 32) | pre_e0;
+    uint32_t pre_sema_gp_idx = gp_put_start & ring_mask;
+    gpfifo[pre_sema_gp_idx] = pre_sema_entry;
+
+    GA10B_DBG("[GA10B-P8-v7]   queue pre_sema_release pb_phys=0x%lx "
+              "pb_gpu_va=0x%lx gp_idx=%lu sema_gpu_va=0x%lx "
+              "(payload=0x%x, FLUSH_DISABLE=1)\n",
+              (unsigned long)pb_pre_sema_phys,
+              (unsigned long)pb_pre_sema_gpu_va,
+              (unsigned long)pre_sema_gp_idx,
+              (unsigned long)sema_gpu_va,
+              (unsigned)GA10B_SEMA_PRELAUNCH_PAYLOAD);
+
+    /* Phase 1: queue all N kernel-dispatch entries. The kernel
+     * pushbuffer area starts AFTER the pre-launch sema's pb block. */
+    uint64_t kernel_pb_base_phys = pushbuf_phys + pb_sema_bytes;
+    uint64_t kernel_pb_base_gpu_va = pushbuf_gpu_va + pb_sema_bytes;
     for (uint32_t i = 0; i < n; i++) {
         const struct ga10b_pipeline_op_v7 *op = &ops_v7[i];
         if (!ga10b_pipeline_op_is_valid(
@@ -2744,11 +2940,12 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
 
         /* Build the dispatch-only pushbuffer at this op's slot in
          * the packed pushbuffer area. Each op gets pb_kernel_bytes
-         * of space starting at offset i * pb_kernel_bytes. */
+         * of space starting at offset i * pb_kernel_bytes (after
+         * the leading pre-sema block). */
         uint64_t pb_op_phys =
-            pushbuf_phys + (uint64_t)i * pb_kernel_bytes;
+            kernel_pb_base_phys + (uint64_t)i * pb_kernel_bytes;
         uint64_t pb_op_gpu_va =
-            pushbuf_gpu_va + (uint64_t)i * pb_kernel_bytes;
+            kernel_pb_base_gpu_va + (uint64_t)i * pb_kernel_bytes;
         uint32_t *pb_op_cpu = (uint32_t *)(uintptr_t)pb_op_phys;
         uint32_t pb_dwords = ga10b_build_launch_kernel_pushbuffer(
             pb_op_cpu, slot.gpu_va);
@@ -2756,12 +2953,13 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
         /* GPFIFO entry: 8-byte Ampere format. gp_e0 is the lower
          * 32 bits of the pushbuffer GPU VA (PCB-aligned, so bits
          * [1:0] are zero); gp_e1 holds the upper 8 bits of the VA
-         * + the pushbuffer length in dwords. */
+         * + the pushbuffer length in dwords. Slot 0 in the GPFIFO
+         * holds the pre-launch sema, so op[i] lands at slot 1+i. */
         uint32_t gp_e0 = (uint32_t)(pb_op_gpu_va & 0xFFFFFFFCu);
         uint32_t gp_e1 = (uint32_t)((pb_op_gpu_va >> 32) & 0xFFu) |
                          (pb_dwords << 10);
         uint64_t entry = ((uint64_t)gp_e1 << 32) | gp_e0;
-        uint32_t gp_idx = (gp_put_start + i) & ring_mask;
+        uint32_t gp_idx = (gp_put_start + 1u + i) & ring_mask;
         gpfifo[gp_idx] = entry;
 
         GA10B_DBG("[GA10B-P8-v7]   queue op[%lu/%lu] slot=%lu "
@@ -2783,19 +2981,21 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
      * the unambiguous "all kernels done, all outputs in DRAM"
      * signal. */
     uint64_t pb_sema_phys =
-        pushbuf_phys + (uint64_t)n * pb_kernel_bytes;
+        kernel_pb_base_phys + (uint64_t)n * pb_kernel_bytes;
     uint64_t pb_sema_gpu_va =
-        pushbuf_gpu_va + (uint64_t)n * pb_kernel_bytes;
+        kernel_pb_base_gpu_va + (uint64_t)n * pb_kernel_bytes;
     uint32_t *pb_sema_cpu = (uint32_t *)(uintptr_t)pb_sema_phys;
     uint32_t sema_pb_dwords =
         ga10b_build_compute_sema_release_pushbuffer(
-            pb_sema_cpu, sema_gpu_va, GA10B_SEMA_RELEASE_PAYLOAD);
+            pb_sema_cpu, sema_gpu_va, GA10B_SEMA_RELEASE_PAYLOAD,
+            /* flags */ 0u);
 
     uint32_t s_e0 = (uint32_t)(pb_sema_gpu_va & 0xFFFFFFFCu);
     uint32_t s_e1 = (uint32_t)((pb_sema_gpu_va >> 32) & 0xFFu) |
                     (sema_pb_dwords << 10);
     uint64_t sema_entry = ((uint64_t)s_e1 << 32) | s_e0;
-    uint32_t sema_gp_idx = (gp_put_start + n) & ring_mask;
+    /* Post-sema lands AFTER (1 pre-sema + n kernel entries). */
+    uint32_t sema_gp_idx = (gp_put_start + 1u + n) & ring_mask;
     gpfifo[sema_gp_idx] = sema_entry;
 
     GA10B_DBG("[GA10B-P8-v7]   queue sema_release pb_phys=0x%lx "
@@ -2862,6 +3062,19 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
     *doorbell = g_handoff.work_submit_token;
     gsp_platform->mb();
 
+    /* #844 NOTE: internal doorbell at 0x17c00090 ring tested with
+     * SET_CHANNEL_INFO encoded as hw_chid=508 (=0x01fc0100) AND
+     * the existing CHRAM[508] + engine_wfi/eng_method_buffer
+     * clears. STILL hits GR-poison 0xbadf1002 during ctxsw, so
+     * SET_CHANNEL_INFO isn't the last missing piece. Most
+     * likely remaining: stale Linux subcontext PDB entries at
+     * inst[168 + 4*veid] for veids ≠ our VEID (= 1) and
+     * Linux's pdb_valid_long bits for those other VEIDs in
+     * inst[166]/[167]. When GR loads our channel it might
+     * iterate subcontexts and dereference Linux's stale PDB
+     * pointers. Next iteration: zero subcontext entries for
+     * veids 0, 2, 3, …, 63 and re-test. */
+
     GA10B_DBG("[GA10B-P8-v7] doorbell rung — polling for sema "
               "(2s timeout)\n");
 
@@ -2916,23 +3129,72 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
         return 0;
     }
 
-    /* Diagnostic on timeout: discriminate "PBDMA didn't see our
-     * submit at all" (gp_get unchanged) from "PBDMA consumed
-     * entries but the trailing sema didn't fire" (gp_get advanced
-     * but poll_val never landed). The second case usually means
-     * one of the kernel dispatches faulted internally; re-run with
-     * `gpu debug on` to see per-op QMD/pb authoring traces. */
-    if (final_gp_get != prev_gp_get) {
+    /* Diagnostic on timeout (#838 three-way discriminator):
+     *
+     *   final_gp_get == prev_gp_get  → PBDMA never advanced. Channel
+     *                                   isn't scheduled (runlist?),
+     *                                   doorbell write got lost, or
+     *                                   PBDMA is stalled.
+     *
+     *   poll_val == 0                → PBDMA advanced but the host
+     *                                   engine NEVER processed either
+     *                                   sema. Methods aren't reaching
+     *                                   the compute engine — subch /
+     *                                   class binding wrong, GR not
+     *                                   loaded for this channel, etc.
+     *
+     *   poll_val == PRELAUNCH (BABE) → host engine alive (pre-sema
+     *                                   with FLUSH_DISABLE=1 fired)
+     *                                   but the post-sema waiting
+     *                                   for GR drain never fired —
+     *                                   compute kernel hangs in
+     *                                   SMs without latching a GR
+     *                                   exception. Classic #844 /
+     *                                   QMD or SASS problem.
+     *
+     *   poll_val == RELEASE (DEAD)   → unreachable here (would have
+     *                                   broken out of the poll above).
+     *
+     *   any other value              → wild bug: sema_gpu_va is
+     *                                   mapping to memory some other
+     *                                   agent writes to. */
+    if (final_gp_get == prev_gp_get) {
         uart_printf("[GA10B-P8-v7] BULK poll timeout — PBDMA "
-                    "advanced (GP_GET %lu → %lu) but sema didn't "
-                    "fire (poll=0x%lx, want 0x%x)\n",
-                    (unsigned long)prev_gp_get,
+                    "didn't see our submits (GP_GET still %lu, "
+                    "poll=0x%lx)\n",
                     (unsigned long)final_gp_get,
-                    (unsigned long)poll_val,
-                    (unsigned)GA10B_SEMA_RELEASE_PAYLOAD);
-    } else {
+                    (unsigned long)poll_val);
+    } else if (poll_val == 0u) {
         uart_printf("[GA10B-P8-v7] BULK poll timeout — PBDMA "
-                    "didn't see our submits (GP_GET still %lu)\n",
+                    "advanced (GP_GET %lu → %lu) but NEITHER sema "
+                    "fired (poll=0x0). Host engine never processed "
+                    "either pre-sema (FLUSH_DISABLE=1) or post-sema "
+                    "— methods aren't reaching the compute engine "
+                    "(subch/class binding, GR-not-loaded, etc.)\n",
+                    (unsigned long)prev_gp_get,
+                    (unsigned long)final_gp_get);
+    } else if (poll_val == GA10B_SEMA_PRELAUNCH_PAYLOAD) {
+        uart_printf("[GA10B-P8-v7] BULK poll timeout — pre-sema "
+                    "FIRED (poll=0x%lx == PRELAUNCH 0xCAFEBABE) "
+                    "but post-sema did NOT (want 0x%x). Host "
+                    "engine is alive; compute kernel hangs in SMs "
+                    "without draining GR. See #844 — investigate "
+                    "QMD content / SASS / cbuf layout. "
+                    "(GP_GET %lu → %lu)\n",
+                    (unsigned long)poll_val,
+                    (unsigned)GA10B_SEMA_RELEASE_PAYLOAD,
+                    (unsigned long)prev_gp_get,
+                    (unsigned long)final_gp_get);
+    } else {
+        uart_printf("[GA10B-P8-v7] BULK poll timeout — UNEXPECTED "
+                    "poll value 0x%lx (want 0x%x or PRELAUNCH 0x%x "
+                    "or 0). sema_gpu_va may be mis-mapped or some "
+                    "other agent is writing to the sema page. "
+                    "(GP_GET %lu → %lu)\n",
+                    (unsigned long)poll_val,
+                    (unsigned)GA10B_SEMA_RELEASE_PAYLOAD,
+                    (unsigned)GA10B_SEMA_PRELAUNCH_PAYLOAD,
+                    (unsigned long)prev_gp_get,
                     (unsigned long)final_gp_get);
     }
     ga10b_dump_gr_state("GA10B-P8-v7");

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -248,6 +248,27 @@ bool ga10b_dispatch_verbose_get(void);
  * post-mortem inspection after the channel has been latched dead. */
 void ga10b_dump_inst_blocks_atomic(const char *tag);
 
+/* Dump a 4 KB inst block from a known phys, prefixed with `tag`.
+ * Skips the FECS_CURRENT_CTX / fb_mmu_fault_inst latch — useful
+ * for callers that already have the inst-block phys in hand (e.g.
+ * ga10b_gmmu_rebuild_for_handoff post-write). Same DRAM bounds
+ * check + pointer-scan-for-fault-VA logic as the atomic dumper. */
+void ga10b_dump_inst_block_at(const char *tag, uint64_t inst_phys);
+
+/* #834: write the channel's inst block phys into `gr_fecs_new_ctx_r()`
+ * (0x00409b04) so FECS treats it as the "next" channel to load on
+ * any subsequent ctxsw. Companion shell verb: `nvgpu fecs-newctx`.
+ * Returns 0 on success, -1 if `inst_block_phys` is zero or not
+ * page-aligned. */
+int ga10b_fecs_set_new_ctx(uint64_t inst_block_phys);
+
+/* #834: submit a FECS method via the standard data+push protocol.
+ * Clears mailbox 0, writes method data + push address, polls mb0
+ * for `expected_mb0` (typically `gr_fecs_ctxsw_mailbox_value_pass_v`
+ * = 0x1). Returns 0 on PASS, -1 on TIMEOUT / FAIL. */
+int ga10b_fecs_method_push(uint32_t method_addr, uint32_t method_data,
+                           uint32_t expected_mb0);
+
 /* Phase 7: Submit host-family SEMAPHORE_RELEASE as smoke test.
  * Returns 0 iff the semaphore is observed at its target VA within
  * timeout. PBDMA-decoded; bypasses GR. */
@@ -303,6 +324,14 @@ uint32_t ga10b_build_sema_release_pushbuffer(uint32_t *pb,
  * name rather than a bare literal. */
 #define GA10B_AMPERE_COMPUTE_B_CLASS_ID  0xC7C0u
 
+/* Flags for `ga10b_build_compute_sema_release_pushbuffer`. */
+#define GA10B_SEMA_FLUSH_DISABLE   (1u << 0)  /* bit 5 of NVC7C0_REPORT_-
+                                                * SEMAPHORE_EXECUTE — fire
+                                                * immediately when the host
+                                                * engine processes the
+                                                * method, do NOT wait for
+                                                * GR pipeline drain. */
+
 /* Phase 7 pushbuffer builder — compute-class variant (pure logic).
  *
  * Writes GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS dwords to `pb`,
@@ -323,12 +352,23 @@ uint32_t ga10b_build_sema_release_pushbuffer(uint32_t *pb,
  *      [4:3] that must be SEMAPHORE_ONE_WORD (1<<3) for a 32-bit
  *      payload.
  *
+ * `flags` controls optional EXECUTE bits. `0` = the historical
+ * "wait for compute drain then release" behavior (FLUSH_DISABLE=0).
+ * `GA10B_SEMA_FLUSH_DISABLE` flips bit 5 of EXECUTE so the host
+ * engine fires the release as soon as it processes the method —
+ * used by the pre-launch diagnostic sema in
+ * `ga10b_dispatch_v7_pipeline_inline` (#838) to discriminate "host
+ * engine never reached the sema entries" (poll == 0) from "host
+ * engine fired pre-sema but GR never drained" (poll ==
+ * GA10B_SEMA_PRELAUNCH_PAYLOAD).
+ *
  * **Buffer contract:** `pb` must point to at least
  * GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS uint32_t slots. Returns the
  * dword count (always GA10B_COMPUTE_SEMA_RELEASE_PB_DWORDS). */
 uint32_t ga10b_build_compute_sema_release_pushbuffer(uint32_t *pb,
                                                      uint64_t sem_gpu_va,
-                                                     uint32_t payload);
+                                                     uint32_t payload,
+                                                     uint32_t flags);
 
 /* Submit a prebuilt pushbuffer through the inherited channel and poll
  * the semaphore at `poll_phys` for `expected_payload`. Drives the
@@ -440,6 +480,32 @@ uint32_t ga10b_build_launch_kernel_pushbuffer(uint32_t *pb,
  * Pre-cleared to zero each iteration, so any reasonable non-zero
  * sentinel works — picked something distinctive for trace clarity. */
 #define GA10B_SEMA_RELEASE_PAYLOAD         0xCAFEDEADu
+
+/* Payload written by the optional pre-launch diagnostic sema in
+ * `ga10b_dispatch_v7_pipeline_inline` (#838). The pre-launch sema
+ * uses FLUSH_DISABLE=1 so it fires immediately when the host engine
+ * processes its method — without waiting for any compute to drain.
+ * Both pre- and post-launch semas target the same sema_gpu_va so a
+ * single CPU poll discriminates:
+ *
+ *   poll == 0                    → host engine never processed the
+ *                                  pre-sema → PBDMA stuck or method
+ *                                  routing broken (subch / class
+ *                                  binding wrong, runlist not
+ *                                  binding the channel, etc.)
+ *   poll == PRELAUNCH (BABE)     → host engine alive, pre-sema fired,
+ *                                  but the post-sema never did → GR
+ *                                  never drained → compute kernel
+ *                                  hangs without latching a fault
+ *                                  (#844: TPC/SM internal stall or
+ *                                  bad QMD).
+ *   poll == RELEASE_PAYLOAD (DEAD) → success path: pre-sema's BABE
+ *                                  was overwritten by post-sema's
+ *                                  DEAD after the kernel drained.
+ *
+ * The two payloads are distinct, non-zero, and pattern-recognisable
+ * in serial captures. */
+#define GA10B_SEMA_PRELAUNCH_PAYLOAD       0xCAFEBABEu
 
 /* Builder for the launch-kernel-with-semaphore pushbuffer. Same QMD
  * dispatch as ga10b_build_launch_kernel_pushbuffer, with a trailing

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -26,6 +26,7 @@
 #include "../../include/pmm.h"
 #include "../../include/string.h"
 #include "../../include/timer.h"
+#include "../../include/vmm.h"      /* vmm_map_region, VMM_FLAG_* */
 
 #include <stdint.h>
 #include <stddef.h>
@@ -186,6 +187,32 @@ static void decode_dual_pde_small(uint64_t entry,
     *out_next_phys = lo << 12;
 }
 
+/* Decode the big-page half of a dual PDE (PDE0). Layout per nvgpu's
+ * `gmmu_new_dual_pde_*_big_*_f()` encoders:
+ *   bits[2:0]   = aperture (0=invalid, 2=vid, 4=sys_coh, 6=sys_ncoh)
+ *   bit 3       = volatile
+ *   bits[31:4]  = big_addr = (phys_of_big_PT >> 8) — 28 bits
+ *   pde_v[1][7:0] = high byte of big_addr (extends to ~36 bits of phys)
+ *
+ * Phys reconstruction: phys = ((hi_byte << 28) | low_28_bits) << 8.
+ *
+ * This decoder is used when our walker reads the FIRST 8 bytes of a
+ * 16-byte dual PDE entry (offset 0..7 in the entry) — that's the
+ * big-page child. For 64-KB big-page mappings (the helper's default
+ * for pushbuf/sem/qmd_pool/shaders), this is the correct half. */
+static void decode_dual_pde_big(uint64_t entry,
+                                uint64_t *out_next_phys,
+                                uint8_t *out_aperture,
+                                bool *out_valid)
+{
+    uint8_t aperture = (uint8_t)(entry & 0x7u);
+    *out_aperture = aperture;
+    *out_valid = (aperture != 0);
+    uint64_t lo28 = (entry >> 4) & 0x0fffffffULL;   /* bits [31:4]   */
+    uint64_t hi8  = (entry >> 32) & 0xffULL;        /* pde_v[1][7:0] */
+    *out_next_phys = ((hi8 << 28) | lo28) << 8;
+}
+
 /* Decode a leaf PTE. */
 static void decode_pte(uint64_t entry,
                        uint64_t *out_phys,
@@ -241,19 +268,45 @@ int ga10b_gmmu_walk(uint64_t inst_block_phys, uint64_t gpu_va,
     /* Walk PDE3 → PDE2 → PDE1 → PDE0 → PTE. */
     struct {
         int hi, lo;
+        uint8_t entry_size;
     } level_bits[5] = {
-        {GA10B_PDE3_VA_HI, GA10B_PDE3_VA_LO},
-        {GA10B_PDE2_VA_HI, GA10B_PDE2_VA_LO},
-        {GA10B_PDE1_VA_HI, GA10B_PDE1_VA_LO},
-        {GA10B_PDE0_VA_HI, GA10B_PDE0_VA_LO},
-        {GA10B_PTE_VA_HI,  GA10B_PTE_VA_LO},
+        {GA10B_PDE3_VA_HI, GA10B_PDE3_VA_LO, GA10B_GMMU_ENTRY_SIZE},
+        {GA10B_PDE2_VA_HI, GA10B_PDE2_VA_LO, GA10B_GMMU_ENTRY_SIZE},
+        {GA10B_PDE1_VA_HI, GA10B_PDE1_VA_LO, GA10B_GMMU_ENTRY_SIZE},
+        /* Level 3 entries are dual-PDE0 (16 bytes each — big-page
+         * child at offset 0..7, small-page child at 8..15). The
+         * walker reads the first 8 bytes (big-page child) — fine
+         * for 64-KB big-page mappings which are the helper's
+         * default; small-page-only mappings will appear as "PDE0
+         * invalid" here. A future follow-up should try both. */
+        {GA10B_PDE0_VA_HI, GA10B_PDE0_VA_LO, GA10B_GMMU_PDE0_SIZE},
+        {GA10B_PTE_VA_HI,  GA10B_PTE_VA_LO,  GA10B_GMMU_ENTRY_SIZE},
     };
 
     uint64_t cur_table_phys = pdb_phys;
+    /* Tracks whether the dual-PDE0 fell through to its small-page
+     * child. Affects how level 4 indexes the PTE table: big-page
+     * mappings use bits [20:16] (5 bits, 32 entries × 64 KB) while
+     * small-page mappings use bits [20:12] (9 bits, 512 entries ×
+     * 4 KB). Hardware-observed on jetson-nano-2 2026-05-17: the
+     * helper's pushbuf is small-page-mapped, so without this
+     * fallback the walker stalled at PDE0 with "big-side invalid"
+     * even though the small-side child held the right pointer. */
+    bool followed_small_pde0 = false;
 
     for (int lvl = 0; lvl < 5; lvl++) {
-        uint16_t idx = va_index(gpu_va, level_bits[lvl].hi, level_bits[lvl].lo);
-        uint64_t entry_phys = cur_table_phys + (uint64_t)idx * GA10B_GMMU_ENTRY_SIZE;
+        /* L4 index width depends on which PDE0 child we followed.
+         * The level_bits[] table holds the big-page width by
+         * default; override for the small-side case here. */
+        int idx_hi = level_bits[lvl].hi;
+        int idx_lo = level_bits[lvl].lo;
+        if (lvl == 4 && followed_small_pde0) {
+            idx_hi = GA10B_PTE_SMALL_VA_HI;
+            idx_lo = GA10B_PTE_SMALL_VA_LO;
+        }
+        uint16_t idx = va_index(gpu_va, idx_hi, idx_lo);
+        uint64_t entry_phys = cur_table_phys +
+                              (uint64_t)idx * level_bits[lvl].entry_size;
         uint64_t entry = phys_read64(entry_phys);
 
         struct ga10b_gmmu_level_record *rec = &result->levels[lvl];
@@ -287,8 +340,30 @@ int ga10b_gmmu_walk(uint64_t inst_block_phys, uint64_t gpu_va,
         uint8_t aperture;
         bool valid;
         if (lvl == 3) {
-            decode_dual_pde_small(entry, &next_phys, &aperture, &valid);
-            rec->dual_pde_followed_small = true;
+            /* PDE0 is a dual entry (16 bytes). First 8 bytes are
+             * the big-page child; bytes 8..15 are the small-page
+             * child. Try big first (cheaper for typical
+             * 64-KB-page workloads); if invalid, read the small-
+             * page child from offset +8 and try again. The
+             * walker's leaf-level indexing follows whichever
+             * child was used. */
+            decode_dual_pde_big(entry, &next_phys, &aperture, &valid);
+            if (!valid) {
+                uint64_t small_entry = phys_read64(entry_phys + 8u);
+                decode_dual_pde_small(small_entry, &next_phys,
+                                       &aperture, &valid);
+                if (valid) {
+                    /* Update record so post-mortem dumps reflect
+                     * which half held the valid pointer. */
+                    rec->entry = small_entry;
+                    followed_small_pde0 = true;
+                    rec->dual_pde_followed_small = true;
+                } else {
+                    rec->dual_pde_followed_small = false;
+                }
+            } else {
+                rec->dual_pde_followed_small = false;
+            }
         } else {
             decode_regular_pde(entry, &next_phys, &aperture, &valid);
         }
@@ -1115,6 +1190,7 @@ int ga10b_gmmu_free(uint64_t inst_block_phys,
  * ============================================================ */
 
 #include "ga10b_channel_handoff.h"
+#include "ga10b_bringup.h"          /* ga10b_dump_inst_block_at */
 #include "../../include/uart.h"
 
 /* Inst-block PDB-pointer encoding per
@@ -1170,6 +1246,7 @@ int ga10b_gmmu_free(uint64_t inst_block_phys,
  * had set up (e.g., subcontext 0 with a different PDB pointer for
  * a Linux-side use case the channel may still need). */
 #define GA10B_RAMIN_W_SC_PDB_VALID_LONG_LO 166u
+#define GA10B_RAMIN_W_SC_PDB_VALID_LONG_HI 167u
 #define GA10B_RAMIN_W_SC_PDB_BASE(veid)    (168u + 4u * (veid))
 
 /* PBDMA-encoded field values for a default Tegra GA10B channel
@@ -1257,14 +1334,32 @@ static int rebuild_map_range(uint64_t pdb_phys, uint64_t gpu_va_base,
 }
 
 int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
-                                   const struct ga10b_channel_handoff *h)
+                                   const struct ga10b_channel_handoff *h_in)
 {
-    if (h == NULL) {
+    if (h_in == NULL) {
         return -1;
     }
     if (!phys_in_dram(inst_block_phys, 4096)) {
         return -1;
     }
+    /* Cast away const so we can override chid/tsg_id/work_submit_token
+     * downstream (#844 chid-override experiment). The handoff struct
+     * is owned by ga10b_bringup.c's `g_handoff` static; the rebuild
+     * path is the single writer post-inherit, and there are no
+     * concurrent readers during oplib stage. */
+    struct ga10b_channel_handoff *h =
+        (struct ga10b_channel_handoff *)(uintptr_t)h_in;
+
+    /* #844 chid override REVERTED. Tried chid=1 with token =
+     * channel_base(0x1fc) + 1 = 0x1fd; produced GR-poison state
+     * (every register reads 0xbadf1002) consistently across two
+     * runs. Reason unclear — chid=1 might collide with a CHRAM
+     * slot Linux still depends on, or the
+     * `token = channel_base + chid` encoding may have extra bits
+     * we haven't decoded. Reverting to chid=0 (helper's value)
+     * keeps GR in the "clean but PBDMA-doesn't-see-submits"
+     * state, which is a better starting point for the runlist-
+     * entry decode work below. */
 
     /* #788 Stage 6: trace every PMM page the rebuild allocates so
      * the operator can spot which one might be colliding with an
@@ -1273,6 +1368,14 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
      * is overwhelming when not specifically investigating.
      * Toggle on for diagnostic captures. */
     /* ga10b_gmmu_table_alloc_trace_set(true); */
+
+    /* #834 diagnostic — dump the inst block BEFORE we touch it, so
+     * the post-rebuild dump (at function exit) can be diffed against
+     * Linux's published state. Reveals which fields the rebuild
+     * actually changes vs leaves as Linux-published. Especially
+     * relevant when GR poisons on ctxsw and we need to identify
+     * the LAST inst-block field that's still stale. */
+    ga10b_dump_inst_block_at("REBUILD-BEFORE", inst_block_phys);
 
     /* 1. Allocate a fresh PDB page from SLM-OS PMM. Zero it so
      *    every PDE3 entry reads as invalid until `map_one_page`
@@ -1314,6 +1417,38 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
      *    word-131 magic + subcontext-PDB write below. */
     volatile uint32_t *inst = (volatile uint32_t *)(uintptr_t)inst_block_phys;
 
+    /* #834 experiment: zero ALL of the RAMFC region (words 0..127)
+     * before writing our subset.
+     *
+     * The inst-block diff dump (REBUILD-BEFORE vs REBUILD-AFTER on
+     * 2026-05-16) shows Linux leaves several preserved-by-us fields
+     * non-zero: pseudorandom-looking values at words 11, 29, 38 and
+     * a VA-encoded pair at words 23-24, plus a bit-31-set value at
+     * word 27. Some of those plausibly hold stale FECS sequence
+     * numbers / checksums / pointers that contribute to the
+     * gr_intr=0xbadf1002 poison during ctxsw-in.
+     *
+     * Strategy: wipe RAMFC, write exactly the fields we know about,
+     * leave the rest at zero. Two outcomes both informative:
+     *   - GR poison disappears → one of those preserved fields was
+     *     the trigger; binary-search to identify which.
+     *   - GR poison shifts to a different register pattern → FECS
+     *     needed a non-zero value somewhere we just cleared; the
+     *     new error code tells us which.
+     *   - GR poison identical → RAMFC isn't the source; look at GR-
+     *     engine-internal state (gr_ctx, golden image), most likely
+     *     fixable only by getting v10 gr_ctx-extents publishing
+     *     working on the helper side.
+     *
+     * Range chosen as 0..127 (i.e. 512 B) which covers all of RAMFC
+     * proper (0..63 by GA10B_RAMFC_W_* constants) plus a margin past
+     * it. Words 128/129 (PDB lo/hi) and 131 (engine_fw_magic) get
+     * re-written immediately below; words 130 + 134-137 + 166-167
+     * + 168-423 are all explicitly handled by the existing code. */
+    for (uint32_t i = 0; i < 128u; i++) {
+        inst[i] = 0u;
+    }
+
     /* Encode PDB-lo word: aperture (sys_mem_ncoh on Tegra),
      * volatile bit, ver2 page-table format, 64 KB big-page size,
      * and phys[31:12] in bits [31:12] (the bottom 12 bits of phys
@@ -1336,21 +1471,49 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
      * (where the inst block started zero). */
     inst[GA10B_RAMIN_W_ENGINE_FW_MAGIC] = GA10B_RAMIN_VAL_ENGINE_FW_MAGIC;
 
-    /* Subcontext-VEID PDB pointer — GR uses this when running
-     * compute under the channel's subcontext. We point it at the
-     * same fresh PDB as the main PDB so both PBDMA (main) and GR
-     * (subcontext) see the same page-table tree.
+    /* Subcontext-VEID PDB pointer + valid-long bitmap.
      *
-     * Also OR in the subcontext-valid-long bit for our VEID. The
-     * valid_long bits are packed 32 per word starting at word 166;
-     * GA10B_HELPER_SUBCTX_ID (= 1) lives at bit 1 of word 166. We
-     * read-modify-write so other valid-long bits Linux had set are
-     * preserved (Linux may have multiple subcontexts active for
-     * its own channel). */
+     * GR loads the subcontext indexed by VEID when running compute
+     * and dereferences *that* subcontext's pdb pointer (NOT the
+     * main pdb). Each VEID 0..63 has a 4-word slot starting at
+     * `168 + 4*veid`; the valid-long bitmap (1 bit per veid) lives
+     * in words 166 (veids 0..31) and 167 (veids 32..63).
+     *
+     * #844: previously we ONLY rewrote the slot for our VEID (= 1)
+     * and OR-ed in bit 1 of the valid-long lo word, preserving
+     * Linux's other subcontext state. That left two stale-pointer
+     * hazards in the inst block:
+     *
+     *   1. Per-VEID PDB slots for veids ≠ 1: Linux may have
+     *      configured multiple subcontexts (e.g. veid 0 = SYNC) with
+     *      PDB pointers into pages SLM-OS's PMM has since re-used.
+     *      When FECS ctxsws to our channel it can iterate the
+     *      subcontext valid mask and try to load the secondary
+     *      PDBs alongside ours; a dereference of a clobbered page
+     *      poisons GR (0xbadf1002).
+     *
+     *   2. valid-long bits for veids ≠ 1: even if a slot's pointer
+     *      is zero, the corresponding valid bit being set tells GR
+     *      "this subcontext is configured", and the load happens.
+     *
+     * Fix: zero ALL 64 subcontext slots (256 words = inst[168..423])
+     * and BOTH valid-long words; then write our VEID=1 slot fresh
+     * and set just bit 1 of the lo valid-long word. Now only the
+     * subcontext we control is visible to GR. */
+    for (uint32_t veid = 0; veid < 64u; veid++) {
+        uint32_t w = GA10B_RAMIN_W_SC_PDB_BASE(veid);
+        inst[w + 0] = 0u;
+        inst[w + 1] = 0u;
+        inst[w + 2] = 0u;
+        inst[w + 3] = 0u;
+    }
+    inst[GA10B_RAMIN_W_SC_PDB_VALID_LONG_LO] = 0u;
+    inst[GA10B_RAMIN_W_SC_PDB_VALID_LONG_HI] = 0u;
+
     uint32_t sc_base = GA10B_RAMIN_W_SC_PDB_BASE(GA10B_HELPER_SUBCTX_ID);
     inst[sc_base + 0] = pdb_lo_word;
     inst[sc_base + 1] = pdb_hi_word;
-    inst[GA10B_RAMIN_W_SC_PDB_VALID_LONG_LO] |=
+    inst[GA10B_RAMIN_W_SC_PDB_VALID_LONG_LO] =
         (1u << GA10B_HELPER_SUBCTX_ID);
 
     /* 2b. Populate RAMFC fields PBDMA reads when fetching submits
@@ -1386,31 +1549,60 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
     inst[GA10B_RAMFC_W_ACQUIRE]       = GA10B_RAMFC_VAL_ACQUIRE_LONG;
     inst[GA10B_RAMFC_W_INTR_NOTIFY]   = GA10B_RAMFC_VAL_INTR_NOTIFY;
     inst[GA10B_RAMFC_W_CONFIG]        = GA10B_RAMFC_VAL_CONFIG_USERD_WB;
+    /* #844: encode SET_CHANNEL_INFO with hw_chid (= channel_base
+     * + chid) rather than the per-runlist chid. FECS validates
+     * RAMFC's chid against the runlist entry's chid (= hw_chid in
+     * our encoding); a mismatch crashes GR during ctxsw with the
+     * same 0xbadf1002 poison signature we see when the internal
+     * doorbell is rung. channel_base = h->work_submit_token
+     * (which the helper publishes as `channel_base + chid` for
+     * chid=0, giving us channel_base directly when h->channel_id
+     * is 0). */
+    const uint32_t ramfc_hw_chid =
+        h->work_submit_token + h->channel_id;
     inst[GA10B_RAMFC_W_SET_CHANNEL_INFO] =
-        GA10B_RAMFC_SET_CHANNEL_INFO(h->channel_id,
+        GA10B_RAMFC_SET_CHANNEL_INFO(ramfc_hw_chid,
                                       GA10B_HELPER_SUBCTX_ID);
 
-    /* engine_wfi block (post-RAMFC, pre-PDB region for the
-     * engine-wait-for-idle save pointer). Only the VEID is written
-     * by `ga10b_ramfc_setup`; ptr_lo/ptr_hi/target stay zero in
-     * the inherited channel because the helper doesn't allocate a
-     * GR ctxsw save buffer (Tegra's nvgpu lazy-allocates it on
-     * first GR engagement, and the helper never engages GR — only
-     * does host-family sema releases on subch 0). */
+    /* engine_wfi block (#844 — clear stale Linux pointers).
+     * Words 132 (target + ptr_lo) and 133 (ptr_hi) point at the
+     * GR ctxsw save buffer Linux nvgpu allocated. Post-kexec
+     * SLM-OS's PMM may have re-allocated those pages, so the
+     * pointer is now dangling. When FECS tries to ctxsw to our
+     * channel, it dereferences `engine_wfi_ptr` to save the
+     * outgoing context — that load/store against clobbered
+     * memory is the likely cause of the `gr_intr=0xbadf1002`
+     * poison we see when word 1 of the TSG header is set to
+     * 0x1 (FECS load attempt).
+     *
+     * Zero target + ptr_hi so nvgpu's "lazy-allocate the
+     * ctxsw save buffer on first engagement" path kicks in.
+     * Word 134 (veid) keeps the helper's subctx (= 1). */
+    inst[132] = 0u;   /* engine_wfi_target + ptr_lo */
+    inst[133] = 0u;   /* engine_wfi_ptr_hi */
     inst[GA10B_RAMIN_W_ENGINE_WFI_VEID] = GA10B_HELPER_SUBCTX_ID;
+    /* Also clear eng_method_buffer_addr (words 136/137). Same
+     * staleness story as engine_wfi: Linux pointed these at a
+     * method-buffer DMA allocation that SLM-OS PMM may have
+     * re-used. nvgpu lazy-allocates when zero. */
+    inst[136] = 0u;   /* eng_method_buffer_addr_lo */
+    inst[137] = 0u;   /* eng_method_buffer_addr_hi */
 
     cache_clean_range((void *)(uintptr_t)inst_block_phys, 4096);
 
-    uart_printf("[rebuild-gmmu] inst_block@0x%lx written (preserving "
-                "Linux-set engine_fw_magic + non-target subcontexts):\n",
-                (unsigned long)inst_block_phys);
+    uart_printf("[rebuild-gmmu] inst_block@0x%lx written "
+                "(non-target subcontexts zeroed; only VEID=%u active):\n",
+                (unsigned long)inst_block_phys,
+                (unsigned)GA10B_HELPER_SUBCTX_ID);
     uart_printf("[rebuild-gmmu]   PDB_lo=0x%08x PDB_hi=0x%08x "
                 "(main + subcontext VEID=%u at word %u)\n",
                 (unsigned)pdb_lo_word, (unsigned)pdb_hi_word,
                 (unsigned)GA10B_HELPER_SUBCTX_ID, (unsigned)sc_base);
-    uart_printf("[rebuild-gmmu]   engine_fw_magic=0x%08x sc_valid_long=0x%08x\n",
+    uart_printf("[rebuild-gmmu]   engine_fw_magic=0x%08x "
+                "sc_valid_long=lo:0x%08x/hi:0x%08x\n",
                 (unsigned)inst[GA10B_RAMIN_W_ENGINE_FW_MAGIC],
-                (unsigned)inst[GA10B_RAMIN_W_SC_PDB_VALID_LONG_LO]);
+                (unsigned)inst[GA10B_RAMIN_W_SC_PDB_VALID_LONG_LO],
+                (unsigned)inst[GA10B_RAMIN_W_SC_PDB_VALID_LONG_HI]);
     uart_printf("[rebuild-gmmu]   gp_base=0x%08x gp_base_hi=0x%08x "
                 "(entries=%u → log2=%u)\n",
                 (unsigned)gp_base_lo_val, (unsigned)gp_base_hi_val,
@@ -1425,7 +1617,7 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
                 GA10B_RAMFC_VAL_ACQUIRE_LONG,
                 GA10B_RAMFC_VAL_INTR_NOTIFY,
                 GA10B_RAMFC_VAL_CONFIG_USERD_WB,
-                GA10B_RAMFC_SET_CHANNEL_INFO(h->channel_id,
+                GA10B_RAMFC_SET_CHANNEL_INFO(ramfc_hw_chid,
                                               GA10B_HELPER_SUBCTX_ID),
                 (unsigned)GA10B_HELPER_SUBCTX_ID);
 
@@ -1577,7 +1769,471 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
                 "mapped (%d PT pages allocated)\n",
                 rc, mapped, g_table_alloc_count);
 
+    /* 5. Enable our channel in CHRAM + force a context reload so
+     *    FECS picks up the new PDB on the next scheduling event
+     *    (#844 fix). Without this, dispatches go to FECS_CURRENT_-
+     *    CTX's loaded channel (typically a Linux nvgpu channel
+     *    still on the runlist post-kexec) — diagnosed via #838's
+     *    pre-launch sema diagnostic ("PBDMA advanced but NEITHER
+     *    pre- nor post-sema fired, poll=0").
+     *
+     *    Mirrors nvgpu's `ga10b_channel_enable` (~/slmos-ref/
+     *    nvidia/nvgpu-hal-fifo-channel_ga10b_fusa.c:59).
+     *
+     *    Runlist register block lives at a Tegra-specific BAR0
+     *    offset, NOT the dGPU's hardcoded 0xC000. Discover via the
+     *    top_device_info2 topology table: walk the per-engine
+     *    rows looking for type_enum=GRAPHICS (0), then read the
+     *    GR engine's `runlist_pri_base` from its row[2]. The
+     *    runlist's `channel_config` (offset 0x4 within the block)
+     *    then carries the CHRAM register BAR0 offset.
+     *
+     *    Topology layout per ~/slmos-ref/nvidia/nvgpu-hal-top-
+     *    top_ga10b_fusa.c:60-114 (`ga10b_top_parse_next_dev`):
+     *      - top_device_info_cfg @ BAR0 + 0x224fc
+     *          bits[31:20] = num_rows
+     *          bits[3:0]   = version (must be 2 = init)
+     *      - top_device_info2_r(i) @ BAR0 + 0x22800 + i*4
+     *          3 rows per device:
+     *            row[0]: type_enum @ [30:24], chain_more @ [31]
+     *            row[1]: device_pri_base @ [25:8] << 8, is_engine @ [30]
+     *            row[2]: runlist_pri_base @ [25:10] << 10
+     *      - Zero rows separate devices (skip those tokens). */
+    {
+        const uint64_t BAR0 = 0x17000000ull;
+        const uint32_t TOP_CFG_OFF      = 0x000224fcu;
+        const uint32_t TOP_DEV_INFO2_OFF = 0x00022800u;
+        const uint32_t TYPE_ENUM_GRAPHICS = 0u;
+
+        uint32_t cfg = *(volatile uint32_t *)(uintptr_t)(BAR0 + TOP_CFG_OFF);
+        uint32_t version  = cfg & 0xfu;
+        uint32_t num_rows = (cfg >> 20) & 0xfffu;
+        uint64_t gr_rl_pri_base = 0u;
+
+        if (version != 2u) {
+            uart_printf("[rebuild-gmmu] top_device_info_cfg=0x%08x "
+                        "version=%u != 2 — can't walk topology; "
+                        "CHRAM enable skipped (#844)\n",
+                        (unsigned)cfg, (unsigned)version);
+        } else {
+            for (uint32_t i = 0; i + 2u < num_rows; i++) {
+                uint32_t row0 = *(volatile uint32_t *)(uintptr_t)
+                    (BAR0 + TOP_DEV_INFO2_OFF + i * 4u);
+                if (row0 == 0u) continue;
+                uint32_t chain_more = (row0 >> 31) & 0x1u;
+                if (chain_more != 1u) continue;
+                uint32_t type = (row0 >> 24) & 0x7fu;
+                if (type != TYPE_ENUM_GRAPHICS) {
+                    i += 2;   /* skip device's rows 1 + 2 */
+                    continue;
+                }
+                uint32_t row2 = *(volatile uint32_t *)(uintptr_t)
+                    (BAR0 + TOP_DEV_INFO2_OFF + (i + 2u) * 4u);
+                gr_rl_pri_base =
+                    (uint64_t)(((row2 >> 10) & 0xffffu)) << 10;
+                uart_printf("[rebuild-gmmu] topology: GR at row %u "
+                            "row0=0x%08x row2=0x%08x "
+                            "runlist_pri_base=0x%lx\n",
+                            (unsigned)i, (unsigned)row0,
+                            (unsigned)row2,
+                            (unsigned long)gr_rl_pri_base);
+                break;
+            }
+        }
+
+        if (gr_rl_pri_base == 0u) {
+            uart_puts("[rebuild-gmmu] couldn't find GR engine in "
+                      "topology table — CHRAM enable skipped (#844)"
+                      "\n");
+        } else {
+            uint64_t channel_cfg_addr =
+                BAR0 + gr_rl_pri_base + 0x4u;
+            uint32_t channel_config =
+                *(volatile uint32_t *)(uintptr_t)channel_cfg_addr;
+            uint32_t chram_bar0_offset =
+                ((channel_config >> 4) & 0x0fffffffu) << 4;
+            /* #844: index CHRAM by `hw_chid = channel_base + chid`,
+             * not by `chid` alone. nvgpu's `gv11b_usermode_doorbell_-
+             * token` formula gives hw_chid = `channel_base + ch->chid`,
+             * and the helper's work_submit_token = 0x1fc for chid=0
+             * implies channel_base = 0x1fc on this Tegra GA10B. The
+             * CHRAM array is indexed by hw_chid (the doorbell's
+             * channel-id namespace), not by per-runlist chid — so
+             * writing CHRAM[chid=0] hits the wrong slot, and FECS
+             * never finds an enabled channel matching the doorbell's
+             * hw_chid encoding.
+             *
+             * Also encode the runlist channel entry's chid field
+             * with `hw_chid` so FECS's entry-lookup uses the same
+             * CHRAM slot. */
+            const uint32_t channel_base_hw = h->work_submit_token;
+            const uint32_t hw_chid =
+                channel_base_hw + h->channel_id;
+            uint64_t chram_chan_addr =
+                BAR0 + (uint64_t)chram_bar0_offset +
+                (uint64_t)hw_chid * 4ull;
+            volatile uint32_t *chram =
+                (volatile uint32_t *)(uintptr_t)chram_chan_addr;
+            /* enable_channel (0x2) then force_ctx_reload (0x200).
+             * The update field accepts one action per write; do two
+             * writes in sequence with a dsb between, matching
+             * nvgpu's bind sequence. */
+            *chram = 0x00000002u;   /* enable_channel */
+            __asm__ volatile("dsb sy" ::: "memory");
+            *chram = 0x00000200u;   /* force_ctx_reload */
+            __asm__ volatile("dsb sy" ::: "memory");
+            uart_printf("[rebuild-gmmu] CHRAM[hw_chid=%u=chid_%u+base_0x%x]"
+                        "@0x%lx enabled + force_ctx_reload "
+                        "(chram_bar0=0x%x from channel_config=0x%08x)"
+                        "\n",
+                        (unsigned)hw_chid,
+                        (unsigned)h->channel_id,
+                        (unsigned)channel_base_hw,
+                        (unsigned long)chram_chan_addr,
+                        (unsigned)chram_bar0_offset,
+                        (unsigned)channel_config);
+
+            /* #844 candidate (3) — REVERTED: clearing all non-ours
+             * CHRAM entries (2047 slots × 0xFFFFFFFF =
+             * update_clear_channel_v) is too destructive. Linux
+             * channels (Xorg display, kworker, etc.) are still
+             * actively bound to GR via these CHRAM entries; the
+             * clear triggers an immediate GR teardown / power-
+             * gate (every register reads 0xbadf1002 poison
+             * post-clear). The "lock FECS to only our channel"
+             * idea needs a less destructive approach — see #844
+             * for the next candidates. */
+
+            /* Force a runlist preempt so FECS unloads the currently-
+             * running Linux channel and re-reads the runlist. After
+             * preempt completes, FECS picks the next runnable
+             * channel (now including ours since we set enable +
+             * force_ctx_reload above). Without this, FECS may
+             * stay loaded with the Linux channel for the lifetime
+             * of SLM-OS — our enable + reload bits become "pending"
+             * but never get acted on. Register at
+             * gr_rl_pri_base + 0x98; value =
+             * runlist_preempt_runlist_preempt_pending_true_f (0x200000)
+             * |  runlist_preempt_type_runlist_f (0x0). */
+            uint64_t preempt_addr =
+                BAR0 + gr_rl_pri_base + 0x98u;
+            *(volatile uint32_t *)(uintptr_t)preempt_addr =
+                0x00200000u;
+            __asm__ volatile("dsb sy" ::: "memory");
+            uart_printf("[rebuild-gmmu] runlist preempt @0x%lx "
+                        "= 0x00200000 (force FECS to re-read "
+                        "runlist & pick our channel)\n",
+                        (unsigned long)preempt_addr);
+
+            /* Poll runlist_submit_info for preempt completion.
+             * `runlist_submit_info_pending_true_f` = 0x8000.
+             * Linux nvgpu uses interrupts for this; we poll
+             * with a short timeout because the preempt should
+             * complete in microseconds. */
+            uint64_t info_addr =
+                BAR0 + gr_rl_pri_base + 0x8cu;
+            volatile uint32_t *info_reg =
+                (volatile uint32_t *)(uintptr_t)info_addr;
+            int preempt_done = 0;
+            for (int i = 0; i < 10000; i++) {
+                uint32_t info = *info_reg;
+                if ((info & 0x8000u) == 0u) {
+                    preempt_done = 1;
+                    break;
+                }
+            }
+            uart_printf("[rebuild-gmmu] preempt %s "
+                        "(info=0x%08x after poll)\n",
+                        preempt_done ? "completed" : "TIMEOUT",
+                        (unsigned)*info_reg);
+
+            /* Diagnostic: dump Linux's existing runlist DRAM so we
+             * know (a) what entry encoding it uses, (b) whether our
+             * channel/TSG is on the runlist, (c) how many entries
+             * to write when we craft our own. Read
+             * `runlist_submit_base_lo/hi` (offsets 0x80/0x84 within
+             * the runlist register block), decode the phys, and
+             * dump the first 4 entries (64 B = a TSG header + up
+             * to 3 channels). Each entry is 16 B (4 dwords) per
+             * ram_rl_entry_size_v() = 0x10. */
+            uint32_t rl_lo = *(volatile uint32_t *)(uintptr_t)
+                (BAR0 + gr_rl_pri_base + 0x80u);
+            uint32_t rl_hi = *(volatile uint32_t *)(uintptr_t)
+                (BAR0 + gr_rl_pri_base + 0x84u);
+            uint64_t rl_phys =
+                ((uint64_t)(rl_lo & 0xfffffc00u)) |
+                ((uint64_t)(rl_hi & 0xffu) << 32);
+            uart_printf("[rebuild-gmmu] runlist base lo=0x%08x "
+                        "hi=0x%08x → phys=0x%lx\n",
+                        (unsigned)rl_lo, (unsigned)rl_hi,
+                        (unsigned long)rl_phys);
+
+            /* Tegra Orin Nano doesn't use the SMMU for the GPU
+             * stream (per the comment at ga10b_gmmu.h:359 — no
+             * `iommus` DT property on the GA10B node), so the
+             * runlist_submit_base register holds a CPU phys
+             * verbatim. SLM-OS's VMM identity-maps the lower part
+             * of DRAM (PA 0x80000000..0x280000000 = 2..10 GB) but
+             * the L1 loop in vmm_setup_platform only covers VAs
+             * 0..8 GB, missing the upper 2 GB of DRAM. Linux
+             * nvgpu allocated the runlist in that upper-DRAM
+             * region (typical for kernel reserved-memory zones),
+             * so dereferencing the runlist phys faults.
+             *
+             * `vmm_map_region` uses 2 MB L2 entries which require
+             * an existing L1 table-descriptor at L1[i]; if L1[i]
+             * is INVALID (the case for L1[8] / L1[9] above the
+             * platform setup loop), it errors out. Install the
+             * L2 table first via `vmm_ensure_kernel_l2_table`,
+             * then call `vmm_map_region` for the runlist's 2 MB
+             * block. Both are idempotent — re-running this path
+             * on a subsequent oplib stage is a no-op. */
+            const uint64_t BLOCK_2M  = 0x200000ull;
+            const uint64_t BLOCK_MASK = BLOCK_2M - 1ull;
+            uint64_t rl_block = rl_phys & ~BLOCK_MASK;
+            int erc = vmm_ensure_kernel_l2_table(rl_block);
+            int mrc = -1;
+            if (erc == 0) {
+                mrc = vmm_map_region(rl_block, rl_block, BLOCK_2M,
+                                     VMM_FLAG_READ | VMM_FLAG_WRITE);
+            }
+            uart_printf("[rebuild-gmmu] vmm_ensure_l2(0x%lx) rc=%d, "
+                        "vmm_map_region(0x%lx, 0x%lx, 2MB) rc=%d\n",
+                        (unsigned long)rl_block, erc,
+                        (unsigned long)rl_block,
+                        (unsigned long)rl_block, mrc);
+
+            if (mrc == 0) {
+                volatile uint32_t *rl =
+                    (volatile uint32_t *)(uintptr_t)rl_phys;
+                uart_printf("[rebuild-gmmu] runlist contents @0x%lx "
+                            "(first 4 × 16 B entries):\n",
+                            (unsigned long)rl_phys);
+                for (uint32_t e = 0; e < 4u; e++) {
+                    uart_printf("[rebuild-gmmu]   rl[%u] (offset 0x%x) "
+                                "0x%08x 0x%08x 0x%08x 0x%08x\n",
+                                (unsigned)e, (unsigned)(e * 16u),
+                                (unsigned)rl[e * 4u + 0u],
+                                (unsigned)rl[e * 4u + 1u],
+                                (unsigned)rl[e * 4u + 2u],
+                                (unsigned)rl[e * 4u + 3u]);
+                }
+            }
+
+            /* #844 — write a fresh runlist containing ONLY our
+             * channel and submit it. Linux's existing runlist
+             * references chids that aren't ours; FECS schedules
+             * Linux channels regardless of our CHRAM/preempt
+             * writes because our channel was never on its runlist.
+             *
+             * Format empirically decoded above:
+             *
+             *   TSG header (16 B):
+             *     word0 = (timeout<<24) | (scale<<16) | length
+             *     word1 = tsgid
+             *     word2 = 0
+             *     word3 = 0
+             *   Channel entry (16 B):
+             *     word0 = (inst_phys[31:12] & 0xfffff) << 12 | chid
+             *     word1 = (inst_phys >> 32) & 0xff
+             *     word2 = (userd_phys[31:8] & 0xffffff) << 8
+             *           | userd_target << 6 | inst_target << 4
+             *           | 0xf  (matches Linux's low-nibble pattern;
+             *                   exact bit meanings TBD — likely
+             *                   includes valid + runqueue_selector)
+             *     word3 = (userd_phys >> 32) & 0xffffffff
+             *
+             * FECS distinguishes TSG from channel by position:
+             * each TSG header is followed by `length` channel
+             * entries. No explicit type bit needed.
+             *
+             * Allocate a 4 KB DRAM page (SLM-OS PMM phys, in the
+             * range L1[2..7] already maps), write the 2 entries,
+             * cache-clean, point runlist_submit_base at it, and
+             * `runlist_submit` length=2. */
+            void *new_rl_page = pmm_alloc_page();
+            if (new_rl_page == NULL) {
+                uart_puts("[rebuild-gmmu] PMM exhausted allocating "
+                          "fresh runlist page — #844 work skipped\n");
+            } else {
+                uint64_t new_rl_phys = (uint64_t)(uintptr_t)new_rl_page;
+                volatile uint32_t *new_rl =
+                    (volatile uint32_t *)(uintptr_t)new_rl_phys;
+                /* Zero entire page so any unused bytes are
+                 * deterministic. */
+                for (int i = 0; i < 1024; i++) new_rl[i] = 0;
+
+                /* TSG header (#844 entry-decode iterations).
+                 *
+                 * Decoded from Linux's runlist that word 0 holds
+                 * timeslice + length, word 1 is a fixed `0x1`
+                 * constant (mystery flag — possibly "valid" or
+                 * "type=tsg"), and word 2 holds the actual tsgid
+                 * (Linux's two TSGs have word2=0 and word2=1,
+                 * which contradicts the slmos-ref macros that
+                 * place tsgid in word 1).
+                 *
+                 * Empirical finding: setting word 1 = 0x1 +
+                 * word 2 = tsg_id_override (matching Linux's
+                 * format) makes FECS recognise the entry — but
+                 * the subsequent ctxsw attempt poisons GR
+                 * (`gr_intr=0xbadf1002` etc.). The poison means
+                 * FECS *tried* to load our channel but something
+                 * inside is invalid; before, FECS ignored the
+                 * entry as malformed and GR stayed clean.
+                 *
+                 * Leaving word 1 = 0 + word 2 = tsg_id_override
+                 * keeps us in the "FECS rejects entry, GR clean"
+                 * state — a better starting point for the next
+                 * iteration. The next focus should be on what's
+                 * invalid inside our channel that crashes GR
+                 * when FECS loads it: probably engine_wfi or
+                 * eng_method_buffer fields preserved from
+                 * Linux pointing at PT pages we may have
+                 * clobbered, OR an unset subcontext-state field. */
+                const uint32_t TSG_ID_OVERRIDE = 2u;
+                new_rl[0] = (0x80u << 24) | (3u << 16) |
+                            (1u << 0);
+                new_rl[1] = 0x00000001u;   /* Linux's "valid/type=tsg" flag */
+                new_rl[2] = TSG_ID_OVERRIDE & 0xfffu;
+                new_rl[3] = 0u;
+
+                /* Channel entry: chid = h->channel_id,
+                 * inst_phys = h->inst_block_phys,
+                 * userd_phys = h->userd_phys.
+                 *
+                 * Type discriminator at bit 11 of word 0: TSG=0,
+                 * channel=1. Decoded empirically from Linux's
+                 * runlist: TSG headers (rl[0], rl[2]) have word 0
+                 * bit 11 = 0; channel entries (rl[1], rl[3]) have
+                 * bit 11 = 1 (e.g. 0x2a925ef0: 0xef0 = chid 0x6f0
+                 * in bits[10:0] + 1 bit 11 = type=channel). This
+                 * reconciles with `runlist_channel_config_num_-
+                 * channels_log2_2k_v() = 11` (CHRAM has 2^11 =
+                 * 2048 entries, so chid is 11 bits, leaving bit
+                 * 11 free for the type discriminator). Our prior
+                 * iteration left bit 11 = 0 → FECS likely
+                 * interpreted the entry as a malformed TSG and
+                 * skipped it. */
+                uint64_t inst_p = h->inst_block_phys;
+                uint64_t userd_p = h->userd_phys;
+                uint32_t inst_lo20 =
+                    (uint32_t)((inst_p >> 12) & 0xfffffu);
+                uint32_t inst_hi = (uint32_t)((inst_p >> 32) & 0xffu);
+                uint32_t userd_lo24 =
+                    (uint32_t)((userd_p >> 8) & 0xffffffu);
+                uint32_t userd_hi = (uint32_t)(userd_p >> 32);
+                /* Runlist channel entry's chid uses hw_chid space
+                 * (channel_base + chid), matching what we wrote
+                 * CHRAM at and what the doorbell value encodes.
+                 * Captured outside the if-else above so it's
+                 * available to this scope. */
+                new_rl[4] = (hw_chid & 0x7ffu) |
+                            (1u << 11) |  /* type = channel */
+                            (inst_lo20 << 12);
+                new_rl[5] = inst_hi;
+                new_rl[6] = (userd_lo24 << 8) |
+                            (3u << 6) |   /* userd_target=ncoh */
+                            (3u << 4) |   /* inst_target=ncoh */
+                            0xfu;
+                new_rl[7] = userd_hi;
+
+                cache_clean_range((void *)(uintptr_t)new_rl_phys, 4096);
+                __asm__ volatile("dsb sy" ::: "memory");
+
+                uart_printf("[rebuild-gmmu] fresh runlist @0x%lx:\n"
+                            "[rebuild-gmmu]   [TSG] 0x%08x 0x%08x "
+                            "0x%08x 0x%08x\n"
+                            "[rebuild-gmmu]   [CHN] 0x%08x 0x%08x "
+                            "0x%08x 0x%08x\n",
+                            (unsigned long)new_rl_phys,
+                            (unsigned)new_rl[0], (unsigned)new_rl[1],
+                            (unsigned)new_rl[2], (unsigned)new_rl[3],
+                            (unsigned)new_rl[4], (unsigned)new_rl[5],
+                            (unsigned)new_rl[6], (unsigned)new_rl[7]);
+
+                /* Disable runlist scheduling while we update the
+                 * base. `runlist_sched_disable_r() = 0x94`,
+                 * disable value = 0x1. */
+                volatile uint32_t *sched_dis =
+                    (volatile uint32_t *)(uintptr_t)
+                    (BAR0 + gr_rl_pri_base + 0x94u);
+                *sched_dis = 1u;
+                __asm__ volatile("dsb sy" ::: "memory");
+
+                /* Update runlist_submit_base: lo bits[31:10] =
+                 * phys[31:10] (1 KB aligned); target = 3 (ncoh).
+                 * hi bits[7:0] = phys[39:32]. */
+                uint32_t base_lo =
+                    (uint32_t)((new_rl_phys & 0xfffffc00u)) | 3u;
+                uint32_t base_hi =
+                    (uint32_t)((new_rl_phys >> 32) & 0xffu);
+                *(volatile uint32_t *)(uintptr_t)
+                    (BAR0 + gr_rl_pri_base + 0x80u) = base_lo;
+                *(volatile uint32_t *)(uintptr_t)
+                    (BAR0 + gr_rl_pri_base + 0x84u) = base_hi;
+                __asm__ volatile("dsb sy" ::: "memory");
+
+                /* Re-enable scheduling. */
+                *sched_dis = 0u;
+                __asm__ volatile("dsb sy" ::: "memory");
+
+                /* Submit: length = 2, offset = 0. */
+                *(volatile uint32_t *)(uintptr_t)
+                    (BAR0 + gr_rl_pri_base + 0x88u) =
+                    (0u << 16) | 2u;
+                __asm__ volatile("dsb sy" ::: "memory");
+
+                /* Poll runlist_submit_info for pending=0. */
+                volatile uint32_t *info2 =
+                    (volatile uint32_t *)(uintptr_t)
+                    (BAR0 + gr_rl_pri_base + 0x8cu);
+                int submit_done = 0;
+                for (int i = 0; i < 100000; i++) {
+                    if ((*info2 & 0x8000u) == 0u) {
+                        submit_done = 1;
+                        break;
+                    }
+                }
+                uart_printf("[rebuild-gmmu] fresh runlist submit %s "
+                            "(submit_base lo=0x%08x hi=0x%08x, "
+                            "info=0x%08x)\n",
+                            submit_done ? "completed" : "TIMEOUT",
+                            (unsigned)base_lo, (unsigned)base_hi,
+                            (unsigned)*info2);
+
+                /* Force a fresh ctxsw to pick our channel now. */
+                *(volatile uint32_t *)(uintptr_t)
+                    (BAR0 + gr_rl_pri_base + 0x98u) = 0x00200000u;
+                __asm__ volatile("dsb sy" ::: "memory");
+                int preempt2 = 0;
+                for (int i = 0; i < 10000; i++) {
+                    if ((*info2 & 0x8000u) == 0u) {
+                        preempt2 = 1;
+                        break;
+                    }
+                }
+                uart_printf("[rebuild-gmmu] post-submit preempt %s "
+                            "(info=0x%08x)\n",
+                            preempt2 ? "completed" : "TIMEOUT",
+                            (unsigned)*info2);
+            }
+        }
+    }
+
     ga10b_gmmu_table_alloc_trace_set(false);
+
+    /* #834 diagnostic — dump the rebuilt inst block AFTER all writes
+     * (PDB pointers + RAMFC + engine_wfi/eng_method_buffer clears +
+     * subcontext zero-and-rewrite + CHRAM/runlist housekeeping), so a
+     * post-mortem can compare against Linux's pre-rebuild state. The
+     * GR-poison-on-ctxsw hypothesis is that *some* field FECS reads
+     * during context-switch-IN is still pointing at clobbered Linux
+     * pages. With the dump in hand, anything that looks like a
+     * pointer (non-zero high bits, page-aligned, in DRAM range) can
+     * be walked separately to see whether it's still valid. */
+    ga10b_dump_inst_block_at("REBUILD-AFTER", inst_block_phys);
+
     return (rc == 0) ? 0 : -1;
 }
 

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -23,26 +23,44 @@
 #include <stdint.h>
 
 /* GA10B page-table levels. Default Ampere config is 5-level:
- *   PDE3 (top)  → PDE2 → PDE1 → PDE0 (dual PDE, leaf) → PTE
+ *   L0 (top)  → L1 → L2 → L3 (PDE0 dual) → L4 (PTE)
  *
- * GPU VA bit decomposition (best-guess for 49-bit VAs; may need
- * tuning on hardware — see ga10b_gmmu.c). The high two levels are
- * unequal in nvgpu's modern config; PDE3 covers the top 9 bits and
- * PDE2 the next 10. */
+ * GPU VA bit decomposition per nvgpu canonical
+ * `ga10b_mm_levels[]` in nvgpu-l4t-r36.4.4-gmmu_ga10b_fusa.c:353.
+ * Each level's index extracts a slice of the 49-bit GPU VA.
+ *
+ * The previous values (HI/LO = {48,40}, {39,30}, {29,21}, {20,16},
+ * {15,12}) were a 49-bit-VA placeholder that never got tuned —
+ * they don't match the GA10B hardware decoder, so reads of valid
+ * PDE entries through this walker came back as "unmapped". Fixed
+ * 2026-05-17 by cross-referencing nvgpu's `gk20a_mmu_level`
+ * struct array verbatim. */
 #define GA10B_PDE3_VA_HI    48
-#define GA10B_PDE3_VA_LO    40   /* PDE3 index = bits [48:40], 9 bits */
-#define GA10B_PDE2_VA_HI    39
-#define GA10B_PDE2_VA_LO    30   /* PDE2 index = bits [39:30], 10 bits */
-#define GA10B_PDE1_VA_HI    29
-#define GA10B_PDE1_VA_LO    21   /* PDE1 index = bits [29:21], 9 bits */
-#define GA10B_PDE0_VA_HI    20
-#define GA10B_PDE0_VA_LO    16   /* PDE0 index = bits [20:16], 5 bits — covers 64 KB */
-#define GA10B_PTE_VA_HI     15
-#define GA10B_PTE_VA_LO     12   /* PTE index = bits [15:12], 4 bits — 16 entries × 4 KB = 64 KB region */
+#define GA10B_PDE3_VA_LO    47   /* L0 (top):    bits [48:47], 2 bits — 4 entries × 128 TB */
+#define GA10B_PDE2_VA_HI    46
+#define GA10B_PDE2_VA_LO    38   /* L1:          bits [46:38], 9 bits — 512 entries × 256 GB */
+#define GA10B_PDE1_VA_HI    37
+#define GA10B_PDE1_VA_LO    29   /* L2:          bits [37:29], 9 bits — 512 entries × 512 MB */
+#define GA10B_PDE0_VA_HI    28
+#define GA10B_PDE0_VA_LO    21   /* L3 (dual):   bits [28:21], 8 bits — 256 entries × 2 MB */
+#define GA10B_PTE_VA_HI     20
+#define GA10B_PTE_VA_LO     16   /* L4 (big PTE):bits [20:16], 5 bits — 32 entries × 64 KB */
+/* Small-page PTE-table index range. The dual-PDE0 (L3) carries
+ * separate big-page and small-page children; if the walker
+ * follows the small-page child, the PTE table at L4 is indexed
+ * by bits [20:12] (9 bits → 512 entries × 4 KB). */
+#define GA10B_PTE_SMALL_VA_HI  20
+#define GA10B_PTE_SMALL_VA_LO  12
 #define GA10B_PAGE_SHIFT    12
 
-/* Each PDE/PTE entry is 8 bytes. */
-#define GA10B_GMMU_ENTRY_SIZE   8
+/* Per-level entry sizes. PDE3/PDE2/PDE1 entries are 8 bytes
+ * (single 64-bit value); PDE0 entries are 16 bytes (dual — packs
+ * a big-page child at offset 0..7 and a small-page child at
+ * 8..15); PTE entries are 8 bytes. Constants per nvgpu's
+ * `GA10B_PDE_DEFAULT_ENTRY_SIZE` / `GA10B_PDE0_ENTRY_SIZE` /
+ * `GA10B_PTE_ENTRY_SIZE` in `gmmu_ga10b_fusa.c`. */
+#define GA10B_GMMU_ENTRY_SIZE   8       /* default (PDE3/2/1/PTE) */
+#define GA10B_GMMU_PDE0_SIZE    16      /* dual-PDE0 entry */
 
 /* PDB target (aperture) — from nvgpu's
  * `ram_in_page_dir_base_target_*_f()` constants (instance-block layout). */

--- a/kernel/gpu/nvidia/ga10b_handoff_reserve.c
+++ b/kernel/gpu/nvidia/ga10b_handoff_reserve.c
@@ -715,12 +715,37 @@ void ga10b_kexec_handoff_register_reserves(void)
      * dmabuf in DRAM by scanning for its magic. ~50 ms one-time-only
      * boot cost. A fresh-boot or no-helper test path that doesn't
      * have a kexec'd channel works fine without these reservations —
-     * just leaves PMM with more pages to allocate from. */
+     * just leaves PMM with more pages to allocate from.
+     *
+     * #834: use the kind-aware + validate-filtered scanner here
+     * (NOT the bare magic-match `ga10b_find_handoff_in_range`).
+     * Stale handoff dmabufs from prior helper invocations remain in
+     * DRAM with intact magic but inst_block_phys=0 (the helper's
+     * fallback when gpu_read_fecs_inst_block_phys() fails). With the
+     * unfiltered scanner, this reserve picked up the stale handoff
+     * — at a lower phys than the fresh one — and pinned its
+     * userd/gpfifo/pushbuf/sem buffers, which point at *old*
+     * channels long-since freed. The FRESH channel's buffers, which
+     * the helper actually used and which the GPU writes to, were
+     * left unreserved → PMM clobbered them on first allocation →
+     * silent corruption + boot-to-boot dispatch flakiness +
+     * eventual PMM-free-list page faults from GPU writes into
+     * PMM-owned pages. Observed on jetson-nano-2 (2026-05-16):
+     *   stale 0x12c097000: userd=0x13ae13000 gpfifo=0x12c034000
+     *                       pushbuf=0x13c4a0000 sem=0x129e2b000
+     *   fresh 0x13aee2000: userd=0x10d706000 gpfifo=0x13accd000
+     *                       pushbuf=0x13a9a0000 sem=0x13af83000
+     * All four buffers different — boot reserve pinned the wrong
+     * set entirely. Switching to the kind-aware scanner cascades
+     * the validate-handoff inst_block_phys=0 rejection (commit
+     * a099cd3b) into this code path too. */
     uart_puts("[ga10b-reserve] scanning DRAM for handoff magic + "
               "weights-pool extents...\n");
     uint64_t handoff_phys =
-        ga10b_find_handoff_in_range(0x100000000ull, 0x200000000ull,
-                                     4096ull);
+        ga10b_find_handoff_of_kind_in_range(0x100000000ull,
+                                             0x200000000ull,
+                                             4096ull,
+                                             GA10B_PIPELINE_KIND_MNIST);
     if (handoff_phys == 0) {
         uart_puts("[ga10b-reserve]   handoff not found — skipping "
                   "weights-pool extent reservation\n");

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -4623,6 +4623,50 @@ int cmd_nvgpu(int argc, char *argv[])
         shell_printf("submit: rc=%d, state=%d\r\n", rc, (int)b_p->state);
         return rc;
     }
+    if (strcmp(argv[1], "fecs-stop-restart") == 0) {
+        /* #834 probe Y: force FECS to flush its internal "current
+         * channel" state by issuing STOP_CTXSW (method 0x38)
+         * followed by START_CTXSW (0x39).
+         *
+         * Hypothesis: the CTXSW_CHECKSUM_MISMATCH (mb6=0x21) we
+         * see during `nvgpu submit-compute` ctxsw is because FECS
+         * holds a stale "expected CRC" for the previously-current
+         * channel and compares it against the bytes it reads for
+         * OUR channel. STOP_CTXSW makes FECS drop that state;
+         * START_CTXSW re-enables it for the next runlist event.
+         * If the watchdog stops firing on a subsequent
+         * submit-compute, the staleness hypothesis is correct.
+         *
+         * Method values per `gr_fecs_method_push_adr_stop_ctxsw_v` /
+         * `_start_ctxsw_v` in nvgpu-include-nvgpu-hw-ga10b-hw_gr_
+         * ga10b.h. Both poll for `mailbox_value_pass_v` = 0x1. */
+        int s = ga10b_fecs_method_push(0x38u, 0xFFFFFFFFu, 0x1u);
+        int t = ga10b_fecs_method_push(0x39u, 0xFFFFFFFFu, 0x1u);
+        shell_printf("fecs-stop-restart: STOP_CTXSW=%d "
+                     "START_CTXSW=%d\r\n", s, t);
+        return (s == 0 && t == 0) ? 0 : -1;
+    }
+    if (strcmp(argv[1], "fecs-newctx") == 0) {
+        /* #834 probe S: poke `gr_fecs_new_ctx_r()` with the
+         * handoff's channel inst block phys so FECS knows the
+         * "next" channel for any subsequent ctxsw. Followed by
+         * `nvgpu submit-compute`, this tests whether the FECS
+         * watchdog timeout (gr_intr=0x80000) is caused by FECS
+         * trying to save a stale current_ctx (PDB=0 leftover from
+         * Linux's tear-down) rather than load our channel.
+         *
+         * Requires `nvgpu inherit` + `nvgpu channel` first. */
+        const struct ga10b_channel_handoff *h2 =
+            ga10b_bringup_handoff();
+        if (h2 == NULL || h2->inst_block_phys == 0) {
+            shell_puts("fecs-newctx: no handoff loaded "
+                       "(run nvgpu channel first)\r\n");
+            return -1;
+        }
+        int rc = ga10b_fecs_set_new_ctx(h2->inst_block_phys);
+        shell_printf("fecs-newctx: rc=%d\r\n", rc);
+        return rc;
+    }
     if (strcmp(argv[1], "submit-compute") == 0) {
         /* Phase 7 (compute): COMPUTE_B SEMAPHORE_RELEASE smoke test.
          * Requires `nvgpu inherit` + `nvgpu channel` first (same as
@@ -4746,8 +4790,49 @@ int cmd_nvgpu(int argc, char *argv[])
                     goto oplib_stage_call;
                 }
                 if (h != NULL && h->inst_block_phys != 0) {
-                    inst_phys = h->inst_block_phys;
-                } else {
+                    /* #834 fix A: rebuild the helper-published inst
+                     * block's PDB before staging. The helper publishes
+                     * inst_block_phys via FECS_CURRENT_CTX right
+                     * after its isolation sema fires, but post-kexec
+                     * the PT pages backing Linux's PDB tree may have
+                     * been clobbered by SLM-OS PMM — static walks of
+                     * pushbuf_gpu_va against this PDB show
+                     * PDE2[127] INVALID even though the channel was
+                     * fully functional pre-kexec. The dispatch path
+                     * sees the same INVALID translations, and the
+                     * trailing sema-release write lands at an
+                     * unmapped VA.
+                     *
+                     * Rebuilding produces a fresh SLM-OS-allocated
+                     * PDB and re-installs pushbuf/sema/qmd_pool
+                     * mappings from the handoff. Then
+                     * `oplib_pool_stage_to_gpu` adds shader/cbuf
+                     * mappings to the same PDB, putting every VA
+                     * the dispatch needs in one consistent tree.
+                     *
+                     * Non-destructive (per #839 / #842): the rebuild
+                     * preserves engine_fw_magic, subcontext PDB
+                     * pointers, and Linux's other inst-block fields.
+                     * Only the main PDB pointer + RAMFC + the
+                     * subcontext-VEID slot are overridden. */
+                    shell_printf("oplib stage: rebuilding handoff "
+                                 "inst 0x%lx PDB before staging "
+                                 "(#834 fix A)\r\n",
+                                 (unsigned long)h->inst_block_phys);
+                    int rrc =
+                        ga10b_gmmu_rebuild_for_handoff(
+                            h->inst_block_phys, h);
+                    if (rrc < 0) {
+                        shell_printf("oplib stage: rebuild-gmmu "
+                                     "rc=%d — falling through to "
+                                     "boot/FECS/DRAM discovery\r\n",
+                                     rrc);
+                    } else {
+                        inst_phys = h->inst_block_phys;
+                        goto oplib_stage_call;
+                    }
+                }
+                {
                     /* Prefer the boot-time capture from
                      * `ga10b_kexec_handoff_register_reserves` over a
                      * live FECS_CURRENT_CTX read. The live register


### PR DESCRIPTION
Bundle of fixes + diagnostic infrastructure from the W-series channel-inherit investigation. **Stacked on #842** (preserve inst block instead of zeroing) — merge #842 first.

## Standalone wins

1. **validate-handoff rejects `inst_block_phys=0`** — stale handoff dmabufs left in DRAM by prior helper invocations had intact magic but `inst_block_phys=0` (the helper's FECS-read-failed fallback). The scanner returned the first magic match by phys, so stale handoffs at lower phys masked the fresh helper handoff at higher phys. The added rejection in `ga10b_validate_handoff` cascades through the kind-filtered scanner.

2. **Boot reserve uses kind-filtered scanner** — `ga10b_kexec_handoff_register_reserves` was calling the bare-magic `ga10b_find_handoff_in_range` (no validation) and pinning stale handoffs' buffer addresses. Now uses `ga10b_find_handoff_of_kind_in_range` so the validate rejection cascades to boot-time reserve, pinning the fresh channel's userd/gpfifo/pushbuf/sem instead. Also unlocks v7 (qmd_pool) + v10 (gr_ctx extents) publish the patched nvgpu has been producing all along but the stale-v6 path was hiding.

3. **GMMU walker VA-bit positions corrected** — the constants `GA10B_PDE3_VA_HI` through `GA10B_PTE_VA_LO` in `ga10b_gmmu.h` were a 49-bit-VA placeholder ("best-guess, may need tuning on hardware" per source comment). Updated to match nvgpu's canonical `ga10b_mm_levels[]` in `nvgpu-l4t-r36.4.4-gmmu_ga10b_fusa.c:353`. Five levels: `[48:47]` / `[46:38]` / `[37:29]` / `[28:21]` / `[20:16]` (big-page PTE). Adds `GA10B_GMMU_PDE0_SIZE=16` (dual entries).

4. **Walker handles dual-PDE0 small + big sides** — at L3 try big-page child (offset 0..7); fall back to small-page child (offset 8..15) if invalid. PTE bit-width override: bits `[20:16]` for big-page mappings, bits `[20:12]` for small. The helper allocates buffers as small pages so the fall-through path is the production case.

## rebuild-gmmu changes (#834 fix A)

- `oplib stage` runs `rebuild-gmmu` first to share one PDB
- zero non-VEID-1 subcontexts in inst block
- RAMFC region zero pass + explicit field writes
- hw_chid encoding (`channel_base + chid`) for runlist + CHRAM
- topology-discovered runlist_pri_base
- fresh-runlist write with TSG header + channel entry
- engine_wfi + eng_method_buffer clear

These collectively unblock the rebuild flow to the point where `nvgpu submit` (host-family) succeeds end-to-end through the rebuilt PDB. The W-series oplib dispatch path still hits a follow-up FECS `CTXSW_CHECKSUM_MISMATCH` (mb6=0x21, named constant `gr_fecs_ctxsw_mailbox_value_ctxsw_checksum_mismatch_v` in `hw_gr_ga10b.h:577`) — separately tracked and not fixed by this PR.

## Diagnostic infrastructure

- `ga10b_dump_inst_block_at`: public wrapper for post-rebuild inst-block snapshots
- `nvgpu fecs-newctx`: probes `gr_fecs_new_ctx_r` write
- `nvgpu fecs-stop-restart`: STOP_CTXSW + START_CTXSW method push
- pre-launch sema `FLUSH_DISABLE=1` mode to discriminate host-vs-compute dispatch hangs
- BEFORE/AFTER inst-block dumps in `rebuild-gmmu`

## Hardware verification (jetson-nano-2, 2026-05-17)

- `nvgpu inherit` + `nvgpu channel`: handoff finds fresh helper publication (not stale leftover)
- Boot reserve log shows v7+v10 buffers pinned including the full 2032 KB of per-channel gr_ctx pages
- `nvgpu gmmu walk 0x1ffc000000` (pushbuf VA) resolves to leaf `0x13be40000` = handoff `pushbuf_phys` (exact match)
- `nvgpu gmmu walk 0x1ffc08b000` (sema VA) resolves to leaf `0x13ba74000` = handoff `semaphore_phys` (exact match)
- `nvgpu submit` (host-family, no GR): rc=0, sema fires
- `nvgpu submit-compute` (GR-required): boot-to-boot variance; sometimes rc=0, sometimes FECS CTXSW_CHECKSUM_MISMATCH
- `nvgpu oplib dispatch-rmsnorm` (W-series via rebuild-gmmu): still fails (separately tracked under #834)

## What's NOT solved

The original goal — W-series GPU dispatch through rebuilt channel — is still wedged. After this PR's wins land, the remaining issues are concretely scoped:

a) **Encoder asymmetry in `map_one_page`**: writes small-side PDE0 child but indexes PTE with big-page bit width `[20:16]` instead of small-page `[20:12]`. With the walker now reliable, this is observable directly via `gmmu walk` after rebuild.

b) **FECS CTXSW_CHECKSUM_MISMATCH on first compute ctxsw**: opaque FECS firmware error code `0x21` in mb6. STOP_CTXSW + START_CTXSW method push doesn't reliably recover; needs the full nvgpu channel-recovery sequence.

## Test plan

- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` builds clean
- [x] Hardware-verified on jetson-nano-2 (see above)
- [ ] `make test-ga10b-bringup` host test target — currently broken on this branch due to unrelated link issue tracked under #950 (separately scoped fix)

## Related

- #842 — prereq, merge first
- #839 — addressed in #842's body change
- #834 — root issue, still open (see "What's NOT solved")
- #841, #801, #803, #805, #806 — closed as superseded by this PR's commits
- #950 — broken `test-ga10b-bringup` host link (independent)