### PR TITLE
hailo-re-driver: classify replay-step soft-refuses as ReplayRefused

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -40,6 +40,7 @@ from .qemu_runner import (
 from .slmos_runner import (
     ReplayDivergence,
     ReplayError,
+    ReplayRefused,
     ReplayResponse,
     SlmosRunner,
 )
@@ -209,6 +210,21 @@ def _extend_corpus(
         return _StepOutcome(
             status="error",
             detail=f"replay-step failed: {result.message}\nstderr: {result.stderr}",
+        )
+
+    if isinstance(result, ReplayRefused):
+        # State-condition refuse from the kernel — surface the exact
+        # kernel line and the classified reason so the operator can
+        # diagnose (corpus inconsistency, target seq drift, etc.)
+        # instead of seeing a generic transient. The wrapper still
+        # counts this against MAX_TRANSIENT_FAILURES for now; a future
+        # change may treat refuses as fatal-fast.
+        return _StepOutcome(
+            status="error",
+            detail=(
+                f"replay-step refused: reason={result.reason} "
+                f"line={result.raw_line!r}"
+            ),
         )
 
     if isinstance(result, ReplayDivergence):

--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -65,7 +65,28 @@ class ReplayError:
     stderr: str
 
 
-ReplayResult = Union[ReplayResponse, ReplayDivergence, ReplayError]
+@dataclass(frozen=True)
+class ReplayRefused:
+    """SLM-OS understood the command but declined to execute it.
+
+    Refuses are emitted by `hailo replay-step` for state conditions that
+    won't resolve on retry — the corpus has a duplicate seq, the target
+    seq is already validated, the target is a write, etc. Distinct from
+    ReplayError (which means the request never reached the kernel or the
+    output was unreadable) so callers can stop counting refuses as
+    "transient" and surface them as actionable feedback to the operator.
+
+    `reason` is one of: "parse_failed", "no_entry", "is_write",
+    "already_validated", "wrong_size". `raw_line` is the kernel's
+    diagnostic text verbatim for the log.
+    """
+
+    kind: str  # "refused"
+    reason: str
+    raw_line: str
+
+
+ReplayResult = Union[ReplayResponse, ReplayDivergence, ReplayError, ReplayRefused]
 
 
 # --------------------------------------------------------------------------- #
@@ -151,6 +172,33 @@ class MockSlmosRunner:
 
 _PROTOCOL_RE = re.compile(
     r"^HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE) .*$", re.MULTILINE
+)
+
+# Kernel soft-refuse messages emitted by `hailo replay-step` in
+# kernel/ai_accel/hailo/hailo_shell.c. These are persistent state
+# conditions (corpus inconsistency, target seq is a write, etc.) — not
+# transients. The host classifies them as ReplayRefused so the wrapper
+# can surface the cause instead of burning the full replay timeout
+# waiting for a RESPONSE that will never come.
+_REFUSE_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    ("parse_failed", re.compile(
+        r"^hailo: replay-step: corpus parse failed \(rc=-?\d+.*$",
+        re.MULTILINE,
+    )),
+    ("no_entry", re.compile(
+        r"^hailo: replay-step: no entry at seq=\d+.*$", re.MULTILINE,
+    )),
+    ("is_write", re.compile(
+        r"^hailo: replay-step: seq=\d+ is a write — refusing.*$",
+        re.MULTILINE,
+    )),
+    ("already_validated", re.compile(
+        r"^hailo: replay-step: seq=\d+ is already validated.*$",
+        re.MULTILINE,
+    )),
+    ("wrong_size", re.compile(
+        r"^hailo: replay-step: seq=\d+ has size=\d+.*$", re.MULTILINE,
+    )),
 )
 
 
@@ -259,9 +307,19 @@ class SlmosRunner:
         # report) explicitly says tools must accept any string for the
         # reason tag — additive tags can be added without bumping the
         # corpus format_version, so the matcher must not narrow that.
+        # The labctl --until regex must fire on success AND on any
+        # kernel soft-refuse so the wrapper doesn't burn replay_timeout_s
+        # (30 s) waiting for a RESPONSE/DIVERGENCE that the kernel
+        # explicitly declined to produce. Each refuse phrase appears
+        # before its trailing newline, so anchoring on the tail token
+        # ("refusing", "(rc=", "supported") keeps the line intact for
+        # the downstream parser.
         until_re = (
             r"(?:slmos_sha=[0-9a-f]{40}|"
-            r"HAILO_RE_CORPUS_DIVERGENCE.*reason=\S+)"
+            r"HAILO_RE_CORPUS_DIVERGENCE.*reason=\S+|"
+            r"hailo: replay-step: corpus parse failed \(rc=|"
+            r"hailo: replay-step: no entry at seq=\d+|"
+            r"hailo: replay-step: seq=\d+ (?:is a write|is already validated|has size=\d+))"
         )
         return self.transport(
             [
@@ -322,9 +380,20 @@ class SlmosRunner:
 
 
 def parse_replay_output(text: str) -> ReplayResult:
-    """Find the first HAILO_RE_CORPUS_(RESPONSE|DIVERGENCE) line in text."""
+    """Classify `hailo replay-step` output. Prefers protocol lines
+    (RESPONSE/DIVERGENCE); falls back to soft-refuse detection so
+    state-condition messages from the kernel are surfaced as
+    ReplayRefused rather than the generic "no RESPONSE" timeout."""
     match = _PROTOCOL_RE.search(text)
     if not match:
+        for reason, pattern in _REFUSE_PATTERNS:
+            rm = pattern.search(text)
+            if rm:
+                return ReplayRefused(
+                    kind="refused",
+                    reason=reason,
+                    raw_line=rm.group(0),
+                )
         return ReplayError(
             kind="error",
             message="no HAILO_RE_CORPUS_RESPONSE or _DIVERGENCE line in output",

--- a/host-tools/hailo-re-driver/tests/test_slmos_runner.py
+++ b/host-tools/hailo-re-driver/tests/test_slmos_runner.py
@@ -20,7 +20,12 @@ import conftest  # noqa: F401
 
 from hailo_re_driver.slmos_runner import (
     CmdResult,
+    ReplayDivergence,
+    ReplayError,
+    ReplayRefused,
+    ReplayResponse,
     SlmosRunner,
+    parse_replay_output,
 )
 
 
@@ -202,6 +207,144 @@ class VerifyCardSideEffectTests(unittest.TestCase):
             rec.calls[0][0],
             ["labctl", "power", "off", "pi-5-1"],
         )
+
+
+class SoftRefuseClassificationTests(unittest.TestCase):
+    """The kernel's `hailo replay-step` emits informational refuse lines
+    (kernel/ai_accel/hailo/hailo_shell.c) that contain neither
+    `slmos_sha=` nor `reason=`. Before this regression net those caused
+    `labctl serial send --until` to burn the full 30 s replay timeout
+    and the wrapper logged "no RESPONSE or DIVERGENCE line" — i.e. a
+    silent classification bug that ate hours of overnight grind. Each
+    test below pins one refuse class to ReplayRefused with the right
+    reason tag."""
+
+    def test_parse_classifies_parse_failed_refuse(self) -> None:
+        text = (
+            "hailo replay-step 0:/corpus.jsonl 100\n"
+            "hailo: replay-step: corpus parse failed (rc=-3, ops_parsed=2056)\n"
+            "slmos>\n"
+        )
+        result = parse_replay_output(text)
+        self.assertIsInstance(result, ReplayRefused)
+        assert isinstance(result, ReplayRefused)
+        self.assertEqual(result.reason, "parse_failed")
+        self.assertIn("rc=-3", result.raw_line)
+
+    def test_parse_classifies_no_entry_refuse(self) -> None:
+        text = "hailo: replay-step: no entry at seq=99999\nslmos>\n"
+        result = parse_replay_output(text)
+        self.assertIsInstance(result, ReplayRefused)
+        assert isinstance(result, ReplayRefused)
+        self.assertEqual(result.reason, "no_entry")
+
+    def test_parse_classifies_is_write_refuse(self) -> None:
+        text = (
+            "hailo: replay-step: seq=52288 is a write — refusing "
+            "(seq=N must be a read with validated_at_commit=null)\n"
+            "slmos>\n"
+        )
+        result = parse_replay_output(text)
+        self.assertIsInstance(result, ReplayRefused)
+        assert isinstance(result, ReplayRefused)
+        self.assertEqual(result.reason, "is_write")
+        self.assertIn("seq=52288", result.raw_line)
+
+    def test_parse_classifies_already_validated_refuse(self) -> None:
+        text = (
+            "hailo: replay-step: seq=51511 is already "
+            "validated — refusing (corpus is inconsistent)\n"
+            "slmos>\n"
+        )
+        result = parse_replay_output(text)
+        self.assertIsInstance(result, ReplayRefused)
+        assert isinstance(result, ReplayRefused)
+        self.assertEqual(result.reason, "already_validated")
+
+    def test_parse_classifies_wrong_size_refuse(self) -> None:
+        text = (
+            "hailo: replay-step: seq=100 has size=8; only size=4 is "
+            "supported by the platform shim\n"
+            "slmos>\n"
+        )
+        result = parse_replay_output(text)
+        self.assertIsInstance(result, ReplayRefused)
+        assert isinstance(result, ReplayRefused)
+        self.assertEqual(result.reason, "wrong_size")
+
+    def test_parse_prefers_response_over_refuse(self) -> None:
+        """If both a RESPONSE line and a refuse marker appear (impossible
+        in practice but cheap to pin), the protocol line wins so a
+        success isn't mis-classified as a refuse."""
+        text = (
+            "hailo: replay-step: corpus parse failed (rc=-1, ops_parsed=0)\n"
+            "HAILO_RE_CORPUS_RESPONSE seq=1 bar=4 offset=0 size=4 "
+            "value=12345678 slmos_sha=" + "ab" * 20 + "\n"
+        )
+        result = parse_replay_output(text)
+        self.assertIsInstance(result, ReplayResponse)
+
+    def test_parse_unmatched_output_stays_replay_error(self) -> None:
+        """Output that's neither a protocol line nor a known refuse
+        falls through to ReplayError — so genuine "Pi 5 hung" cases are
+        still distinguishable from refuses."""
+        text = "some unrelated boot noise\nslmos>\n"
+        result = parse_replay_output(text)
+        self.assertIsInstance(result, ReplayError)
+
+
+class SoftRefuseUntilRegexTests(unittest.TestCase):
+    """The `--until` regex passed to `labctl serial send` must fire
+    immediately on a soft-refuse line so the wrapper doesn't burn
+    replay_timeout_s (30 s) per refuse iteration. Pinned per-class so a
+    future kernel message tweak that breaks the regex fails fast."""
+
+    def _get_until_re(self) -> "re.Pattern[str]":
+        import re as re_mod
+
+        rec = _RecordingTransport()
+        runner = SlmosRunner(sbc="pi-5-1", transport=rec)
+        runner.send_replay_command(Path("/dev/null"), 1)
+        argv = rec.calls[0][0]
+        until_idx = argv.index("--until")
+        return re_mod.compile(argv[until_idx + 1])
+
+    def test_until_fires_on_parse_failed(self) -> None:
+        rx = self._get_until_re()
+        line = "hailo: replay-step: corpus parse failed (rc=-3, ops_parsed=2056)"
+        self.assertIsNotNone(rx.search(line))
+
+    def test_until_fires_on_no_entry(self) -> None:
+        rx = self._get_until_re()
+        line = "hailo: replay-step: no entry at seq=99999"
+        self.assertIsNotNone(rx.search(line))
+
+    def test_until_fires_on_is_write(self) -> None:
+        rx = self._get_until_re()
+        line = "hailo: replay-step: seq=52288 is a write — refusing (...)"
+        self.assertIsNotNone(rx.search(line))
+
+    def test_until_fires_on_already_validated(self) -> None:
+        rx = self._get_until_re()
+        line = "hailo: replay-step: seq=51511 is already validated — refusing"
+        self.assertIsNotNone(rx.search(line))
+
+    def test_until_fires_on_wrong_size(self) -> None:
+        rx = self._get_until_re()
+        line = "hailo: replay-step: seq=100 has size=8; only size=4 supported"
+        self.assertIsNotNone(rx.search(line))
+
+    def test_until_does_not_fire_on_in_progress_diag(self) -> None:
+        """The success-path diagnostic line `hailo: replay-step: corpus
+        ops=N target seq=M ...` must NOT match the until regex — if it
+        did, labctl would return before the actual RESPONSE line
+        landed."""
+        rx = self._get_until_re()
+        line = (
+            "hailo: replay-step: corpus ops=2057 target seq=51511 "
+            "bar=4 offset=0x0"
+        )
+        self.assertIsNone(rx.search(line))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause

Investigating the Phase 2 grind's recurring \"no HAILO_RE_CORPUS_RESPONSE or _DIVERGENCE line\" failures (batches 1, 5, 10 of last night's run), live serial probe on pi-5-1 showed the kernel was actually emitting one of five informational refuse lines from \`hailo replay-step\` in \`kernel/ai_accel/hailo/hailo_shell.c\`:

\`\`\`
hailo: replay-step: corpus parse failed (rc=-3, ops_parsed=2056)
hailo: replay-step: no entry at seq=N
hailo: replay-step: seq=N is a write — refusing (...)
hailo: replay-step: seq=N is already validated — refusing (...)
hailo: replay-step: seq=N has size=K; only size=4 is supported (...)
\`\`\`

None of these contain \`slmos_sha=\` (RESPONSE marker) or \`reason=\` (DIVERGENCE marker), so:

1. \`labctl serial send --until\` waits the **full 30 s** \`replay_timeout_s\` before returning (lab time burned per iteration).
2. The bootstrap reports the generic \"no RESPONSE or DIVERGENCE line\" — an operator can't tell a state-bug from a hung Pi 5.
3. The wrapper retries it as transient, but the refuse conditions are persistent (corpus inconsistency, target seq drift, etc.) — retry doesn't help.

## Fix

Three host-tool changes:

1. **Widen \`--until\` regex** in \`send_replay_command\` to anchor on each refuse phrase. labctl returns immediately on a refuse — no 30 s wait.
2. **New \`ReplayRefused\` result type** carrying \`reason\` (one of: \`parse_failed\`, \`no_entry\`, \`is_write\`, \`already_validated\`, \`wrong_size\`) and \`raw_line\` (kernel diagnostic verbatim).
3. **\`parse_replay_output\`** tries \`_PROTOCOL_RE\` first (RESPONSE always wins), then \`_REFUSE_PATTERNS\`, then falls through to generic \`ReplayError\` so genuine hangs stay distinguishable.

\`_extend_corpus\` in \`loop.py\` handles the new variant and surfaces \`replay-step refused: reason=... line=...\` to the batch log. The wrapper still counts refuses against \`MAX_TRANSIENT_FAILURES\` — a future change may classify them as fatal-fast.

## What this does NOT do

- Doesn't fix the **underlying** state condition that makes the wrapper request EXTEND at a seq the kernel already treats as a write / validated read. That's a separate driver-side investigation (next_seq calculation, cross-run corpus reconciliation).
- Doesn't change wrapper's retry policy — refuses still count as transient, but they're now visible and don't waste 30 s each.

## Test plan

- [x] 5 classification tests (one per refuse class).
- [x] Cross-check: RESPONSE line preempts refuse marker in the same buffer.
- [x] Unmatched output → still \`ReplayError\` (silent-hang case stays distinguishable).
- [x] 5 \`--until\` regex tests (one per refuse class).
- [x] Negative test: success-path \"corpus ops=... target seq=...\" diagnostic must NOT match (otherwise labctl returns mid-line).
- [x] \`python3 -m unittest discover tests\`: 72/72 PASS.
- [ ] Live grind re-relaunch: confirm refuses appear with actionable reason in the batch log and labctl returns sub-second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)