### PR TITLE
ai-runtime: per-operator profiling harness (#56)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -312,6 +312,27 @@ Real ONNX model inference using the built-in MNIST digit classifier (26 KB, 12 o
 
 Every sample in 1000 iterations measured 1,092 µs except one outlier at 1,100 µs. The 8 µs max jitter demonstrates deterministic inference suitable for real-time edge deployment.
 
+### Per-operator Profile (#56)
+
+The per-op profiling harness in `runtime/src/inference/engine.rs` wraps every `execute_node` dispatch in CNTPCT timestamps and accumulates per-`OpType` counts and latencies. Enable with `model profile on`, run the workload, then `model profile show` (clear with `model profile reset`). Overhead is negligible: 200-iteration MNIST bench on pi-5-2 measured 3,011 µs/inference both profile-on and profile-off (run-to-run jitter swamps the harness cost).
+
+Baseline before #56 micro-kernel work (Pi 5, BUILD_TYPE=Release, pi-5-2, 200 iterations, MNIST). Per-op figures are reported in microseconds; "calls" is the count of `execute_node` invocations across the run.
+
+| Op | Calls | Avg | Min | Max | Notes |
+|----|-------|-----|-----|-----|-------|
+| Conv | 400 | **1,433 µs** | 1,048 µs | 1,818 µs | Dominant — two conv layers × 200 iters |
+| MatMul | 200 | 22 µs | 22 µs | 24 µs | Output Gemm decomposes to one MatMul |
+| Relu | 400 | 19 µs | 7 µs | 31 µs | |
+| MaxPool | 400 | 15 µs | 6 µs | 24 µs | |
+| Add | 600 | 9 µs | 2 µs | 21 µs | Conv-bias + Gemm-bias adds |
+| Reshape | 400 | 1 µs | 1 µs | 2 µs | |
+
+Total dispatched-op time per inference (`Σ avg × calls / iters`): ~2,985 µs, accounting for ~99% of the 3,011 µs bench latency. The remaining ~26 µs is engine-side overhead (binding lookups, output copy, weight lease, atomic stats).
+
+`Conv` consumes ~95% of inference latency — the matmul micro-kernel improvements in #56 PR 2 / PR 3 target the im2col→matmul inner loop inside `conv2d`, so the speedup on this column is what the post-optimization rows track. Note the current Pi 5 baseline is **3.01 ms/inference**, higher than the 1.09 ms recorded in the cross-platform table above (which dates from an earlier build); the #56 PRs land before/after numbers against the current measurement so the delta is apples-to-apples.
+
+The Jetson hardware baseline will be captured during PR 2 deployment once the slmos-kexec deploy path is in this agent's reach.
+
 ### Model Memory Utilization
 
 | Model | Weight Blocks | Workspace Blocks | Actual Weights |

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -729,9 +729,13 @@ extern int rust_infer_bench(uint32_t model_index, uint32_t iterations);
 
 /*
  * Per-operator profile entry (#56). Layout must match
- * `runtime/src/inference/engine.rs::OpProfileEntry`.
- * `op_type` is the same discriminant the Rust engine stores in
- * `GraphNode.op_type` — see slm_op_type_name() for a label.
+ * `runtime/src/inference/engine.rs::OpProfileEntry` exactly — see the
+ * `_pad` comment there for the explicit-padding rationale.
+ *
+ * `op_type` is the `OpType` discriminant from
+ * `runtime/src/loader/graph.rs` (0 = MatMul, 1 = Add, …, 16 = MaxPool,
+ * 255 = Unknown). The `model profile show` handler in shell_sys.c
+ * does the label lookup inline.
  */
 typedef struct {
     uint8_t  op_type;

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -728,6 +728,51 @@ extern int rust_infer_stats(RustInferStats *stats);
 extern int rust_infer_bench(uint32_t model_index, uint32_t iterations);
 
 /*
+ * Per-operator profile entry (#56). Layout must match
+ * `runtime/src/inference/engine.rs::OpProfileEntry`.
+ * `op_type` is the same discriminant the Rust engine stores in
+ * `GraphNode.op_type` — see slm_op_type_name() for a label.
+ */
+typedef struct {
+    uint8_t  op_type;
+    uint8_t  _pad[7];
+    uint64_t count;
+    uint64_t total_ns;
+    uint64_t min_ns;
+    uint64_t max_ns;
+} RustOpProfileEntry;
+
+/*
+ * Number of profile buckets (one per OpType, plus Unknown).
+ * Mirrors PROFILE_NUM_OPS in the Rust side; if the enum gains a
+ * variant, bump both at once.
+ */
+#define RUST_INFER_PROFILE_NUM_OPS 18
+
+/*
+ * Enable or disable per-operator profiling.
+ *   enabled == 0  -> profiling off (default, near-zero overhead).
+ *   enabled != 0  -> profiling on; each op pays two CNTPCT reads
+ *                    plus three atomic updates per invocation.
+ * Returns 0.
+ */
+extern int rust_infer_profile_enable(uint32_t enabled);
+
+/*
+ * Reset every bucket to zero. Call before a measurement window so
+ * warm-up samples don't pollute the average.
+ */
+extern int rust_infer_profile_reset(void);
+
+/*
+ * Snapshot the per-operator profile into `out` (must be sized for at
+ * least `max_entries` RustOpProfileEntry slots). Returns the number
+ * of rows written, or -1 if `out` is NULL.
+ */
+extern int rust_infer_profile_snapshot(RustOpProfileEntry *out,
+                                       uint32_t max_entries);
+
+/*
  * Square FP32 matmul benchmark (128×128×128, N iterations). Prints
  * latency and achieved GFLOPS. Exercises the NEON-tiled FP32 kernel
  * on aarch64; scalar fallback on other archs.

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -3098,6 +3098,89 @@ int cmd_model(int argc, char *argv[])
         return rust_infer_bench((uint32_t)idx, iters);
     }
 
+    /*
+     * `model profile <on|off|reset|show>` — per-operator profiler hook
+     * for #56. `show` is the most useful subcommand: it prints a table
+     * of (op, count, avg, min, max) so a benchmark run can be sliced
+     * down to its dominant kernels. Workflow:
+     *   model profile reset && model bench mnist 200 && model profile show
+     * The on/off knobs are exposed so an operator can leave profiling
+     * armed across multiple bench runs (or compare profiled vs
+     * unprofiled steady-state latency).
+     */
+    if (strcmp(subcmd, "profile") == 0) {
+        if (argc < 3) {
+            shell_puts("Usage: model profile <on|off|reset|show>\r\n");
+            return -1;
+        }
+        const char *action = argv[2];
+        if (strcmp(action, "on") == 0) {
+            rust_infer_profile_enable(1);
+            shell_puts("model profile: ON\r\n");
+            return 0;
+        }
+        if (strcmp(action, "off") == 0) {
+            rust_infer_profile_enable(0);
+            shell_puts("model profile: off\r\n");
+            return 0;
+        }
+        if (strcmp(action, "reset") == 0) {
+            rust_infer_profile_reset();
+            shell_puts("model profile: cleared\r\n");
+            return 0;
+        }
+        if (strcmp(action, "show") == 0) {
+            RustOpProfileEntry entries[RUST_INFER_PROFILE_NUM_OPS];
+            int n = rust_infer_profile_snapshot(
+                entries, RUST_INFER_PROFILE_NUM_OPS);
+            if (n <= 0) {
+                shell_puts("model profile: no data\r\n");
+                return 0;
+            }
+            /*
+             * Op-type names mirror runtime/src/loader/graph.rs::OpType.
+             * Indexed by the `op_type` discriminant (255 = Unknown
+             * folds onto the last slot via the lookup below).
+             */
+            static const char *op_name[] = {
+                "MatMul", "Add", "Relu", "Softmax", "LayerNorm",
+                "Reshape", "Transpose", "Gather", "Concat",
+                "Unsqueeze", "Gemm", "Flatten", "Shape", "Constant",
+                "Cast", "Conv", "MaxPool",
+            };
+            shell_puts("Per-op profile (count / avg us / min us / max us)\r\n");
+            shell_puts("---------------------------------------------------\r\n");
+            int printed = 0;
+            for (int i = 0; i < n; i++) {
+                if (entries[i].count == 0) {
+                    continue;
+                }
+                const char *label;
+                if (entries[i].op_type < 17u) {
+                    label = op_name[entries[i].op_type];
+                } else {
+                    label = "Unknown";
+                }
+                unsigned long avg_us = (unsigned long)(
+                    entries[i].total_ns / entries[i].count / 1000u);
+                shell_printf("  %-10s  %8lu  %6lu  %6lu  %6lu\r\n",
+                    label,
+                    (unsigned long)entries[i].count,
+                    avg_us,
+                    (unsigned long)(entries[i].min_ns / 1000u),
+                    (unsigned long)(entries[i].max_ns / 1000u));
+                printed++;
+            }
+            if (printed == 0) {
+                shell_puts("  (no ops sampled — is profiling enabled?)\r\n");
+            }
+            return 0;
+        }
+        shell_printf("model profile: unknown action '%s' "
+                     "(want on|off|reset|show)\r\n", action);
+        return -1;
+    }
+
     if (strcmp(subcmd, "pin") == 0) {
         if (argc < 3) {
             shell_puts("Usage: model pin <name|idx>\r\n");

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -2969,6 +2969,23 @@ static int model_infer(int argc, char *argv[])
     return 0;
 }
 
+/*
+ * Op-type names indexed by the `op_type` discriminant from
+ * `runtime/src/loader/graph.rs::OpType`. Slot 0 = MatMul .. slot 16
+ * = MaxPool; discriminant 255 (Unknown) falls outside the table and
+ * is labelled inline at the call site. Hoisted to file scope so a
+ * future diagnostic dump (per-op cost stats, op-counter histograms)
+ * can reuse the same lookup without redefining the table.
+ */
+static const char *const slm_op_type_names[] = {
+    "MatMul", "Add", "Relu", "Softmax", "LayerNorm",
+    "Reshape", "Transpose", "Gather", "Concat",
+    "Unsqueeze", "Gemm", "Flatten", "Shape", "Constant",
+    "Cast", "Conv", "MaxPool",
+};
+#define SLM_OP_TYPE_NAME_COUNT \
+    (sizeof(slm_op_type_names) / sizeof(slm_op_type_names[0]))
+
 int cmd_model(int argc, char *argv[])
 {
     if (argc < 2) {
@@ -3137,19 +3154,6 @@ int cmd_model(int argc, char *argv[])
                 shell_puts("model profile: no data\r\n");
                 return 0;
             }
-            /*
-             * Op-type names mirror runtime/src/loader/graph.rs::OpType.
-             * Indexed by the `op_type` discriminant (255 = Unknown
-             * folds onto the last slot via the lookup below).
-             */
-            static const char *op_name[] = {
-                "MatMul", "Add", "Relu", "Softmax", "LayerNorm",
-                "Reshape", "Transpose", "Gather", "Concat",
-                "Unsqueeze", "Gemm", "Flatten", "Shape", "Constant",
-                "Cast", "Conv", "MaxPool",
-            };
-            const size_t op_name_count =
-                sizeof(op_name) / sizeof(op_name[0]);
             shell_puts("Per-op profile (count / avg us / min us / max us)\r\n");
             shell_puts("---------------------------------------------------\r\n");
             int printed = 0;
@@ -3157,9 +3161,13 @@ int cmd_model(int argc, char *argv[])
                 if (entries[i].count == 0) {
                     continue;
                 }
+                /*
+                 * Discriminant 255 (Unknown) and any future
+                 * out-of-table discriminant fall through to "Unknown".
+                 */
                 const char *label;
-                if ((size_t)entries[i].op_type < op_name_count) {
-                    label = op_name[entries[i].op_type];
+                if ((size_t)entries[i].op_type < SLM_OP_TYPE_NAME_COUNT) {
+                    label = slm_op_type_names[entries[i].op_type];
                 } else {
                     label = "Unknown";
                 }

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -3148,6 +3148,8 @@ int cmd_model(int argc, char *argv[])
                 "Unsqueeze", "Gemm", "Flatten", "Shape", "Constant",
                 "Cast", "Conv", "MaxPool",
             };
+            const size_t op_name_count =
+                sizeof(op_name) / sizeof(op_name[0]);
             shell_puts("Per-op profile (count / avg us / min us / max us)\r\n");
             shell_puts("---------------------------------------------------\r\n");
             int printed = 0;
@@ -3156,7 +3158,7 @@ int cmd_model(int argc, char *argv[])
                     continue;
                 }
                 const char *label;
-                if (entries[i].op_type < 17u) {
+                if ((size_t)entries[i].op_type < op_name_count) {
                     label = op_name[entries[i].op_type];
                 } else {
                     label = "Unknown";

--- a/runtime/src/inference/engine.rs
+++ b/runtime/src/inference/engine.rs
@@ -83,6 +83,205 @@ fn record_error() {
     STATS_ERRORS.fetch_add(1, Ordering::Relaxed);
 }
 
+// =============================================================================
+// Per-operator profiling (#56)
+// =============================================================================
+
+/// Number of buckets in the per-operator profile table.
+///
+/// One bucket per known `OpType` variant plus one for `OpType::Unknown`,
+/// so a graph with an unhandled op still gets counted instead of being
+/// silently lost. `op_type_to_index` maps the enum onto this index space.
+pub const PROFILE_NUM_OPS: usize = 18;
+
+/// One row of the per-operator profile snapshot.
+///
+/// `op_type` is the same `u8` discriminant the engine stores in
+/// `GraphNode.op_type` (so the C side can label rows without copying
+/// any strings across the FFI). `count == 0` means the op never ran in
+/// the current measurement window.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct OpProfileEntry {
+    pub op_type: u8,
+    pub _pad: [u8; 7],
+    pub count: u64,
+    pub total_ns: u64,
+    pub min_ns: u64,
+    pub max_ns: u64,
+}
+
+impl OpProfileEntry {
+    pub const EMPTY: Self = Self {
+        op_type: 0,
+        _pad: [0; 7],
+        count: 0,
+        total_ns: 0,
+        min_ns: 0,
+        max_ns: 0,
+    };
+}
+
+static OP_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
+
+// One `AtomicU64` per (bucket, field). Split arrays (rather than an
+// `[OpProfileEntry; N]` struct) so that the hot path can update a
+// single field without a CAS-the-whole-struct dance.
+static PROF_COUNT: [AtomicU64; PROFILE_NUM_OPS] = {
+    const Z: AtomicU64 = AtomicU64::new(0);
+    [Z; PROFILE_NUM_OPS]
+};
+static PROF_TOTAL_NS: [AtomicU64; PROFILE_NUM_OPS] = {
+    const Z: AtomicU64 = AtomicU64::new(0);
+    [Z; PROFILE_NUM_OPS]
+};
+static PROF_MIN_NS: [AtomicU64; PROFILE_NUM_OPS] = {
+    const M: AtomicU64 = AtomicU64::new(u64::MAX);
+    [M; PROFILE_NUM_OPS]
+};
+static PROF_MAX_NS: [AtomicU64; PROFILE_NUM_OPS] = {
+    const Z: AtomicU64 = AtomicU64::new(0);
+    [Z; PROFILE_NUM_OPS]
+};
+
+/// Map an `OpType` discriminant into the `[0, PROFILE_NUM_OPS)` index
+/// space the profile arrays use. `OpType::Unknown` is intentionally
+/// folded onto the last slot rather than being dropped on the floor.
+fn op_type_to_index(op: OpType) -> usize {
+    match op {
+        OpType::MatMul => 0,
+        OpType::Add => 1,
+        OpType::Relu => 2,
+        OpType::Softmax => 3,
+        OpType::LayerNorm => 4,
+        OpType::Reshape => 5,
+        OpType::Transpose => 6,
+        OpType::Gather => 7,
+        OpType::Concat => 8,
+        OpType::Unsqueeze => 9,
+        OpType::Gemm => 10,
+        OpType::Flatten => 11,
+        OpType::Shape => 12,
+        OpType::Constant => 13,
+        OpType::Cast => 14,
+        OpType::Conv => 15,
+        OpType::MaxPool => 16,
+        OpType::Unknown => 17,
+    }
+}
+
+/// Reverse of `op_type_to_index` — used by snapshot consumers to label
+/// rows with the original `OpType` discriminant.
+fn index_to_op_type_u8(i: usize) -> u8 {
+    match i {
+        0 => OpType::MatMul as u8,
+        1 => OpType::Add as u8,
+        2 => OpType::Relu as u8,
+        3 => OpType::Softmax as u8,
+        4 => OpType::LayerNorm as u8,
+        5 => OpType::Reshape as u8,
+        6 => OpType::Transpose as u8,
+        7 => OpType::Gather as u8,
+        8 => OpType::Concat as u8,
+        9 => OpType::Unsqueeze as u8,
+        10 => OpType::Gemm as u8,
+        11 => OpType::Flatten as u8,
+        12 => OpType::Shape as u8,
+        13 => OpType::Constant as u8,
+        14 => OpType::Cast as u8,
+        15 => OpType::Conv as u8,
+        16 => OpType::MaxPool as u8,
+        _ => OpType::Unknown as u8,
+    }
+}
+
+/// Enable or disable per-op profiling. When disabled, `execute_node`
+/// takes the same fast path it did before #56 (single match dispatch,
+/// no timestamps). When enabled, every op invocation pays two CNTPCT
+/// reads + one `fetch_add` triple — measured at ~250 ns/op on Pi 5,
+/// negligible against op latencies in the µs range but enough that the
+/// flag stays opt-in.
+pub fn op_profile_set_enabled(enabled: bool) {
+    OP_PROFILE_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub fn op_profile_is_enabled() -> bool {
+    OP_PROFILE_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Zero every bucket. `min_ns` resets to `u64::MAX` so the first
+/// recorded sample wins the CAS unconditionally; the snapshot getter
+/// reports it as 0 if `count == 0`.
+pub fn op_profile_reset() {
+    for i in 0..PROFILE_NUM_OPS {
+        PROF_COUNT[i].store(0, Ordering::Relaxed);
+        PROF_TOTAL_NS[i].store(0, Ordering::Relaxed);
+        PROF_MIN_NS[i].store(u64::MAX, Ordering::Relaxed);
+        PROF_MAX_NS[i].store(0, Ordering::Relaxed);
+    }
+}
+
+/// Record one op invocation. Called from `execute_node` only when
+/// profiling is enabled — the caller does the enable check so that the
+/// disabled path doesn't even read `OP_PROFILE_ENABLED`.
+fn op_profile_record(op_type: OpType, ns: u64) {
+    let i = op_type_to_index(op_type);
+    PROF_COUNT[i].fetch_add(1, Ordering::Relaxed);
+    PROF_TOTAL_NS[i].fetch_add(ns, Ordering::Relaxed);
+    let mut cur = PROF_MIN_NS[i].load(Ordering::Relaxed);
+    while ns < cur {
+        match PROF_MIN_NS[i].compare_exchange_weak(
+            cur, ns, Ordering::Relaxed, Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(actual) => cur = actual,
+        }
+    }
+    cur = PROF_MAX_NS[i].load(Ordering::Relaxed);
+    while ns > cur {
+        match PROF_MAX_NS[i].compare_exchange_weak(
+            cur, ns, Ordering::Relaxed, Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(actual) => cur = actual,
+        }
+    }
+}
+
+/// Copy at most `max_entries` rows into `out` (one per op bucket, in
+/// fixed `op_type_to_index` order). Returns the number of rows written.
+/// Caller is responsible for sizing `out` to at least `PROFILE_NUM_OPS`
+/// entries when they want the full table.
+///
+/// # Safety
+///
+/// `out` must be writable for `min(max_entries, PROFILE_NUM_OPS)`
+/// `OpProfileEntry` values and properly aligned.
+pub unsafe fn op_profile_snapshot(
+    out: *mut OpProfileEntry,
+    max_entries: usize,
+) -> usize {
+    let n = core::cmp::min(max_entries, PROFILE_NUM_OPS);
+    for i in 0..n {
+        let count = PROF_COUNT[i].load(Ordering::Relaxed);
+        let min = PROF_MIN_NS[i].load(Ordering::Relaxed);
+        let entry = OpProfileEntry {
+            op_type: index_to_op_type_u8(i),
+            _pad: [0; 7],
+            count,
+            total_ns: PROF_TOTAL_NS[i].load(Ordering::Relaxed),
+            // When no samples have been recorded, `min` is still
+            // `u64::MAX` from reset. Surface 0 to the consumer so a
+            // `model profile show` line for an unused op reads cleanly
+            // instead of as a 64-bit poison value.
+            min_ns: if count == 0 || min == u64::MAX { 0 } else { min },
+            max_ns: PROF_MAX_NS[i].load(Ordering::Relaxed),
+        };
+        unsafe { *out.add(i) = entry; }
+    }
+    n
+}
+
 /// Errors from the inference engine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EngineError {
@@ -317,32 +516,56 @@ impl InferenceEngine {
     }
 
     /// Execute a single graph node.
+    ///
+    /// Wraps the op dispatch in CNTPCT timestamps when per-op profiling
+    /// is enabled (#56). The unwrapped path is unchanged when profiling
+    /// is off: a single load of `OP_PROFILE_ENABLED` and a branch.
     fn execute_node(&mut self, node_idx: usize) -> Result<(), EngineError> {
         let node = self.graph.nodes[node_idx];
 
+        if op_profile_is_enabled() {
+            let start = kernel_ffi::get_time_ns();
+            let result = self.dispatch_node(&node);
+            let elapsed = kernel_ffi::get_time_ns().saturating_sub(start);
+            // Record the timing even on error so the profile reflects
+            // wall-clock cost paid by the engine, not just successful
+            // ops. Callers that want success-only numbers can filter
+            // by `result.is_ok()` themselves.
+            op_profile_record(node.op_type, elapsed);
+            result
+        } else {
+            self.dispatch_node(&node)
+        }
+    }
+
+    /// Inner op dispatch, separated from `execute_node` so the
+    /// profiling wrapper above can time it without the match having to
+    /// be duplicated. The body is exactly what `execute_node` did
+    /// before #56.
+    fn dispatch_node(&mut self, node: &GraphNode) -> Result<(), EngineError> {
         match node.op_type {
-            OpType::Reshape => self.exec_reshape(&node),
+            OpType::Reshape => self.exec_reshape(node),
             OpType::MatMul => {
                 // Hybrid dispatch: try GPU for large MatMul, fall back to CPU
                 let backend = super::gpu::select_backend(
                     OpType::MatMul,
-                    self.estimate_input_elements(&node),
+                    self.estimate_input_elements(node),
                     &self.gpu_caps,
                 );
                 if backend == super::gpu::Backend::Gpu {
-                    if self.exec_matmul_gpu(&node).is_ok() {
+                    if self.exec_matmul_gpu(node).is_ok() {
                         return Ok(());
                     }
                 }
-                self.exec_matmul(&node)
+                self.exec_matmul(node)
             }
-            OpType::Add => self.exec_add(&node),
-            OpType::Relu => self.exec_relu(&node),
-            OpType::Softmax => self.exec_softmax(&node),
-            OpType::Gemm => self.exec_gemm(&node),
-            OpType::Flatten => self.exec_flatten(&node),
-            OpType::Conv => self.exec_conv(&node),
-            OpType::MaxPool => self.exec_maxpool(&node),
+            OpType::Add => self.exec_add(node),
+            OpType::Relu => self.exec_relu(node),
+            OpType::Softmax => self.exec_softmax(node),
+            OpType::Gemm => self.exec_gemm(node),
+            OpType::Flatten => self.exec_flatten(node),
+            OpType::Conv => self.exec_conv(node),
+            OpType::MaxPool => self.exec_maxpool(node),
             // Shape/Constant/Cast are handled implicitly (weights already bound)
             OpType::Shape | OpType::Constant | OpType::Cast | OpType::Unsqueeze => {
                 // These ops produce values that should already be in the weight table

--- a/runtime/src/inference/engine.rs
+++ b/runtime/src/inference/engine.rs
@@ -100,6 +100,12 @@ pub const PROFILE_NUM_OPS: usize = 18;
 /// `GraphNode.op_type` (so the C side can label rows without copying
 /// any strings across the FFI). `count == 0` means the op never ran in
 /// the current measurement window.
+///
+/// Layout MUST match `RustOpProfileEntry` in `kernel/include/slm_ffi.h`.
+/// `#[repr(C)]` on a `(u8, u64, ...)` would natively pad 7 bytes after
+/// `op_type` anyway, but the explicit `_pad` field documents the
+/// guarantee and lets the snapshot writer zero-init the bytes (no
+/// kernel-stack contents leak across the FFI to the shell printer).
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct OpProfileEntry {
@@ -212,6 +218,14 @@ pub fn op_profile_is_enabled() -> bool {
 /// Zero every bucket. `min_ns` resets to `u64::MAX` so the first
 /// recorded sample wins the CAS unconditionally; the snapshot getter
 /// reports it as 0 if `count == 0`.
+///
+/// **Not atomic** with respect to a concurrent `op_profile_record`:
+/// a record interleaved with the reset can yield COUNT=0 while
+/// TOTAL/MIN/MAX still carry pre-reset data (or vice-versa). The
+/// intended usage is `reset` → run the workload → `snapshot`; the
+/// engine's `EngineGuard` already serialises ops in practice so an
+/// interleaving is only possible if the operator runs `model profile
+/// reset` mid-bench, which is a user-error pattern.
 pub fn op_profile_reset() {
     for i in 0..PROFILE_NUM_OPS {
         PROF_COUNT[i].store(0, Ordering::Relaxed);
@@ -252,6 +266,16 @@ fn op_profile_record(op_type: OpType, ns: u64) {
 /// fixed `op_type_to_index` order). Returns the number of rows written.
 /// Caller is responsible for sizing `out` to at least `PROFILE_NUM_OPS`
 /// entries when they want the full table.
+///
+/// **Not atomic across rows.** Each row's four fields (count, total,
+/// min, max) are read with independent Relaxed loads, and the
+/// row-to-row loop is not synchronised against
+/// `op_profile_record`. A concurrent record can land between two
+/// rows of the same snapshot. For a diagnostic profiler this is fine
+/// — the inference engine serialises ops through `EngineGuard` so
+/// the only "concurrent" recorder in practice is the very op the
+/// shell command interleaves with, and the loop completes in tens of
+/// nanoseconds. Do not use this snapshot for hard correctness checks.
 ///
 /// # Safety
 ///

--- a/runtime/src/inference/engine.rs
+++ b/runtime/src/inference/engine.rs
@@ -110,6 +110,12 @@ pub const PROFILE_NUM_OPS: usize = 18;
 #[derive(Debug, Clone, Copy)]
 pub struct OpProfileEntry {
     pub op_type: u8,
+    /// Explicit padding for FFI layout parity with
+    /// `RustOpProfileEntry` in `kernel/include/slm_ffi.h`. Treat as
+    /// private — `pub` only because `#[repr(C)]` requires all fields
+    /// be visible to layout consumers; `#[doc(hidden)]` keeps it out
+    /// of rustdoc so consumers aren't tempted to read or write it.
+    #[doc(hidden)]
     pub _pad: [u8; 7],
     pub count: u64,
     pub total_ns: u64,

--- a/runtime/src/inference/mod.rs
+++ b/runtime/src/inference/mod.rs
@@ -33,3 +33,8 @@ pub mod gpu_slm;
 pub use tensor::Tensor;
 pub use workspace::BumpAllocator;
 pub use engine::{InferenceEngine, EngineError, InferenceStats, run_inference, get_stats};
+pub use engine::{
+    OpProfileEntry, PROFILE_NUM_OPS,
+    op_profile_set_enabled, op_profile_is_enabled,
+    op_profile_reset, op_profile_snapshot,
+};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5709,6 +5709,54 @@ pub extern "C" fn rust_infer_bench(model_index: u32, iterations: u32) -> i32 {
     0
 }
 
+/// Enable or disable per-operator profiling (#56).
+///
+/// When enabled, `Engine::execute_node` wraps every op dispatch in
+/// CNTPCT timestamps and updates the per-op bucket in
+/// `inference::engine`'s profile table. When disabled, the engine
+/// takes the same fast path it did before this hook was added.
+///
+/// `enabled`: 0 turns profiling off, any non-zero value turns it on.
+/// Returns 0 unconditionally.
+#[no_mangle]
+pub extern "C" fn rust_infer_profile_enable(enabled: u32) -> i32 {
+    inference::op_profile_set_enabled(enabled != 0);
+    0
+}
+
+/// Reset every bucket in the per-operator profile table to zero.
+/// Useful to drop warmup-iteration samples before a benchmark run.
+#[no_mangle]
+pub extern "C" fn rust_infer_profile_reset() -> i32 {
+    inference::op_profile_reset();
+    0
+}
+
+/// Snapshot the per-operator profile into a caller-supplied buffer.
+///
+/// `out` must point to at least `max_entries` `inference::OpProfileEntry`
+/// slots. The function writes up to `min(max_entries, PROFILE_NUM_OPS)`
+/// rows in fixed op-bucket order and returns the count written.
+/// Returns -1 on null `out`.
+///
+/// # Safety
+///
+/// `out` must be writable for the declared `max_entries`, properly
+/// aligned. The buffer lifetime must cover the call.
+#[no_mangle]
+pub unsafe extern "C" fn rust_infer_profile_snapshot(
+    out: *mut inference::OpProfileEntry,
+    max_entries: u32,
+) -> i32 {
+    if out.is_null() {
+        return -1;
+    }
+    let n = unsafe {
+        inference::op_profile_snapshot(out, max_entries as usize)
+    };
+    n as i32
+}
+
 /// Run inference with zero input and return the argmax class.
 ///
 /// Used by kernel-mode components (compiled with -mgeneral-regs-only)
@@ -7145,6 +7193,52 @@ pub extern "C" fn rust_inference_test() -> i32 {
         // round-to-zero in f32_to_fp16 adds up to 1 ULP more.
         let passed = max_err < 0.01;
         print_test_result(b"fp16: f32_to_fp16 round-trip\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: per-op profile reset/snapshot is sane.
+    //
+    // Validates the #56 harness without needing a loaded model.
+    // After a fresh reset, every bucket is zero. The snapshot writes
+    // exactly `min(max_entries, PROFILE_NUM_OPS)` rows, in the bucket
+    // order defined by `op_type_to_index`, with `op_type == MatMul`
+    // (`0`) at slot 0 and `op_type == Unknown` (`255`) at slot 17.
+    // Together this catches both "snapshot wrote nothing" and "bucket
+    // 17 wrote OpType::Unknown's discriminant" regressions.
+    {
+        inference::op_profile_reset();
+        let mut buf = [inference::OpProfileEntry::EMPTY;
+                       inference::PROFILE_NUM_OPS];
+        let n = unsafe {
+            inference::op_profile_snapshot(buf.as_mut_ptr(),
+                                           inference::PROFILE_NUM_OPS)
+        };
+        let len_ok = n == inference::PROFILE_NUM_OPS;
+        let zeroed_ok = buf.iter().all(|e| {
+            e.count == 0 && e.total_ns == 0 && e.min_ns == 0 && e.max_ns == 0
+        });
+        // Slot 0 is MatMul (discriminant 0); slot 17 is Unknown
+        // (discriminant 255). Both label assertions catch reorderings
+        // of `op_type_to_index` / `index_to_op_type_u8`.
+        let labels_ok = buf[0].op_type == 0 && buf[17].op_type == 255;
+        let passed = len_ok && zeroed_ok && labels_ok;
+        print_test_result(b"profile: reset/snapshot baseline\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test: enable flag round-trips, disabled is the default.
+    {
+        let pre = inference::op_profile_is_enabled();
+        inference::op_profile_set_enabled(true);
+        let on = inference::op_profile_is_enabled();
+        inference::op_profile_set_enabled(false);
+        let off = !inference::op_profile_is_enabled();
+        // Restore the prior state so a future test runner that
+        // arms profiling before calling rust_inference_test() isn't
+        // surprised by us flipping it off.
+        inference::op_profile_set_enabled(pre);
+        let passed = on && off;
+        print_test_result(b"profile: enable flag round-trip\0", passed);
         if !passed { failures += 1; }
     }
 


### PR DESCRIPTION
## Summary

- Adds a per-`OpType` CNTPCT-timed profiler around the engine's `execute_node` dispatch, gated by an opt-in flag (no overhead when off, ~250 ns/op when on).
- Exposes `model profile <on|off|reset|show>` via the shell so a benchmark run can be sliced down to the dominant kernels — Conv eats ~95% of MNIST inference, MatMul ~1%.
- Lands the baseline table in `docs/benchmarks.md` so PR 2 (4×4 NEON outer-product) and PR 3 (software prefetch) have an apples-to-apples reference.

This is the first of three #56 PRs (PR 2 micro-kernel and PR 3 prefetch follow, both depend on this harness to demonstrate measurable before/after).

## Test plan

- [x] `make test` (QEMU ARM64) — all 620+ tests pass, including the two new `profile:` regression tests
- [x] `make kernel PLATFORM=RASPI5` — clean build
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build
- [x] Pi 5 hardware (pi-5-2) — boots cleanly, `model profile show` prints expected table, 200-iter MNIST bench identical 3,011 µs avg with profiling on vs off
- [x] `labctl boot_test --runs 5` on pi-5-2 — 5/5 successful boots
- [ ] Jetson hardware run deferred to PR 2 (no labctl path for non-SD deploy; cross-build verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)