### PR TITLE
ai-runtime: 4x4 NEON outer-product matmul micro-kernel (#56)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -316,7 +316,9 @@ Every sample in 1000 iterations measured 1,092 µs except one outlier at 1,100 �
 
 The per-op profiling harness in `runtime/src/inference/engine.rs` wraps every `execute_node` dispatch in CNTPCT timestamps and accumulates per-`OpType` counts and latencies. Enable with `model profile on`, run the workload, then `model profile show` (clear with `model profile reset`). Overhead is negligible: 200-iteration MNIST bench on pi-5-2 measured 3,011 µs/inference both profile-on and profile-off (run-to-run jitter swamps the harness cost).
 
-Baseline before #56 micro-kernel work (Pi 5, BUILD_TYPE=Release, pi-5-2, 200 iterations, MNIST). Per-op figures are reported in microseconds; "calls" is the count of `execute_node` invocations across the run.
+All measurements on Pi 5 (BCM2712 Cortex-A76 @ 2.4 GHz), pi-5-2, `BUILD_TYPE=Release`, `model bench mnist 200`. Per-op figures are microseconds; "calls" is the count of `execute_node` invocations across the run.
+
+**Baseline (pre-#56 — row × scalar `simd_fma_row` inner kernel):**
 
 | Op | Calls | Avg | Min | Max | Notes |
 |----|-------|-----|-----|-----|-------|
@@ -327,11 +329,24 @@ Baseline before #56 micro-kernel work (Pi 5, BUILD_TYPE=Release, pi-5-2, 200 ite
 | Add | 600 | 9 µs | 2 µs | 21 µs | Conv-bias + Gemm-bias adds |
 | Reshape | 400 | 1 µs | 1 µs | 2 µs | |
 
-Total dispatched-op time per inference (`Σ avg × calls / iters`): ~2,985 µs, accounting for ~99% of the 3,011 µs bench latency. The remaining ~26 µs is engine-side overhead (binding lookups, output copy, weight lease, atomic stats).
+Total dispatched-op time per inference: ~2,985 µs → 3,011 µs bench latency. `Conv` is ~95% of inference time. Note this current measurement is higher than the 1.09 ms recorded in the cross-platform table further up the doc (an older build); the #56 PRs report before/after against this current measurement so the deltas are apples-to-apples.
 
-`Conv` consumes ~95% of inference latency — the matmul micro-kernel improvements in #56 PR 2 / PR 3 target the im2col→matmul inner loop inside `conv2d`, so the speedup on this column is what the post-optimization rows track. Note the current Pi 5 baseline is **3.01 ms/inference**, higher than the 1.09 ms recorded in the cross-platform table above (which dates from an earlier build); the #56 PRs land before/after numbers against the current measurement so the delta is apples-to-apples.
+**After PR 2 (4×4 NEON outer-product micro-kernel):**
 
-The Jetson hardware baseline will be captured during PR 2 deployment once the slmos-kexec deploy path is in this agent's reach.
+| Op | Calls | Avg | Min | Max | Δ vs baseline |
+|----|-------|-----|-----|-----|---------------|
+| Conv | 400 | **169 µs** | 141 µs | 199 µs | **8.5× faster** |
+| MatMul | 200 | 22 µs | 22 µs | 25 µs | Unchanged (small matmuls take `matmul_simd`) |
+| Relu | 400 | 19 µs | 7 µs | 31 µs | Unchanged |
+| MaxPool | 400 | 16 µs | 6 µs | 25 µs | Unchanged |
+| Add | 600 | 9 µs | 2 µs | 21 µs | Unchanged |
+| Reshape | 400 | 1 µs | 1 µs | 2 µs | Unchanged |
+
+End-to-end MNIST: **3,011 µs → 483 µs (6.23× faster)**, throughput **332 → 2,070 infer/sec**. The win lands entirely on `Conv` because conv2d → im2col → `matmul_tiled` is the only op that uses the tiled path; small fully-connected matmuls fall through `matmul_inner` to the non-tiled `matmul_simd` form and keep the old row×scalar kernel.
+
+The 4×4 kernel keeps the C accumulator block resident in 4 NEON registers across the full K sweep, issuing 4 FMAs per `vld1q_f32(B)` + 4 × `vdupq_n_f32(A)` cycle — eliminating the per-K-step C load/store pair the row×scalar form pays.
+
+Jetson hardware run deferred until lab tooling for non-SD-card deploy is in this agent's reach; the change is platform-agnostic Rust + NEON intrinsics and cross-builds clean for `PLATFORM=JETSON_ORIN_NANO`.
 
 ### Model Memory Utilization
 

--- a/runtime/src/inference/ops.rs
+++ b/runtime/src/inference/ops.rs
@@ -878,9 +878,12 @@ unsafe fn matmul_tiled(ap: *const f32, bp: *const f32, cp: *mut f32,
 /// row-scalar's 4 B-loads + 4 C-loads + 4 C-stores + 4 FMAs across the
 /// same 4 output rows.
 ///
-/// AAPCS register usage: 5 NEON registers (q0..q3 for C, q4 for the B
-/// row); A scalars go through GP regs into `vdupq_n_f32`. Total live ≤
-/// 8, well within the 32-register NEON file.
+/// AAPCS register usage at peak (inside the FMA chain): 4 NEON regs
+/// for C (q0..q3) + 1 for the loaded B row + 4 for the broadcast A
+/// scalars (`vdupq_n_f32` materializes a vector register, not a GP
+/// register) = 9 simultaneously live NEON regs. The Cortex-A76 NEON
+/// register file is 32 wide so there's ample headroom; a future
+/// 4×8 or 8×4 expansion could keep more C state resident.
 ///
 /// # Safety
 ///

--- a/runtime/src/inference/ops.rs
+++ b/runtime/src/inference/ops.rs
@@ -756,26 +756,103 @@ unsafe fn matmul_inner(ap: *const f32, bp: *const f32, cp: *mut f32,
 }
 
 /// Cache-tiled matmul: splits M, K, N into tiles that fit in L1 cache.
+///
+/// Per-tile inner micro-kernel dispatch (#56 PR 2):
+///
+/// - On aarch64, the 4-aligned interior of each tile is processed by a
+///   register-blocked 4×4 outer-product kernel (`matmul_4x4_kernel_neon`).
+///   That kernel keeps the 16-element C block resident in 4 NEON
+///   registers across the full K sweep, issuing 4 FMAs per (B-load +
+///   4 A-broadcasts) cycle. C is loaded once at block entry and stored
+///   once at block exit, eliminating `kn − 1` memory round-trips per
+///   4×4 block compared to the row×scalar form.
+/// - The right strip (cols past the 4-aligned interior) and bottom
+///   strip (rows past the 4-aligned interior) fall back to the
+///   row×scalar `simd_fma_row` kernel — same path used pre-PR 2.
+/// - On non-aarch64 targets the row×scalar form runs uniformly.
 unsafe fn matmul_tiled(ap: *const f32, bp: *const f32, cp: *mut f32,
                        m: usize, k: usize, n: usize, tile: usize) {
     // Tile over K (accumulation dimension) first for cache reuse of C
     let mut kk = 0;
     while kk < k {
         let k_end = core::cmp::min(kk + tile, k);
+        let kn = k_end - kk;
         let mut ii = 0;
         while ii < m {
             let i_end = core::cmp::min(ii + tile, m);
+            let tile_m = i_end - ii;
             let mut jj = 0;
             while jj < n {
                 let j_end = core::cmp::min(jj + tile, n);
-                // Micro-kernel: C[ii..i_end, jj..j_end] += A[ii..i_end, kk..k_end] * B[kk..k_end, jj..j_end]
-                for i in ii..i_end {
-                    for kki in kk..k_end {
-                        let a_ik = *ap.add(i * k + kki);
-                        let b_row = kki * n;
-                        let c_row = i * n;
-                        let tile_n = j_end - jj;
-                        simd_fma_row(cp.add(c_row + jj), bp.add(b_row + jj), a_ik, tile_n);
+                let tile_n = j_end - jj;
+
+                // C[ii..i_end, jj..j_end] += A[ii..i_end, kk..k_end] * B[kk..k_end, jj..j_end]
+                #[cfg(target_arch = "aarch64")]
+                {
+                    let i_blocks = tile_m & !3;
+                    let j_blocks = tile_n & !3;
+
+                    // 4×4-aligned interior — fastest path.
+                    let mut ib = 0;
+                    while ib < i_blocks {
+                        let mut jb = 0;
+                        while jb < j_blocks {
+                            matmul_4x4_kernel_neon(
+                                ap.add((ii + ib) * k + kk),
+                                bp.add(kk * n + jj + jb),
+                                cp.add((ii + ib) * n + jj + jb),
+                                kn, k, n,
+                            );
+                            jb += 4;
+                        }
+                        ib += 4;
+                    }
+
+                    // Right strip: 4-aligned rows, partial cols
+                    // (tile_n - j_blocks ∈ {0,1,2,3}).
+                    if j_blocks < tile_n {
+                        for ir in 0..i_blocks {
+                            for kki in 0..kn {
+                                let a_ik = *ap.add((ii + ir) * k + kk + kki);
+                                simd_fma_row(
+                                    cp.add((ii + ir) * n + jj + j_blocks),
+                                    bp.add((kk + kki) * n + jj + j_blocks),
+                                    a_ik,
+                                    tile_n - j_blocks,
+                                );
+                            }
+                        }
+                    }
+
+                    // Bottom strip: partial rows
+                    // (tile_m - i_blocks ∈ {0,1,2,3}), full tile_n.
+                    for ir in i_blocks..tile_m {
+                        for kki in 0..kn {
+                            let a_ik = *ap.add((ii + ir) * k + kk + kki);
+                            simd_fma_row(
+                                cp.add((ii + ir) * n + jj),
+                                bp.add((kk + kki) * n + jj),
+                                a_ik,
+                                tile_n,
+                            );
+                        }
+                    }
+                }
+                #[cfg(not(target_arch = "aarch64"))]
+                {
+                    // Non-aarch64: keep the original row×scalar form so
+                    // x86-64 + scalar-fallback paths are untouched by
+                    // PR 2 (x86-64 work is tracked in #847).
+                    for i in ii..i_end {
+                        for kki in kk..k_end {
+                            let a_ik = *ap.add(i * k + kki);
+                            simd_fma_row(
+                                cp.add(i * n + jj),
+                                bp.add(kki * n + jj),
+                                a_ik,
+                                tile_n,
+                            );
+                        }
                     }
                 }
                 jj += tile;
@@ -784,6 +861,85 @@ unsafe fn matmul_tiled(ap: *const f32, bp: *const f32, cp: *mut f32,
         }
         kk += tile;
     }
+}
+
+/// 4×4 NEON outer-product micro-kernel (#56 PR 2).
+///
+/// Computes the contraction step:
+///   C[ii..ii+4, jj..jj+4] += A[ii..ii+4, kk..kk+kn] * B[kk..kk+kn, jj..jj+4]
+///
+/// Strategy: keep the 4×4 C block resident in `q0..q3` for the whole
+/// K loop. Each iteration loads one B row (4 elements, one `vld1q_f32`),
+/// broadcasts 4 scalars from A's 4 rows (`vdupq_n_f32` ×4), and issues
+/// 4 `vfmaq_f32` accumulations — for 8 ops/cycle of arithmetic against
+/// just one vector load. The row×scalar baseline issues 1 FMA, 1 B-load,
+/// 1 C-load, and 1 C-store per cycle, so per (i, k) pair the new kernel
+/// trades 1 B-load + 4 A-broadcasts + 4 FMAs (and no C traffic) for the
+/// row-scalar's 4 B-loads + 4 C-loads + 4 C-stores + 4 FMAs across the
+/// same 4 output rows.
+///
+/// AAPCS register usage: 5 NEON registers (q0..q3 for C, q4 for the B
+/// row); A scalars go through GP regs into `vdupq_n_f32`. Total live ≤
+/// 8, well within the 32-register NEON file.
+///
+/// # Safety
+///
+/// - `ap_block` must be the address of A[ii*k + kk], with at least
+///   `(3 * k_stride) + kn` f32 elements reachable from it.
+/// - `bp_block` must be the address of B[kk*n + jj], with at least
+///   `(kn - 1) * n_stride + 4` f32 elements reachable.
+/// - `cp_block` must be the address of C[ii*n + jj], writable for at
+///   least `3 * n_stride + 4` f32 elements; the kernel both reads and
+///   writes the 4×4 C block.
+/// - `kn` ≤ remaining K, `k_stride == k`, `n_stride == n`.
+/// - Caller is on aarch64 with NEON enabled (mandated by ARMv8-A; the
+///   `target_feature` attribute documents intent).
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn matmul_4x4_kernel_neon(
+    ap_block: *const f32,
+    bp_block: *const f32,
+    cp_block: *mut f32,
+    kn: usize,
+    k_stride: usize,
+    n_stride: usize,
+) {
+    use core::arch::aarch64::*;
+
+    let cp1 = cp_block.add(n_stride);
+    let cp2 = cp_block.add(2 * n_stride);
+    let cp3 = cp_block.add(3 * n_stride);
+
+    // Load existing C — accumulating into pre-existing values is the
+    // correct behaviour under K-tiling (later K tiles add to earlier
+    // partial sums) and matches what `simd_fma_row` does.
+    let mut c0 = vld1q_f32(cp_block);
+    let mut c1 = vld1q_f32(cp1);
+    let mut c2 = vld1q_f32(cp2);
+    let mut c3 = vld1q_f32(cp3);
+
+    let ap1 = ap_block.add(k_stride);
+    let ap2 = ap_block.add(2 * k_stride);
+    let ap3 = ap_block.add(3 * k_stride);
+
+    for kki in 0..kn {
+        let b_row = vld1q_f32(bp_block.add(kki * n_stride));
+
+        let a0 = vdupq_n_f32(*ap_block.add(kki));
+        let a1 = vdupq_n_f32(*ap1.add(kki));
+        let a2 = vdupq_n_f32(*ap2.add(kki));
+        let a3 = vdupq_n_f32(*ap3.add(kki));
+
+        c0 = vfmaq_f32(c0, a0, b_row);
+        c1 = vfmaq_f32(c1, a1, b_row);
+        c2 = vfmaq_f32(c2, a2, b_row);
+        c3 = vfmaq_f32(c3, a3, b_row);
+    }
+
+    vst1q_f32(cp_block, c0);
+    vst1q_f32(cp1, c1);
+    vst1q_f32(cp2, c2);
+    vst1q_f32(cp3, c3);
 }
 
 /// Non-tiled SIMD matmul for small matrices.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7013,6 +7013,71 @@ pub extern "C" fn rust_inference_test() -> i32 {
         if !passed { failures += 1; }
     }
 
+    // Test: 4×4 NEON outer-product micro-kernel correctness (#56 PR 2).
+    //
+    // Uses M=36, K=4, N=36 — both M and N are >TILE/32+ blocks so the
+    // tiled path runs, both are 4-aligned so every iteration of the
+    // inner kernel hits the 4×4 NEON fast path (no edge fallback).
+    // K=4 means one inner-kernel call has exactly 4 K-steps, which
+    // distinguishes a row-ordering bug from a column-ordering bug
+    // (different rows of A see different scalars).
+    //
+    // Operand pattern: A[i,k] = (i+1)*0.1 + k*0.01, B[k,j] = (j+1)*0.1 + k*0.001.
+    // Each (i,j) cell is a distinct sum-of-products — an indexing bug
+    // (swapped row/col, off-by-one stride, broadcast wrong scalar)
+    // surfaces as a single failing cell rather than a uniform multiplier.
+    {
+        const M: usize = 36;
+        const K: usize = 4;
+        const N: usize = 36;
+        static mut A_44: [f32; M * K] = [0.0; M * K];
+        static mut B_44: [f32; K * N] = [0.0; K * N];
+        static mut C_44: [f32; M * N] = [0.0; M * N];
+        static mut C_REF_44: [f32; M * N] = [0.0; M * N];
+
+        unsafe {
+            for i in 0..M {
+                for kk in 0..K {
+                    A_44[i * K + kk] = (i as f32 + 1.0) * 0.1 + (kk as f32) * 0.01;
+                }
+            }
+            for kk in 0..K {
+                for j in 0..N {
+                    B_44[kk * N + j] = (j as f32 + 1.0) * 0.1 + (kk as f32) * 0.001;
+                }
+            }
+            for i in 0..M {
+                for j in 0..N {
+                    let mut acc = 0.0f32;
+                    for kk in 0..K {
+                        acc += A_44[i * K + kk] * B_44[kk * N + j];
+                    }
+                    C_REF_44[i * N + j] = acc;
+                }
+            }
+
+            let a = inference::Tensor::new(
+                core::ptr::addr_of!(A_44) as *const f32, &[M as u32, K as u32]);
+            let b = inference::Tensor::new(
+                core::ptr::addr_of!(B_44) as *const f32, &[K as u32, N as u32]);
+            let mut c = inference::Tensor::new(
+                core::ptr::addr_of_mut!(C_44) as *const f32, &[M as u32, N as u32]);
+            let result = inference::ops::matmul(&a, &b, &mut c);
+            let ok = result.is_ok();
+
+            let mut vals_ok = true;
+            let mut max_err: f32 = 0.0;
+            for i in 0..(M * N) {
+                let err = (C_44[i] - C_REF_44[i]).abs();
+                if err > max_err { max_err = err; }
+                if err > 0.001 { vals_ok = false; break; }
+            }
+            let passed = ok && vals_ok;
+            print_test_result(b"simd: matmul 36x4 * 4x36 (4-aligned 4x4 kernel)\0", passed);
+            if !passed { failures += 1; }
+        }
+    }
+
     // Test: Tiled matmul (matrices > 32x32 trigger the tiling path)
     {
         // 64x64 × 64x64 matmul — all ones → each element should be 64.0


### PR DESCRIPTION
**Successor to #856** (auto-closed when its base branch was deleted on #849 merge). Rebased onto main now that #849 is in.

## Summary

- Replaces row×scalar matmul inner kernel with a register-blocked **4×4 NEON outer-product micro-kernel** inside \`matmul_tiled\`.
- The 4-aligned tile interior takes the new path; edge strips fall back to the old kernel so non-aligned shapes (e.g. 33×37×41 regression test) still work.
- C accumulator block stays resident in 4 NEON registers across the full K sweep — eliminates per-K-step C load/store pairs.

**Measured speedup (pi-5-2, MNIST 200 iters, Release build):**

| Metric | Baseline | PR 2 | Δ |
|---|---|---|---|
| Conv (avg) | 1,433 µs | **169 µs** | **8.5× faster** |
| End-to-end | 3,011 µs | **483 µs** | **6.23× faster** |
| Throughput | 332 infer/s | **2,070 infer/s** | 6.23× |

MatMul, Relu, Add, MaxPool, Reshape are unchanged — only \`matmul_tiled\` was modified and the small fully-connected matmuls take the non-tiled \`matmul_simd\` path.

## Test plan

- [x] \`make test\` (QEMU ARM64) — all 620+ tests pass, plus new \`simd: matmul 36x4 * 4x36 (4-aligned 4x4 kernel)\` regression test
- [x] Existing edge-case tests: \`simd: tiled matmul 64x64\` (4-aligned) + \`simd: matmul 33x37 * 37x41\` (non-aligned) — both still pass
- [x] \`make kernel PLATFORM=RASPI5\` — clean
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean
- [x] Pi 5 hardware (pi-5-2) — MNIST bench 483 µs avg (vs 3,011 baseline)
- [x] \`labctl boot_test --runs 5\` on pi-5-2 — 5/5 successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)