### PR TITLE
sched: ai_xgb policy + SCHED_MODEL_KIND_XGBOOST blob (#855)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2082,6 +2082,7 @@ if(ENABLE_AI_SCHEDULER)
         kernel/sched/ai/ai_inference.c
         kernel/sched/ai/ai_state.c
         kernel/sched/ai/sched_ai.c
+        kernel/sched/ai/sched_xgb.c
         kernel/sched/ai/runtime_model.c
         kernel/sched/ai/inference_cpu.c
         kernel/sched/ai/ai_weights_mlp.c

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -419,6 +419,36 @@ extern int32_t rust_eviction_blob_activate(uint16_t kind_id);
 extern int32_t rust_eviction_blob_rollback(uint16_t kind_id);
 extern int32_t rust_eviction_blob_clear(uint16_t kind_id);
 
+/* ==========================================================================
+ * Scheduler XGBoost cascade FFI (#855)
+ *
+ * The XGBoost scheduler policy stores its ~9 MB cascade Rust-side
+ * because the static MLP/PPO dense pool in runtime_model.c is too
+ * narrow. The C-side runtime_model.c forwards `kind_id ==
+ * SCHED_MODEL_KIND_XGBOOST` to these entry points; everything else
+ * stays in the existing dense / config / threshold paths.
+ *
+ * Status struct must stay byte-for-byte aligned with
+ * `runtime/src/sched/xgb.rs::SchedModelStatusC`, which mirrors
+ * `struct sched_model_status` in `kernel/sched/ai/runtime_model.h`.
+ * ========================================================================== */
+extern int32_t rust_sched_xgb_validate_blob(const uint8_t *data, size_t len);
+extern int32_t rust_sched_xgb_stage_blob(const uint8_t *data, size_t len);
+extern int32_t rust_sched_xgb_activate(void);
+extern int32_t rust_sched_xgb_rollback(void);
+extern int32_t rust_sched_xgb_clear(void);
+/* `out` points to `struct sched_model_status` — same layout as the
+ * value returned by the Rust `SchedModelStatusC`. */
+extern int32_t rust_sched_xgb_status(void *out);
+extern int32_t rust_sched_xgb_is_active(void);
+/* Run the cascade against the supplied 108-d state. Writes the raw
+ * (core, priority, preempt) labels to the output pointers. Returns 0
+ * on success, -1 if no cascade is active or any pointer is NULL. */
+extern int32_t rust_sched_xgb_predict(const float *state,
+                                      int32_t *out_core,
+                                      int32_t *out_priority,
+                                      int32_t *out_preempt);
+
 /* Feature-name introspection (#112). */
 extern uint32_t rust_eviction_feature_count(void);
 extern size_t rust_eviction_feature_name(uint32_t index, uint8_t *buf, size_t buf_len);

--- a/kernel/sched/ai/runtime_model.c
+++ b/kernel/sched/ai/runtime_model.c
@@ -1,5 +1,6 @@
 #include "runtime_model.h"
 
+#include "slm_ffi.h"
 #include "spinlock.h"
 #include "string.h"
 
@@ -551,6 +552,13 @@ static int sched_store_role_busy(const struct sched_model_store *store, uint8_t 
 
 int sched_model_stage_blob(uint16_t kind_id, const uint8_t *data, size_t len)
 {
+    /* XGBoost storage lives Rust-side (cascade is ~9 MB — too large
+     * for the static dense pool). Forward to the FFI and return; the
+     * outer header is parsed Rust-side too, so no work happens here. */
+    if (kind_id == SCHED_MODEL_KIND_XGBOOST) {
+        return rust_sched_xgb_stage_blob(data, len);
+    }
+
     int store_idx = sched_model_store_index(kind_id);
     irq_flags_t stage_flags;
     irq_flags_t flags;
@@ -598,6 +606,10 @@ int sched_model_stage_blob(uint16_t kind_id, const uint8_t *data, size_t len)
 
 int sched_model_validate_blob(uint16_t kind_id, const uint8_t *data, size_t len)
 {
+    if (kind_id == SCHED_MODEL_KIND_XGBOOST) {
+        return rust_sched_xgb_validate_blob(data, len);
+    }
+
     int store_idx = sched_model_store_index(kind_id);
     irq_flags_t stage_flags;
 
@@ -619,6 +631,10 @@ int sched_model_validate_blob(uint16_t kind_id, const uint8_t *data, size_t len)
 
 int sched_model_activate(uint16_t kind_id)
 {
+    if (kind_id == SCHED_MODEL_KIND_XGBOOST) {
+        return rust_sched_xgb_activate();
+    }
+
     int store_idx = sched_model_store_index(kind_id);
     irq_flags_t flags;
     struct sched_model_store *store;
@@ -657,6 +673,10 @@ int sched_model_activate(uint16_t kind_id)
 
 int sched_model_rollback(uint16_t kind_id)
 {
+    if (kind_id == SCHED_MODEL_KIND_XGBOOST) {
+        return rust_sched_xgb_rollback();
+    }
+
     int store_idx = sched_model_store_index(kind_id);
     irq_flags_t flags;
     struct sched_model_store *store;
@@ -696,6 +716,10 @@ int sched_model_rollback(uint16_t kind_id)
 
 int sched_model_clear(uint16_t kind_id)
 {
+    if (kind_id == SCHED_MODEL_KIND_XGBOOST) {
+        return rust_sched_xgb_clear();
+    }
+
     int store_idx = sched_model_store_index(kind_id);
     irq_flags_t flags;
     struct sched_model_store *store;
@@ -727,6 +751,11 @@ int sched_model_clear(uint16_t kind_id)
 
 int sched_model_status(uint16_t kind_id, struct sched_model_status *out)
 {
+    if (kind_id == SCHED_MODEL_KIND_XGBOOST) {
+        if (!out) return -1;
+        return rust_sched_xgb_status(out);
+    }
+
     int store_idx = sched_model_store_index(kind_id);
     irq_flags_t flags;
     struct sched_model_store *store;

--- a/kernel/sched/ai/runtime_model.h
+++ b/kernel/sched/ai/runtime_model.h
@@ -49,6 +49,17 @@ struct sched_model_status {
     struct sched_model_meta rollback;
 };
 
+/* Byte-for-byte layout pin against `SchedModelMetaC` / `SchedModelStatusC`
+ * in `runtime/src/sched/xgb.rs`. The Rust side has the matching
+ * `const _: () = assert!(size_of::<...>() == N)` asserts at module scope;
+ * keeping both halves of the pin live means any future struct reorder
+ * (here or in xgb.rs) breaks the build instead of silently mis-reading
+ * the FFI status payload at runtime. */
+_Static_assert(sizeof(struct sched_model_meta) == 20,
+    "struct sched_model_meta must be 20 bytes for SchedModelMetaC FFI layout");
+_Static_assert(sizeof(struct sched_model_status) == 76,
+    "struct sched_model_status must be 76 bytes for SchedModelStatusC FFI layout");
+
 struct sched_runtime_mlp_model {
     uint16_t feature_version;
     uint16_t action_version;

--- a/kernel/sched/ai/runtime_model.h
+++ b/kernel/sched/ai/runtime_model.h
@@ -11,6 +11,11 @@
 #define SCHED_MODEL_KIND_CONFIG           0x1003u
 #define SCHED_MODEL_KIND_THRESHOLDS       0x1004u
 #define SCHED_MODEL_KIND_REBALANCE        0x1005u
+/* XGBoost 3-classifier cascade (#855). Payload is too large
+ * (~9 MB on the trained model) for the static MLP/PPO dense pool;
+ * storage lives Rust-side and the staged/active/rollback dance
+ * forwards through the Rust FFI in xgb_ffi.rs. */
+#define SCHED_MODEL_KIND_XGBOOST          0x1006u
 #define SCHED_MODEL_BLOB_VERSION_V1       1u
 #define SCHED_MODEL_SCHEMA_VERSION_V1     1u
 #define SCHED_MODEL_FEATURE_VERSION_V1    1u

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -752,10 +752,17 @@ int sched_ai_get_rate_stats(const char *policy_name,
  * Registration
  * ============================================================================ */
 
+/* XGBoost cascade policy — defined in sched_xgb.c. Forward-declared
+ * here (no separate header) because the only external caller is
+ * `sched_ai_init` below; everything else routes through the
+ * `sched_set_policy` name lookup. */
+extern const struct sched_policy_ops sched_policy_ai_xgb;
+
 void sched_ai_init(void)
 {
     sched_register_policy(&sched_policy_ai_mlp);
     sched_register_policy(&sched_policy_ai_ppo);
+    sched_register_policy(&sched_policy_ai_xgb);
 #ifndef PLATFORM_X86_64
     sched_register_policy(&sched_policy_ai_hailo);
 #endif

--- a/kernel/sched/ai/sched_xgb.c
+++ b/kernel/sched/ai/sched_xgb.c
@@ -1,0 +1,157 @@
+/*
+ * sched_xgb.c — XGBoost cascade scheduler policy (#855).
+ *
+ * Mirrors `sched_policy_ai_mlp` but invokes a Rust-side 3-classifier
+ * cascade (core / priority / preempt) loaded via the existing
+ * `slm.sched_model_*` workflow. Cascade storage lives Rust-side in
+ * `runtime/src/sched/xgb.rs` because the trained model (~9 MB) is too
+ * large for the static MLP/PPO dense pool used by other sched-model
+ * kinds in `runtime_model.c`.
+ *
+ * Compiled WITHOUT `-mgeneral-regs-only`, like `sched_ai.c`, so the
+ * Rust cascade walker can use FP/NEON freely. The C wrapper saves /
+ * restores the FP context around every assign_cpu so the policy is
+ * safe to invoke from IRQ context.
+ */
+
+#include "sched_policy.h"
+#include "fp_context.h"
+#include "ai_inference.h"
+#include "ai_state.h"
+#include "ai_types.h"
+#include "runtime_model.h"
+#include "sched.h"
+#include "smp.h"
+#include "slm_ffi.h"
+#include "debug.h"
+
+struct ai_xgb_stats {
+    uint32_t decisions;
+    uint32_t fallbacks;
+    uint32_t cpu_clamped;       /* core >= cpu_count, clamped via modulo */
+    uint64_t total_latency_ns;
+};
+
+static struct ai_xgb_stats ai_xgb_stats;
+
+static int ai_xgb_init(void)
+{
+    ai_xgb_stats.decisions = 0;
+    ai_xgb_stats.fallbacks = 0;
+    ai_xgb_stats.cpu_clamped = 0;
+    ai_xgb_stats.total_latency_ns = 0;
+    /* No self-test inference: predict() returns failure cleanly when
+     * no cascade is active (assign_cpu falls back to heuristic) so
+     * registering with no blob loaded is the expected idle state.
+     * The operator stages + activates a blob via
+     *   slm.sched_model_stage("xgboost", path)
+     *   slm.sched_model_activate("xgboost")
+     * before switching to this policy. */
+    if (rust_sched_xgb_is_active()) {
+        INFO("AI XGB: policy initialized (cascade active)");
+    } else {
+        INFO("AI XGB: policy initialized (no cascade staged — assign_cpu "
+             "will fall back to heuristic until `slm.sched_model_*` "
+             "loads xgb_sched.smb)");
+    }
+    return 0;
+}
+
+static void ai_xgb_shutdown(void)
+{
+    if (ai_xgb_stats.decisions > 0) {
+        uint64_t avg_ns =
+            ai_xgb_stats.total_latency_ns / ai_xgb_stats.decisions;
+        INFO("AI XGB: %u decisions, %u fallbacks, %u CPU-clamped, "
+             "avg latency %lu ns",
+             ai_xgb_stats.decisions, ai_xgb_stats.fallbacks,
+             ai_xgb_stats.cpu_clamped, (unsigned long)avg_ns);
+    }
+}
+
+static uint32_t ai_xgb_assign_cpu(struct task *task)
+{
+    FP_CONTEXT_SAVE();
+
+    float state[AI_STATE_DIM];
+    int32_t core_label = 0;
+    int32_t prio_label = 0;
+    int32_t preempt_label = 0;
+
+    uint64_t t0 = slm_get_time_ns();
+    ai_extract_state(state);
+    int rc = rust_sched_xgb_predict(state, &core_label,
+                                    &prio_label, &preempt_label);
+    uint64_t t1 = slm_get_time_ns();
+    ai_xgb_stats.total_latency_ns += (t1 > t0) ? (t1 - t0) : 0u;
+    ai_xgb_stats.decisions++;
+
+    if (rc != 0) {
+        ai_xgb_stats.fallbacks++;
+        FP_CONTEXT_RESTORE();
+        return sched_policy_heuristic.assign_cpu(task);
+    }
+
+    /* CPU-id clamping. The cascade was trained on a 6-core space; on
+     * Pi 5 (cpu_count == 4) the core classifier can emit 4 or 5.
+     * Clamp via modulo and continue — refusing the prediction would
+     * thrash to heuristic on every Pi 5 dispatch. WARN once per
+     * session so the operator notices the deployment mismatch.
+     *
+     * Negative core labels would indicate a corrupt label_classes
+     * map or a Rust-side bug; treat as a hard fallback. */
+    if (core_label < 0) {
+        ai_xgb_stats.fallbacks++;
+        FP_CONTEXT_RESTORE();
+        return sched_policy_heuristic.assign_cpu(task);
+    }
+    uint32_t core = (uint32_t)core_label;
+    if (core >= cpu_count) {
+        static bool clamp_warned = false;
+        if (!clamp_warned) {
+            WARN("AI XGB: cascade emitted core=%u but cpu_count=%u; "
+                 "clamping via modulo. Trained for a wider topology — "
+                 "predictions still applied but distribution may skew.",
+                 core, cpu_count);
+            clamp_warned = true;
+        }
+        core = core % cpu_count;
+        ai_xgb_stats.cpu_clamped++;
+    }
+
+    /* Skip isolated cores: heuristic fallback respects affinity flags. */
+    if (sched_is_core_isolated(core)
+     && task->cpu_affinity == CPU_AFFINITY_ANY) {
+        ai_xgb_stats.fallbacks++;
+        FP_CONTEXT_RESTORE();
+        return sched_policy_heuristic.assign_cpu(task);
+    }
+
+    /* Apply priority adjustment using the same encoding as sched_ai.c:
+     *   1 = boost, 2 = reduce. Other values are no-ops. */
+    if (prio_label == 1) {
+        if (task->effective_priority < TASK_PRIORITY_CRITICAL)
+            task->effective_priority++;
+    } else if (prio_label == 2) {
+        if (task->effective_priority > TASK_PRIORITY_IDLE)
+            task->effective_priority--;
+    }
+
+    /* Preempt: boost priority so pick_next_task prefers this task. */
+    if (preempt_label != 0
+     && task->effective_priority < TASK_PRIORITY_CRITICAL) {
+        task->effective_priority++;
+    }
+
+    FP_CONTEXT_RESTORE();
+    return core;
+}
+
+const struct sched_policy_ops sched_policy_ai_xgb = {
+    .name       = "ai_xgb",
+    .init       = ai_xgb_init,
+    .shutdown   = ai_xgb_shutdown,
+    .assign_cpu = ai_xgb_assign_cpu,
+    .tick       = NULL,
+    .has_gpu_backend = false,
+};

--- a/kernel/sched/ai/sched_xgb.c
+++ b/kernel/sched/ai/sched_xgb.c
@@ -99,11 +99,16 @@ static uint32_t ai_xgb_assign_cpu(struct task *task)
         return sched_policy_heuristic.assign_cpu(task);
     }
 
-    /* CPU-id clamping. The cascade was trained on a 6-core space; on
-     * Pi 5 (cpu_count == 4) the core classifier can emit 4 or 5.
-     * Clamp via modulo and continue — refusing the prediction would
-     * thrash to heuristic on every Pi 5 dispatch. WARN once per
-     * session so the operator notices the deployment mismatch.
+    /* CPU-id clamping. The cascade was trained on a 6-core space
+     * (see `slm-os-scheduler-ai/training/xgboost/train.py`'s
+     * `MAX_CORES`); on Pi 5 (cpu_count == 4) the core classifier
+     * can emit 4 or 5. Clamp via modulo and continue — refusing
+     * the prediction would thrash to heuristic on every Pi 5
+     * dispatch. WARN once per session so the operator notices the
+     * deployment mismatch. The WARN's "wider topology" phrasing
+     * assumes the trainer's arity (6); if a future blob is
+     * mistrained the message will still fire and the warning will
+     * (correctly) point at the cascade.
      *
      * Negative core labels would indicate a corrupt label_classes
      * map or a Rust-side bug; treat as a hard fallback. */
@@ -137,11 +142,13 @@ static uint32_t ai_xgb_assign_cpu(struct task *task)
     /* Apply priority adjustment using the same encoding as sched_ai.c:
      *   1 = boost, 2 = reduce. Other values are no-ops. */
     if (prio_label == 1) {
-        if (task->effective_priority < TASK_PRIORITY_CRITICAL)
+        if (task->effective_priority < TASK_PRIORITY_CRITICAL) {
             task->effective_priority++;
+        }
     } else if (prio_label == 2) {
-        if (task->effective_priority > TASK_PRIORITY_IDLE)
+        if (task->effective_priority > TASK_PRIORITY_IDLE) {
             task->effective_priority--;
+        }
     }
 
     /* Preempt: boost priority so pick_next_task prefers this task. */

--- a/kernel/sched/ai/sched_xgb.c
+++ b/kernel/sched/ai/sched_xgb.c
@@ -34,6 +34,13 @@ struct ai_xgb_stats {
 
 static struct ai_xgb_stats ai_xgb_stats;
 
+/* The Rust predictor (`runtime/src/sched/xgb.rs::STATE_DIM`) hard-
+ * codes 108. Pin the C-side `AI_STATE_DIM` against it so a future
+ * drift surfaces at build time, not as silent garbage when the
+ * Rust side reads past the C-allocated buffer. */
+_Static_assert(AI_STATE_DIM == 108,
+    "sched_xgb.c assumes the Rust predictor's STATE_DIM == 108");
+
 static int ai_xgb_init(void)
 {
     ai_xgb_stats.decisions = 0;

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -2407,6 +2407,7 @@ static int sched_model_kind_id(const char *kind)
     if (strcmp(kind, "config") == 0) return SCHED_MODEL_KIND_CONFIG;
     if (strcmp(kind, "thresholds") == 0) return SCHED_MODEL_KIND_THRESHOLDS;
     if (strcmp(kind, "rebalance") == 0) return SCHED_MODEL_KIND_REBALANCE;
+    if (strcmp(kind, "xgboost") == 0) return SCHED_MODEL_KIND_XGBOOST;
     return 0;
 }
 

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6518,6 +6518,7 @@ static uint16_t sched_model_kind_id(const char *name)
     if (strcmp(name, "config") == 0) return SCHED_MODEL_KIND_CONFIG;
     if (strcmp(name, "thresholds") == 0) return SCHED_MODEL_KIND_THRESHOLDS;
     if (strcmp(name, "rebalance") == 0) return SCHED_MODEL_KIND_REBALANCE;
+    if (strcmp(name, "xgboost") == 0) return SCHED_MODEL_KIND_XGBOOST;
     return 0;
 }
 
@@ -6529,6 +6530,7 @@ static const char *sched_model_kind_name(uint16_t kind_id)
         case SCHED_MODEL_KIND_CONFIG: return "config";
         case SCHED_MODEL_KIND_THRESHOLDS: return "thresholds";
         case SCHED_MODEL_KIND_REBALANCE: return "rebalance";
+        case SCHED_MODEL_KIND_XGBOOST: return "xgboost";
         default: return "unknown";
     }
 }
@@ -6720,7 +6722,7 @@ static int sched_model_autoload_cmd(int argc, char *argv[])
     static const uint16_t kinds[] = {
         SCHED_MODEL_KIND_MLP, SCHED_MODEL_KIND_PPO,
         SCHED_MODEL_KIND_CONFIG, SCHED_MODEL_KIND_THRESHOLDS,
-        SCHED_MODEL_KIND_REBALANCE
+        SCHED_MODEL_KIND_REBALANCE, SCHED_MODEL_KIND_XGBOOST
     };
 
     if (argc < 4 || strcmp(argv[3], "status") == 0) {
@@ -6828,6 +6830,7 @@ int cmd_sched(int argc, char *argv[])
             if (sched_model_status_one(SCHED_MODEL_KIND_CONFIG) != 0) return 1;
             if (sched_model_status_one(SCHED_MODEL_KIND_THRESHOLDS) != 0) return 1;
             if (sched_model_status_one(SCHED_MODEL_KIND_REBALANCE) != 0) return 1;
+            if (sched_model_status_one(SCHED_MODEL_KIND_XGBOOST) != 0) return 1;
             if (argc < 3) {
                 shell_puts("\r\nUsage:\r\n");
                 shell_puts("  sched model status\r\n");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -771,9 +771,8 @@ pub extern "C" fn rust_run_tests() -> i32 {
     {
         sched::xgb::clear();
         let blob = sched::xgb::build_smoke_blob();
-        let staged_ok = unsafe {
-            sched::xgb::rust_sched_xgb_stage_blob(blob.as_ptr(), blob.len()) == 0
-        };
+        let staged_ok =
+            sched::xgb::rust_sched_xgb_stage_blob(blob.as_ptr(), blob.len()) == 0;
         print_test_result(b"sched_xgb_stage_synthetic\0", staged_ok);
         if !staged_ok { failures += 1; }
 
@@ -789,14 +788,12 @@ pub extern "C" fn rust_run_tests() -> i32 {
         let mut core: i32 = -1;
         let mut prio: i32 = -1;
         let mut preempt: i32 = -1;
-        let predicted = unsafe {
-            sched::xgb::rust_sched_xgb_predict(
-                state.as_ptr(),
-                &mut core as *mut i32,
-                &mut prio as *mut i32,
-                &mut preempt as *mut i32,
-            ) == 0
-        };
+        let predicted = sched::xgb::rust_sched_xgb_predict(
+            state.as_ptr(),
+            &mut core as *mut i32,
+            &mut prio as *mut i32,
+            &mut preempt as *mut i32,
+        ) == 0;
         print_test_result(b"sched_xgb_predict\0", predicted);
         if !predicted { failures += 1; }
 
@@ -811,12 +808,10 @@ pub extern "C" fn rust_run_tests() -> i32 {
         let mut blob_corrupt = sched::xgb::build_smoke_blob();
         let last = blob_corrupt.len() - 1;
         blob_corrupt[last] ^= 0xFF;
-        let rejected = unsafe {
-            sched::xgb::rust_sched_xgb_stage_blob(
-                blob_corrupt.as_ptr(),
-                blob_corrupt.len(),
-            ) != 0
-        };
+        let rejected = sched::xgb::rust_sched_xgb_stage_blob(
+            blob_corrupt.as_ptr(),
+            blob_corrupt.len(),
+        ) != 0;
         print_test_result(b"sched_xgb_rejects_bad_checksum\0", rejected);
         if !rejected { failures += 1; }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -763,6 +763,66 @@ pub extern "C" fn rust_run_tests() -> i32 {
         if !passed { failures += 1; }
     }
 
+    // XGBoost cascade scheduler (#855): build a synthetic 3-classifier
+    // cascade in memory, stage + activate via the FFI surface the C
+    // policy uses, predict against a zero state, and assert the raw
+    // labels produced. No trained-model fixtures required — those
+    // ship via `slm.sched_model_stage("xgboost", path)` from FAT.
+    {
+        sched::xgb::clear();
+        let blob = sched::xgb::build_smoke_blob();
+        let staged_ok = unsafe {
+            sched::xgb::rust_sched_xgb_stage_blob(blob.as_ptr(), blob.len()) == 0
+        };
+        print_test_result(b"sched_xgb_stage_synthetic\0", staged_ok);
+        if !staged_ok { failures += 1; }
+
+        let active_ok = sched::xgb::rust_sched_xgb_activate() == 0;
+        print_test_result(b"sched_xgb_activate\0", active_ok);
+        if !active_ok { failures += 1; }
+
+        let is_active = sched::xgb::rust_sched_xgb_is_active() == 1;
+        print_test_result(b"sched_xgb_is_active_after_activate\0", is_active);
+        if !is_active { failures += 1; }
+
+        let state = [0.0_f32; 108];
+        let mut core: i32 = -1;
+        let mut prio: i32 = -1;
+        let mut preempt: i32 = -1;
+        let predicted = unsafe {
+            sched::xgb::rust_sched_xgb_predict(
+                state.as_ptr(),
+                &mut core as *mut i32,
+                &mut prio as *mut i32,
+                &mut preempt as *mut i32,
+            ) == 0
+        };
+        print_test_result(b"sched_xgb_predict\0", predicted);
+        if !predicted { failures += 1; }
+
+        // The synthetic cascade emits raw labels (3, 1, 1).
+        let labels_match = predicted && core == 3 && prio == 1 && preempt == 1;
+        print_test_result(b"sched_xgb_labels_match_synthetic\0", labels_match);
+        if !labels_match { failures += 1; }
+
+        // Bad checksum must be rejected by stage and leave the active
+        // cascade untouched.
+        sched::xgb::clear();
+        let mut blob_corrupt = sched::xgb::build_smoke_blob();
+        let last = blob_corrupt.len() - 1;
+        blob_corrupt[last] ^= 0xFF;
+        let rejected = unsafe {
+            sched::xgb::rust_sched_xgb_stage_blob(
+                blob_corrupt.as_ptr(),
+                blob_corrupt.len(),
+            ) != 0
+        };
+        print_test_result(b"sched_xgb_rejects_bad_checksum\0", rejected);
+        if !rejected { failures += 1; }
+
+        sched::xgb::clear();
+    }
+
     // Summary
     unsafe {
         if failures == 0 {

--- a/runtime/src/sched/mod.rs
+++ b/runtime/src/sched/mod.rs
@@ -16,6 +16,7 @@
 pub mod deadline;
 pub mod heterogeneous;
 pub mod inference;
+pub mod xgb;
 
 // Re-export commonly used types from deadline module
 pub use deadline::{

--- a/runtime/src/sched/xgb.rs
+++ b/runtime/src/sched/xgb.rs
@@ -1,0 +1,845 @@
+//! XGBoost cascade scheduler policy (#855).
+//!
+//! Holds the runtime-loaded `XGBC` cascade (3 classifiers — `core /
+//! priority / preempt`) emitted by `slm-os-scheduler-ai`'s
+//! `write_xgboost_blob` (#850 / sibling-repo `scripts/export_models.py`)
+//! and exposes the C-callable FFI used by `kernel/sched/ai/sched_xgb.c`
+//! and the Lua/shell `slm.sched_model_*` wiring.
+//!
+//! Storage lives Rust-side because the trained cascade is ~9 MB —
+//! far too large for the 528 KB-per-slot static dense pool used by
+//! the MLP / PPO stores in `kernel/sched/ai/runtime_model.c`.
+//!
+//! # Cascade ordering
+//!
+//! Matches `TripleClassifier.predict` in
+//! `~/projects/slm-os-scheduler-ai/training/xgboost/train.py`:
+//!
+//! ```text
+//!   core_clf      reads 113 features (108 raw + 5 derived)
+//!   priority_clf  reads 114 features (113 + predicted core)
+//!   preempt_clf   reads 115 features (114 + predicted priority)
+//! ```
+//!
+//! Each prediction is the **raw label value** (e.g. `core ∈ {0..5}`),
+//! not the encoded class index. The classifier's `label_classes` map
+//! does the inverse-transform that Python's `LabelEncoder` performs.
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::ptr::addr_of_mut;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use crate::ml::xgb_tree::{self, XgbCascade};
+
+// ---------------------------------------------------------------------
+// Wire-format constants — must mirror runtime_model.h + the SEMB header
+// shape used by every `SCHED_MODEL_KIND_*` blob.
+// ---------------------------------------------------------------------
+
+const SEMB_MAGIC: [u8; 4] = *b"SEMB";
+const SEMB_OUTER_HEADER_LEN: usize = 24;
+const SEMB_BLOB_VERSION_V1: u16 = 1;
+const SCHED_MODEL_KIND_XGBOOST: u16 = 0x1006;
+const SCHED_MODEL_SCHEMA_V1: u16 = 1;
+
+// ---------------------------------------------------------------------
+// Feature-shape constants — must mirror
+// `slm-os-scheduler-ai/training/xgboost/features.py` and
+// `slm_sim/observation.py` exactly. A drift here silently mis-feeds
+// the trees.
+// ---------------------------------------------------------------------
+
+pub const STATE_DIM: usize = 108;
+pub const N_DERIVED_FEATURES: usize = 5;
+pub const FEATURES_PER_CORE: usize = 6;
+pub const FEATURES_PER_TASK: usize = 8;
+pub const MAX_CORES: usize = 6;
+pub const MAX_PENDING_TASKS: usize = 8;
+pub const GLOBAL_FEATURE_COUNT: usize = 8;
+
+const TASK_START: usize = MAX_CORES * FEATURES_PER_CORE; // 36
+const GLOBAL_START: usize =
+    TASK_START + MAX_PENDING_TASKS * FEATURES_PER_TASK; // 100
+
+// Per-core sub-offsets.
+const CORE_UTIL: usize = 0;
+const CORE_CACHE: usize = 2;
+const CORE_TYPE: usize = 3;
+const CORE_ISOLATED: usize = 4;
+
+// Per-task sub-offsets.
+const TASK_DEADLINE_URG: usize = 1;
+const TASK_GPU: usize = 5;
+
+// Global sub-offsets.
+const GLOB_GPU_DEPTH: usize = 5;
+
+// Cascade input widths.
+const CORE_INPUT_LEN: usize = STATE_DIM + N_DERIVED_FEATURES; // 113
+const PRIORITY_INPUT_LEN: usize = CORE_INPUT_LEN + 1; // 114
+const PREEMPT_INPUT_LEN: usize = PRIORITY_INPUT_LEN + 1; // 115
+
+// Per-classifier feature-index bound for the parser. Each classifier
+// only references features from its own input vector (the previous
+// classifier's prediction shows up as a new feature index for the
+// next stage).
+const CASCADE_MAX_FEATURE_IDX: [usize; 3] = [
+    CORE_INPUT_LEN,
+    PRIORITY_INPUT_LEN,
+    PREEMPT_INPUT_LEN,
+];
+
+// ---------------------------------------------------------------------
+// FFI status struct — mirrors `struct sched_model_status` /
+// `struct sched_model_meta` in `kernel/sched/ai/runtime_model.h`. Must
+// stay byte-for-byte aligned with that layout (size + field offsets).
+// ---------------------------------------------------------------------
+
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+pub struct SchedModelMetaC {
+    pub version: u16,
+    pub schema_version: u16,
+    pub feature_version: u16,
+    pub action_version: u16,
+    pub action_count: u16,
+    pub _pad: u16,
+    pub payload_len: u32,
+    pub checksum: u32,
+}
+
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+pub struct SchedModelStatusC {
+    pub kind_id: u16,
+    pub state: u16,
+    pub has_staged: u32,
+    pub has_active: u32,
+    pub has_rollback: u32,
+    pub staged: SchedModelMetaC,
+    pub active: SchedModelMetaC,
+    pub rollback: SchedModelMetaC,
+}
+
+const SCHED_MODEL_EMPTY: u16 = 0;
+const SCHED_MODEL_STAGED: u16 = 1;
+const SCHED_MODEL_ACTIVE: u16 = 2;
+const SCHED_MODEL_ROLLED_BACK: u16 = 3;
+
+// ---------------------------------------------------------------------
+// Slot store. Three slots — staged, active, rollback — match the
+// existing dense-pool semantics so the Lua/shell verbs (`stage`,
+// `activate`, `rollback`, `clear`, `status`) behave identically across
+// all model kinds.
+// ---------------------------------------------------------------------
+
+struct Slot {
+    cascade: Option<Box<XgbCascade>>,
+    meta: SchedModelMetaC,
+}
+
+impl Slot {
+    const fn empty() -> Self {
+        Self {
+            cascade: None,
+            meta: SchedModelMetaC {
+                version: 0,
+                schema_version: 0,
+                feature_version: 0,
+                action_version: 0,
+                action_count: 0,
+                _pad: 0,
+                payload_len: 0,
+                checksum: 0,
+            },
+        }
+    }
+
+    fn present(&self) -> bool {
+        self.cascade.is_some()
+    }
+
+    fn clear(&mut self) {
+        self.cascade = None;
+        self.meta = SchedModelMetaC::default();
+    }
+}
+
+struct Store {
+    staged: Slot,
+    active: Slot,
+    rollback: Slot,
+    state: u16,
+}
+
+impl Store {
+    const fn empty() -> Self {
+        Self {
+            staged: Slot::empty(),
+            active: Slot::empty(),
+            rollback: Slot::empty(),
+            state: SCHED_MODEL_EMPTY,
+        }
+    }
+}
+
+static STORE_LOCK: AtomicBool = AtomicBool::new(false);
+static mut STORE: Store = Store::empty();
+
+struct SpinGuard;
+
+impl SpinGuard {
+    fn new() -> Self {
+        while STORE_LOCK
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+        SpinGuard
+    }
+}
+
+impl Drop for SpinGuard {
+    fn drop(&mut self) {
+        STORE_LOCK.store(false, Ordering::Release);
+    }
+}
+
+unsafe fn store_mut() -> *mut Store {
+    addr_of_mut!(STORE)
+}
+
+// ---------------------------------------------------------------------
+// SEMB outer-header parse. Borrowed shape from
+// `runtime/src/mm/eviction/blob.rs::parse_blob` but pinned to the
+// scheduler-side kind id (0x1006) and the FNV-1a checksum used by the
+// existing C-side parser in `runtime_model.c`.
+// ---------------------------------------------------------------------
+
+fn read_u16_le(b: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes([b[off], b[off + 1]])
+}
+
+fn read_u32_le(b: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]])
+}
+
+fn fnv1a_32(bytes: &[u8]) -> u32 {
+    let mut h: u32 = 0x811C_9DC5;
+    for &b in bytes {
+        h ^= b as u32;
+        h = h.wrapping_mul(0x0100_0193);
+    }
+    h
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XgbStageError {
+    TooShort,
+    BadMagic,
+    BadVersion,
+    BadKind,
+    BadSchema,
+    NonZeroReserved,
+    BadLength,
+    Checksum,
+    PayloadInvalid,
+    BadClassifierCount,
+}
+
+fn parse_outer_header(bytes: &[u8]) -> Result<(SchedModelMetaC, &[u8]), XgbStageError> {
+    if bytes.len() < SEMB_OUTER_HEADER_LEN {
+        return Err(XgbStageError::TooShort);
+    }
+    if bytes[0..4] != SEMB_MAGIC {
+        return Err(XgbStageError::BadMagic);
+    }
+    let version = read_u16_le(bytes, 4);
+    if version != SEMB_BLOB_VERSION_V1 {
+        return Err(XgbStageError::BadVersion);
+    }
+    let kind = read_u16_le(bytes, 6);
+    if kind != SCHED_MODEL_KIND_XGBOOST {
+        return Err(XgbStageError::BadKind);
+    }
+    let schema_version = read_u16_le(bytes, 8);
+    if schema_version != SCHED_MODEL_SCHEMA_V1 {
+        return Err(XgbStageError::BadSchema);
+    }
+    if read_u16_le(bytes, 10) != 0 || read_u32_le(bytes, 20) != 0 {
+        return Err(XgbStageError::NonZeroReserved);
+    }
+    let payload_len = read_u32_le(bytes, 12);
+    let checksum = read_u32_le(bytes, 16);
+    let total = SEMB_OUTER_HEADER_LEN
+        .checked_add(payload_len as usize)
+        .ok_or(XgbStageError::BadLength)?;
+    if bytes.len() != total {
+        return Err(XgbStageError::BadLength);
+    }
+    let payload = &bytes[SEMB_OUTER_HEADER_LEN..];
+    if fnv1a_32(payload) != checksum {
+        return Err(XgbStageError::Checksum);
+    }
+    let meta = SchedModelMetaC {
+        version,
+        schema_version,
+        feature_version: 0,
+        action_version: 0,
+        action_count: 0,
+        _pad: 0,
+        payload_len,
+        checksum,
+    };
+    Ok((meta, payload))
+}
+
+fn parse_full(bytes: &[u8]) -> Result<(SchedModelMetaC, XgbCascade), XgbStageError> {
+    let (meta, payload) = parse_outer_header(bytes)?;
+    let cascade = xgb_tree::parse_cascade(payload, &CASCADE_MAX_FEATURE_IDX)
+        .map_err(|_| XgbStageError::PayloadInvalid)?;
+    if cascade.classifiers.len() != 3 {
+        return Err(XgbStageError::BadClassifierCount);
+    }
+    Ok((meta, cascade))
+}
+
+// ---------------------------------------------------------------------
+// Public stage / activate / rollback / clear / status / predict.
+// All operations short-circuit in O(1) if the store is empty.
+// ---------------------------------------------------------------------
+
+pub fn validate(bytes: &[u8]) -> Result<(), XgbStageError> {
+    parse_full(bytes).map(|_| ())
+}
+
+pub fn stage(bytes: &[u8]) -> Result<(), XgbStageError> {
+    let (meta, cascade) = parse_full(bytes)?;
+    let _g = SpinGuard::new();
+    // SAFETY: lock held — exclusive access to STORE.
+    unsafe {
+        let s = &mut *store_mut();
+        s.staged.cascade = Some(Box::new(cascade));
+        s.staged.meta = meta;
+        s.state = SCHED_MODEL_STAGED;
+    }
+    Ok(())
+}
+
+pub fn activate() -> Result<(), XgbStageError> {
+    let _g = SpinGuard::new();
+    unsafe {
+        let s = &mut *store_mut();
+        if !s.staged.present() {
+            return Err(XgbStageError::BadLength);
+        }
+        // Move active into rollback (drops the prior rollback), then
+        // staged into active. Manual swaps because Slot isn't Copy.
+        s.rollback.cascade = s.active.cascade.take();
+        s.rollback.meta = s.active.meta;
+        s.active.cascade = s.staged.cascade.take();
+        s.active.meta = s.staged.meta;
+        s.staged.clear();
+        s.state = SCHED_MODEL_ACTIVE;
+    }
+    Ok(())
+}
+
+pub fn rollback() -> Result<(), XgbStageError> {
+    let _g = SpinGuard::new();
+    unsafe {
+        let s = &mut *store_mut();
+        if !s.rollback.present() {
+            return Err(XgbStageError::BadLength);
+        }
+        // Swap active and rollback in place.
+        let (a_c, a_m) = (s.active.cascade.take(), s.active.meta);
+        s.active.cascade = s.rollback.cascade.take();
+        s.active.meta = s.rollback.meta;
+        s.rollback.cascade = a_c;
+        s.rollback.meta = a_m;
+        s.state = SCHED_MODEL_ROLLED_BACK;
+    }
+    Ok(())
+}
+
+pub fn clear() {
+    let _g = SpinGuard::new();
+    unsafe {
+        let s = &mut *store_mut();
+        s.staged.clear();
+        s.active.clear();
+        s.rollback.clear();
+        s.state = SCHED_MODEL_EMPTY;
+    }
+}
+
+pub fn status() -> SchedModelStatusC {
+    let _g = SpinGuard::new();
+    let mut out = SchedModelStatusC::default();
+    out.kind_id = SCHED_MODEL_KIND_XGBOOST;
+    unsafe {
+        let s = &*store_mut();
+        out.state = s.state;
+        out.has_staged = if s.staged.present() { 1 } else { 0 };
+        out.has_active = if s.active.present() { 1 } else { 0 };
+        out.has_rollback = if s.rollback.present() { 1 } else { 0 };
+        out.staged = s.staged.meta;
+        out.active = s.active.meta;
+        out.rollback = s.rollback.meta;
+    }
+    out
+}
+
+/// True if there's an active cascade ready to predict against.
+pub fn is_active() -> bool {
+    let _g = SpinGuard::new();
+    unsafe { (*store_mut()).active.present() }
+}
+
+// ---------------------------------------------------------------------
+// Derived features. Mirrors
+// `slm-os-scheduler-ai/training/xgboost/features.py::add_derived_features`
+// term-for-term. Any drift here silently mis-feeds the cascade.
+// ---------------------------------------------------------------------
+
+fn compute_derived(state: &[f32; STATE_DIM]) -> [f32; N_DERIVED_FEATURES] {
+    let mut out = [0.0_f32; N_DERIVED_FEATURES];
+
+    // 1. max_deadline_urgency over the top-K pending tasks.
+    let mut max_urg = 0.0_f32;
+    for t in 0..MAX_PENDING_TASKS {
+        let off = TASK_START + t * FEATURES_PER_TASK + TASK_DEADLINE_URG;
+        let v = state[off];
+        if v > max_urg {
+            max_urg = v;
+        }
+    }
+    out[0] = max_urg;
+
+    // 2. core_util_std with the same "non-padding" mask Python uses.
+    // Python: include core if (core_type > 0 OR util > 0 OR c < 4).
+    let mut utils: [f32; MAX_CORES] = [0.0; MAX_CORES];
+    let mut n = 0usize;
+    for c in 0..MAX_CORES {
+        let base = c * FEATURES_PER_CORE;
+        let u = state[base + CORE_UTIL];
+        let core_type = state[base + CORE_TYPE];
+        if core_type > 0.0 || u > 0.0 || c < 4 {
+            utils[n] = u;
+            n += 1;
+        }
+    }
+    if n > 1 {
+        let mut sum = 0.0_f32;
+        for i in 0..n {
+            sum += utils[i];
+        }
+        let mean = sum / (n as f32);
+        let mut var_sum = 0.0_f32;
+        for i in 0..n {
+            let d = utils[i] - mean;
+            var_sum += d * d;
+        }
+        // Population std (numpy default). Use the no_libm `mathf::sqrtf`
+        // — `libm::sqrtf` triggers the f16 soften crash on
+        // x86_64-unknown-none (issue #141).
+        let var = var_sum / (n as f32);
+        out[1] = crate::inference::mathf::sqrtf(var);
+    } else {
+        out[1] = 0.0;
+    }
+
+    // 3. deadline_task_count, normalized to [0, 1].
+    let mut count: u32 = 0;
+    for t in 0..MAX_PENDING_TASKS {
+        let off = TASK_START + t * FEATURES_PER_TASK + TASK_DEADLINE_URG;
+        if state[off] > 0.0 {
+            count += 1;
+        }
+    }
+    out[2] = (count as f32) / (MAX_PENDING_TASKS as f32);
+
+    // 4. gpu_should_use: (top task is GPU-eligible) AND (GPU queue depth low).
+    let gpu_depth = state[GLOBAL_START + GLOB_GPU_DEPTH];
+    let top_task_gpu = state[TASK_START + TASK_GPU];
+    out[3] = if top_task_gpu > 0.5 && gpu_depth < 0.25 {
+        1.0
+    } else {
+        0.0
+    };
+
+    // 5. best_cache_fit_core: lowest cache pressure among non-isolated
+    // cores, normalized by (MAX_CORES - 1).
+    let mut best_pressure = f32::INFINITY;
+    let mut best_core = 0usize;
+    for c in 0..MAX_CORES {
+        let base = c * FEATURES_PER_CORE;
+        if state[base + CORE_ISOLATED] > 0.5 {
+            continue;
+        }
+        let pressure = state[base + CORE_CACHE];
+        if pressure < best_pressure {
+            best_pressure = pressure;
+            best_core = c;
+        }
+    }
+    let denom = (MAX_CORES - 1) as f32;
+    out[4] = (best_core as f32) / denom;
+
+    out
+}
+
+// ---------------------------------------------------------------------
+// Predict. Three classifiers in cascade — each appends its prediction
+// to the input vector before invoking the next.
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub struct CascadeOutput {
+    pub core: i32,
+    pub priority: i32,
+    pub preempt: i32,
+}
+
+pub fn predict(state: &[f32; STATE_DIM]) -> Option<CascadeOutput> {
+    // Take a snapshot of the active cascade under the lock, then
+    // release the lock before tree-walking. The cascade is held by
+    // an `Arc`-equivalent via `Box`; we clone the `Box` contents into
+    // a stack-temporary view by re-borrowing the existing one. To
+    // keep the lock's critical section short, we copy the trees out.
+    //
+    // Pragmatic implementation: hold the lock for the full tree walk.
+    // This is the same shape the eviction `XGBoostPolicy` takes —
+    // assign_cpu happens at scheduling decisions, which is rare
+    // compared to other kernel hot paths.
+    let _g = SpinGuard::new();
+    let cascade = unsafe { (*store_mut()).active.cascade.as_ref() }?;
+
+    let derived = compute_derived(state);
+
+    // Build the core-classifier input (113 features).
+    let mut features: Vec<f32> = Vec::with_capacity(PREEMPT_INPUT_LEN);
+    features.extend_from_slice(state);
+    features.extend_from_slice(&derived);
+
+    let core_clf = &cascade.classifiers[0];
+    let core_label =
+        core_clf.predict_label(&features, core_clf.label_classes().len());
+
+    features.push(core_label as f32);
+    let priority_clf = &cascade.classifiers[1];
+    let prio_label = priority_clf
+        .predict_label(&features, priority_clf.label_classes().len());
+
+    features.push(prio_label as f32);
+    let preempt_clf = &cascade.classifiers[2];
+    let preempt_label = preempt_clf
+        .predict_label(&features, preempt_clf.label_classes().len());
+
+    Some(CascadeOutput {
+        core: core_label,
+        priority: prio_label,
+        preempt: preempt_label,
+    })
+}
+
+// ---------------------------------------------------------------------
+// C FFI surface. All `extern "C"` entry points are no-mangle and use
+// `*const`/`*mut` pointers because the caller is C; safety contracts
+// are documented per function.
+// ---------------------------------------------------------------------
+
+/// SAFETY: `data..data+len` must be a valid readable slice for the
+/// duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn rust_sched_xgb_validate_blob(
+    data: *const u8,
+    len: usize,
+) -> i32 {
+    if data.is_null() || len == 0 {
+        return -1;
+    }
+    let slice = unsafe { core::slice::from_raw_parts(data, len) };
+    match validate(slice) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+/// SAFETY: `data..data+len` must be a valid readable slice for the
+/// duration of the call. Bytes are copied into Rust-owned heap; the
+/// caller may free its buffer immediately on return.
+#[no_mangle]
+pub unsafe extern "C" fn rust_sched_xgb_stage_blob(
+    data: *const u8,
+    len: usize,
+) -> i32 {
+    if data.is_null() || len == 0 {
+        return -1;
+    }
+    let slice = unsafe { core::slice::from_raw_parts(data, len) };
+    match stage(slice) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_sched_xgb_activate() -> i32 {
+    match activate() {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_sched_xgb_rollback() -> i32 {
+    match rollback() {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_sched_xgb_clear() -> i32 {
+    clear();
+    0
+}
+
+/// SAFETY: `out` must point to a writable `struct sched_model_status`
+/// (`SchedModelStatusC`). Layout is asserted via static-assert on the
+/// C side; mismatches surface at compile time, not at runtime.
+#[no_mangle]
+pub unsafe extern "C" fn rust_sched_xgb_status(
+    out: *mut SchedModelStatusC,
+) -> i32 {
+    if out.is_null() {
+        return -1;
+    }
+    unsafe { *out = status(); }
+    0
+}
+
+/// Returns 1 if a cascade is currently active and ready to serve
+/// predictions, 0 otherwise.
+#[no_mangle]
+pub extern "C" fn rust_sched_xgb_is_active() -> i32 {
+    if is_active() {
+        1
+    } else {
+        0
+    }
+}
+
+/// Run the cascade against the supplied 108-d state vector. On
+/// success, writes the (core, priority, preempt) triple to the
+/// output pointers and returns 0. Returns -1 if no cascade is active
+/// or any of the pointers is NULL.
+///
+/// SAFETY: `state` must point to `STATE_DIM` floats; `out_*` must be
+/// non-null and writable.
+#[no_mangle]
+pub unsafe extern "C" fn rust_sched_xgb_predict(
+    state: *const f32,
+    out_core: *mut i32,
+    out_priority: *mut i32,
+    out_preempt: *mut i32,
+) -> i32 {
+    if state.is_null()
+        || out_core.is_null()
+        || out_priority.is_null()
+        || out_preempt.is_null()
+    {
+        return -1;
+    }
+    let buf: &[f32; STATE_DIM] = unsafe {
+        &*(state as *const [f32; STATE_DIM])
+    };
+    let Some(out) = predict(buf) else { return -1 };
+    unsafe {
+        *out_core = out.core;
+        *out_priority = out.priority;
+        *out_preempt = out.preempt;
+    }
+    0
+}
+
+// ---------------------------------------------------------------------
+// Smoke-test fixture. Reused by the kernel-side `rust_run_tests` path
+// in `lib.rs` (synthetic 3-classifier cascade — no trained weights
+// required) and by the unit tests below.
+// ---------------------------------------------------------------------
+
+/// Build a tiny SEMB+XGBC blob holding a 3-classifier cascade that
+/// emits raw labels (3, 1, 1) regardless of input. Each classifier is
+/// 1 tree of 1 leaf with `n_classes == 1`.
+pub fn build_smoke_blob() -> Vec<u8> {
+    use core::convert::TryFrom;
+
+    let mut payload: Vec<u8> = Vec::new();
+    payload.extend_from_slice(b"XGBC");
+    payload.extend_from_slice(&1u16.to_le_bytes()); // version
+    payload.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    payload.extend_from_slice(&3u16.to_le_bytes()); // n_classifiers
+    payload.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    payload.extend_from_slice(&0u32.to_le_bytes()); // reserved
+
+    for label in [3i32, 1i32, 1i32] {
+        payload.extend_from_slice(&1u32.to_le_bytes()); // n_trees
+        payload.extend_from_slice(&1u32.to_le_bytes()); // n_nodes
+        payload.extend_from_slice(&1u16.to_le_bytes()); // n_classes
+        payload.extend_from_slice(&0u16.to_le_bytes()); // reserved (u16)
+        payload.extend_from_slice(&0u32.to_le_bytes()); // reserved (u32)
+        payload.extend_from_slice(&0u32.to_le_bytes()); // root[0]
+        // Single leaf node.
+        payload.extend_from_slice(&0u16.to_le_bytes()); // feature
+        payload.extend_from_slice(&1u16.to_le_bytes()); // FLAG_LEAF
+        payload.extend_from_slice(&0u32.to_le_bytes()); // left
+        payload.extend_from_slice(&0u32.to_le_bytes()); // right
+        payload.extend_from_slice(&0.0_f32.to_le_bytes()); // threshold
+        payload.extend_from_slice(&1.0_f32.to_le_bytes()); // value
+        payload.extend_from_slice(&label.to_le_bytes()); // label[0]
+    }
+
+    let payload_len = u32::try_from(payload.len()).unwrap();
+    let checksum = fnv1a_32(&payload);
+
+    let mut blob: Vec<u8> = Vec::with_capacity(SEMB_OUTER_HEADER_LEN + payload.len());
+    blob.extend_from_slice(&SEMB_MAGIC);
+    blob.extend_from_slice(&SEMB_BLOB_VERSION_V1.to_le_bytes());
+    blob.extend_from_slice(&SCHED_MODEL_KIND_XGBOOST.to_le_bytes());
+    blob.extend_from_slice(&SCHED_MODEL_SCHEMA_V1.to_le_bytes());
+    blob.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    blob.extend_from_slice(&payload_len.to_le_bytes());
+    blob.extend_from_slice(&checksum.to_le_bytes());
+    blob.extend_from_slice(&0u32.to_le_bytes()); // trailing reserved
+    blob.extend_from_slice(&payload);
+    blob
+}
+
+// ---------------------------------------------------------------------
+// Unit tests. Exercise every part of the path: SEMB outer-header
+// round-trip, cascade parse, staged → active dance, derived-feature
+// computation, full predict.
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_minimal_cascade_blob() -> Vec<u8> {
+        super::build_smoke_blob()
+    }
+
+    /// Reset the global STORE between tests — module-static state would
+    /// otherwise carry over and conflate failure attribution.
+    fn reset_store() {
+        clear();
+    }
+
+    #[test]
+    fn outer_header_rejects_wrong_kind() {
+        reset_store();
+        let mut blob = build_minimal_cascade_blob();
+        // Overwrite kind id at offset 6 with a foreign value.
+        blob[6] = 0x99;
+        blob[7] = 0x99;
+        // Recompute checksum (changing the kind doesn't affect payload,
+        // so checksum is still valid — the kind check fires first).
+        assert!(matches!(validate(&blob), Err(XgbStageError::BadKind)));
+    }
+
+    #[test]
+    fn outer_header_rejects_bad_checksum() {
+        reset_store();
+        let mut blob = build_minimal_cascade_blob();
+        // Flip a byte in the payload (after the 24-byte header).
+        let last = blob.len() - 1;
+        blob[last] ^= 0xFF;
+        assert!(matches!(validate(&blob), Err(XgbStageError::Checksum)));
+    }
+
+    #[test]
+    fn stage_activate_predict_round_trip() {
+        reset_store();
+        let blob = build_minimal_cascade_blob();
+        assert!(stage(&blob).is_ok());
+        let s = status();
+        assert_eq!(s.has_staged, 1);
+        assert_eq!(s.has_active, 0);
+        assert!(activate().is_ok());
+        let s = status();
+        assert_eq!(s.has_active, 1);
+        assert_eq!(s.has_staged, 0);
+
+        let state = [0.0_f32; STATE_DIM];
+        let out = predict(&state).expect("active cascade predicts");
+        // Each classifier has 1 class so argmax is 0 → label_map[0].
+        // The minimal cascade's labels were [3, 1, 1].
+        assert_eq!(out.core, 3);
+        assert_eq!(out.priority, 1);
+        assert_eq!(out.preempt, 1);
+    }
+
+    #[test]
+    fn rollback_restores_prior_active() {
+        reset_store();
+        let blob = build_minimal_cascade_blob();
+        stage(&blob).unwrap();
+        activate().unwrap();
+        // Stage a *different* cascade and activate to push the first
+        // into rollback. Reusing the same blob bytes is fine for the
+        // mechanics test — what matters is that the slot dance works.
+        stage(&blob).unwrap();
+        activate().unwrap();
+        let s = status();
+        assert_eq!(s.has_rollback, 1);
+        assert!(rollback().is_ok());
+        let s = status();
+        assert_eq!(s.state, SCHED_MODEL_ROLLED_BACK);
+    }
+
+    #[test]
+    fn predict_returns_none_when_no_active_cascade() {
+        reset_store();
+        let state = [0.0_f32; STATE_DIM];
+        assert!(predict(&state).is_none());
+    }
+
+    #[test]
+    fn derived_features_match_python_reference() {
+        // Construct a state where every derived feature has a
+        // hand-computable answer and assert each one.
+        let mut state = [0.0_f32; STATE_DIM];
+        // Task 2 has urgency 0.7 (max), task 5 has 0.3.
+        state[TASK_START + 2 * FEATURES_PER_TASK + TASK_DEADLINE_URG] = 0.7;
+        state[TASK_START + 5 * FEATURES_PER_TASK + TASK_DEADLINE_URG] = 0.3;
+        // Cores 0..3 have utilisations [0.2, 0.4, 0.0, 0.6]; cores 4..5
+        // have type=0 / util=0 → excluded by the (c<4) mask.
+        state[0 * FEATURES_PER_CORE + CORE_UTIL] = 0.2;
+        state[1 * FEATURES_PER_CORE + CORE_UTIL] = 0.4;
+        state[3 * FEATURES_PER_CORE + CORE_UTIL] = 0.6;
+        // Top task is GPU-eligible; gpu queue depth is 0.1 (< 0.25).
+        state[TASK_START + TASK_GPU] = 1.0;
+        state[GLOBAL_START + GLOB_GPU_DEPTH] = 0.1;
+        // Core 2 has the lowest cache pressure (0.1) and is non-isolated.
+        for c in 0..MAX_CORES {
+            state[c * FEATURES_PER_CORE + CORE_CACHE] = 0.5;
+        }
+        state[2 * FEATURES_PER_CORE + CORE_CACHE] = 0.1;
+
+        let d = compute_derived(&state);
+        assert!((d[0] - 0.7).abs() < 1e-6);
+        // utils = [0.2, 0.4, 0.0, 0.6]; mean = 0.3; var = 0.05; std ≈ 0.2236.
+        assert!((d[1] - 0.22360680).abs() < 1e-3,
+                "core_util_std = {} (expected ~0.224)", d[1]);
+        // 2 tasks have urgency > 0; 2 / 8 = 0.25.
+        assert!((d[2] - 0.25).abs() < 1e-6);
+        assert_eq!(d[3], 1.0);
+        // best_core = 2; 2 / 5 = 0.4.
+        assert!((d[4] - 0.4).abs() < 1e-6);
+    }
+}

--- a/runtime/src/sched/xgb.rs
+++ b/runtime/src/sched/xgb.rs
@@ -259,6 +259,11 @@ pub enum XgbStageError {
     Checksum,
     PayloadInvalid,
     BadClassifierCount,
+    /// `activate()` called with no staged blob, or `rollback()` called
+    /// with no rollback slot. C-side surfaces both as `-1` (same as
+    /// any other error), but Rust callers can pattern-match for
+    /// clearer logging.
+    NotPresent,
 }
 
 fn parse_outer_header(bytes: &[u8]) -> Result<(SchedModelMetaC, &[u8]), XgbStageError> {
@@ -346,7 +351,7 @@ pub fn activate() -> Result<(), XgbStageError> {
     unsafe {
         let s = &mut *store_mut();
         if !s.staged.present() {
-            return Err(XgbStageError::BadLength);
+            return Err(XgbStageError::NotPresent);
         }
         // Move active into rollback (drops the prior rollback), then
         // staged into active. Manual swaps because Slot isn't Copy.
@@ -365,7 +370,7 @@ pub fn rollback() -> Result<(), XgbStageError> {
     unsafe {
         let s = &mut *store_mut();
         if !s.rollback.present() {
-            return Err(XgbStageError::BadLength);
+            return Err(XgbStageError::NotPresent);
         }
         // Swap active and rollback in place.
         let (a_c, a_m) = (s.active.cascade.take(), s.active.meta);
@@ -649,13 +654,12 @@ pub extern "C" fn rust_sched_xgb_clear() -> i32 {
     0
 }
 
-/// SAFETY: `out` must point to a writable `struct sched_model_status`
-/// (`SchedModelStatusC`). Layout is asserted via static-assert on the
-/// C side; mismatches surface at compile time, not at runtime.
 /// SAFETY (caller contract): `out` must point to a writable
-/// `struct sched_model_status` (`SchedModelStatusC`). Layout is
-/// asserted via `const _: () = assert!` at module scope; mismatches
-/// surface at compile time, not at runtime.
+/// `struct sched_model_status` (`SchedModelStatusC`). Layout is pinned
+/// on both sides — `const _: () = assert!` in this module
+/// (`size_of::<SchedModelStatusC>() == 76`) and `_Static_assert` in
+/// `kernel/sched/ai/runtime_model.h` — so any future reorder breaks
+/// the build instead of silently mis-reading the status payload.
 #[no_mangle]
 pub extern "C" fn rust_sched_xgb_status(out: *mut SchedModelStatusC) -> i32 {
     if out.is_null() {
@@ -685,7 +689,9 @@ pub extern "C" fn rust_sched_xgb_is_active() -> i32 {
 /// or any of the pointers is NULL.
 ///
 /// SAFETY (caller contract): `state` must point to `STATE_DIM`
-/// floats; `out_*` must be non-null and writable.
+/// contiguous `f32`s and be 4-byte aligned (any `float state[N]` on
+/// the C side satisfies this naturally). `out_*` must be non-null and
+/// writable.
 #[no_mangle]
 pub extern "C" fn rust_sched_xgb_predict(
     state: *const f32,
@@ -727,8 +733,6 @@ pub extern "C" fn rust_sched_xgb_predict(
 /// emits raw labels (3, 1, 1) regardless of input. Each classifier is
 /// 1 tree of 1 leaf with `n_classes == 1`.
 pub fn build_smoke_blob() -> Vec<u8> {
-    use core::convert::TryFrom;
-
     let mut payload: Vec<u8> = Vec::new();
     payload.extend_from_slice(b"XGBC");
     payload.extend_from_slice(&1u16.to_le_bytes()); // version
@@ -754,7 +758,9 @@ pub fn build_smoke_blob() -> Vec<u8> {
         payload.extend_from_slice(&label.to_le_bytes()); // label[0]
     }
 
-    let payload_len = u32::try_from(payload.len()).unwrap();
+    // Synthetic blob is <200 bytes; `as u32` truncation is safe and
+    // avoids a panic path reachable from the kernel test harness.
+    let payload_len = payload.len() as u32;
     let checksum = fnv1a_32(&payload);
 
     let mut blob: Vec<u8> = Vec::with_capacity(SEMB_OUTER_HEADER_LEN + payload.len());

--- a/runtime/src/sched/xgb.rs
+++ b/runtime/src/sched/xgb.rs
@@ -866,6 +866,18 @@ mod tests {
     }
 
     #[test]
+    fn activate_without_staged_returns_not_present() {
+        reset_store();
+        assert!(matches!(activate(), Err(XgbStageError::NotPresent)));
+    }
+
+    #[test]
+    fn rollback_without_prior_returns_not_present() {
+        reset_store();
+        assert!(matches!(rollback(), Err(XgbStageError::NotPresent)));
+    }
+
+    #[test]
     fn derived_features_match_python_reference() {
         // Construct a state where every derived feature has a
         // hand-computable answer and assert each one.

--- a/runtime/src/sched/xgb.rs
+++ b/runtime/src/sched/xgb.rs
@@ -25,7 +25,7 @@
 //! not the encoded class index. The classifier's `label_classes` map
 //! does the inverse-transform that Python's `LabelEncoder` performs.
 
-use alloc::boxed::Box;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::ptr::addr_of_mut;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -127,6 +127,14 @@ const SCHED_MODEL_STAGED: u16 = 1;
 const SCHED_MODEL_ACTIVE: u16 = 2;
 const SCHED_MODEL_ROLLED_BACK: u16 = 3;
 
+// Build-time layout pin against `struct sched_model_status` /
+// `struct sched_model_meta` in `kernel/sched/ai/runtime_model.h`.
+// Either the field order or the implicit pad changes here, the build
+// breaks instead of the C side silently mis-reading the FFI status
+// payload.
+const _: () = assert!(core::mem::size_of::<SchedModelMetaC>() == 20);
+const _: () = assert!(core::mem::size_of::<SchedModelStatusC>() == 76);
+
 // ---------------------------------------------------------------------
 // Slot store. Three slots — staged, active, rollback — match the
 // existing dense-pool semantics so the Lua/shell verbs (`stage`,
@@ -135,7 +143,11 @@ const SCHED_MODEL_ROLLED_BACK: u16 = 3;
 // ---------------------------------------------------------------------
 
 struct Slot {
-    cascade: Option<Box<XgbCascade>>,
+    /// `Arc` (not `Box`) so `predict()` can clone a reference under
+    /// the lock and walk the trees with the lock released — the lock
+    /// would otherwise be held for hundreds of thousands of node
+    /// reads per decision.
+    cascade: Option<Arc<XgbCascade>>,
     meta: SchedModelMetaC,
 }
 
@@ -317,11 +329,12 @@ pub fn validate(bytes: &[u8]) -> Result<(), XgbStageError> {
 
 pub fn stage(bytes: &[u8]) -> Result<(), XgbStageError> {
     let (meta, cascade) = parse_full(bytes)?;
+    let arc = Arc::new(cascade);
     let _g = SpinGuard::new();
     // SAFETY: lock held — exclusive access to STORE.
     unsafe {
         let s = &mut *store_mut();
-        s.staged.cascade = Some(Box::new(cascade));
+        s.staged.cascade = Some(arc);
         s.staged.meta = meta;
         s.state = SCHED_MODEL_STAGED;
     }
@@ -432,6 +445,7 @@ fn compute_derived(state: &[f32; STATE_DIM]) -> [f32; N_DERIVED_FEATURES] {
             n += 1;
         }
     }
+    debug_assert!(n <= MAX_CORES);
     if n > 1 {
         let mut sum = 0.0_f32;
         for i in 0..n {
@@ -505,39 +519,58 @@ pub struct CascadeOutput {
 }
 
 pub fn predict(state: &[f32; STATE_DIM]) -> Option<CascadeOutput> {
-    // Take a snapshot of the active cascade under the lock, then
-    // release the lock before tree-walking. The cascade is held by
-    // an `Arc`-equivalent via `Box`; we clone the `Box` contents into
-    // a stack-temporary view by re-borrowing the existing one. To
-    // keep the lock's critical section short, we copy the trees out.
-    //
-    // Pragmatic implementation: hold the lock for the full tree walk.
-    // This is the same shape the eviction `XGBoostPolicy` takes —
-    // assign_cpu happens at scheduling decisions, which is rare
-    // compared to other kernel hot paths.
-    let _g = SpinGuard::new();
-    let cascade = unsafe { (*store_mut()).active.cascade.as_ref() }?;
+    // Snapshot the active cascade under the lock, release the lock,
+    // then walk the trees. `Arc::clone` is a single refcount bump
+    // so the critical section is O(1) regardless of cascade size.
+    // Without this, every IRQ-context `assign_cpu` on every CPU
+    // would serialise on the lock for the full tree walk
+    // (hundreds of thousands of node reads).
+    let cascade: Arc<XgbCascade> = {
+        let _g = SpinGuard::new();
+        // SAFETY: lock held — exclusive access to STORE.
+        unsafe { (*store_mut()).active.cascade.clone() }
+    }?;
+    debug_assert_eq!(cascade.classifiers.len(), 3);
 
     let derived = compute_derived(state);
 
-    // Build the core-classifier input (113 features).
-    let mut features: Vec<f32> = Vec::with_capacity(PREEMPT_INPUT_LEN);
-    features.extend_from_slice(state);
-    features.extend_from_slice(&derived);
+    // Stack-allocated 115-float feature buffer — avoids the
+    // ~460-byte heap alloc that a `Vec` would do per assign_cpu.
+    // `assign_cpu` runs from IRQ context on hardware-tick paths;
+    // hitting the global Rust heap there pressures the allocator
+    // and lengthens the IRQ-disabled window.
+    let mut features = [0.0_f32; PREEMPT_INPUT_LEN];
+    let mut len: usize = 0;
+    for (dst, src) in features[..STATE_DIM].iter_mut().zip(state.iter()) {
+        *dst = *src;
+    }
+    len += STATE_DIM;
+    for (dst, src) in features[len..len + N_DERIVED_FEATURES]
+        .iter_mut()
+        .zip(derived.iter())
+    {
+        *dst = *src;
+    }
+    len += N_DERIVED_FEATURES;
+    debug_assert_eq!(len, CORE_INPUT_LEN);
 
     let core_clf = &cascade.classifiers[0];
     let core_label =
-        core_clf.predict_label(&features, core_clf.label_classes().len());
+        core_clf.predict_label(&features[..len], core_clf.label_classes().len());
 
-    features.push(core_label as f32);
+    features[len] = core_label as f32;
+    len += 1;
+    debug_assert_eq!(len, PRIORITY_INPUT_LEN);
     let priority_clf = &cascade.classifiers[1];
     let prio_label = priority_clf
-        .predict_label(&features, priority_clf.label_classes().len());
+        .predict_label(&features[..len], priority_clf.label_classes().len());
 
-    features.push(prio_label as f32);
+    features[len] = prio_label as f32;
+    len += 1;
+    debug_assert_eq!(len, PREEMPT_INPUT_LEN);
     let preempt_clf = &cascade.classifiers[2];
     let preempt_label = preempt_clf
-        .predict_label(&features, preempt_clf.label_classes().len());
+        .predict_label(&features[..len], preempt_clf.label_classes().len());
 
     Some(CascadeOutput {
         core: core_label,
@@ -552,16 +585,19 @@ pub fn predict(state: &[f32; STATE_DIM]) -> Option<CascadeOutput> {
 // are documented per function.
 // ---------------------------------------------------------------------
 
-/// SAFETY: `data..data+len` must be a valid readable slice for the
-/// duration of the call.
+/// Validate a candidate blob without mutating the store.
+///
+/// SAFETY (caller contract): `data..data+len` must be a valid
+/// readable slice for the duration of the call.
 #[no_mangle]
-pub unsafe extern "C" fn rust_sched_xgb_validate_blob(
+pub extern "C" fn rust_sched_xgb_validate_blob(
     data: *const u8,
     len: usize,
 ) -> i32 {
     if data.is_null() || len == 0 {
         return -1;
     }
+    // SAFETY: caller-contract; validated above.
     let slice = unsafe { core::slice::from_raw_parts(data, len) };
     match validate(slice) {
         Ok(()) => 0,
@@ -569,17 +605,21 @@ pub unsafe extern "C" fn rust_sched_xgb_validate_blob(
     }
 }
 
-/// SAFETY: `data..data+len` must be a valid readable slice for the
-/// duration of the call. Bytes are copied into Rust-owned heap; the
-/// caller may free its buffer immediately on return.
+/// Parse + stage a blob into the STAGED slot.
+///
+/// SAFETY (caller contract): `data..data+len` must be a valid
+/// readable slice for the duration of the call. Bytes are copied
+/// into Rust-owned heap; the caller may free its buffer immediately
+/// on return.
 #[no_mangle]
-pub unsafe extern "C" fn rust_sched_xgb_stage_blob(
+pub extern "C" fn rust_sched_xgb_stage_blob(
     data: *const u8,
     len: usize,
 ) -> i32 {
     if data.is_null() || len == 0 {
         return -1;
     }
+    // SAFETY: caller-contract; validated above.
     let slice = unsafe { core::slice::from_raw_parts(data, len) };
     match stage(slice) {
         Ok(()) => 0,
@@ -612,14 +652,19 @@ pub extern "C" fn rust_sched_xgb_clear() -> i32 {
 /// SAFETY: `out` must point to a writable `struct sched_model_status`
 /// (`SchedModelStatusC`). Layout is asserted via static-assert on the
 /// C side; mismatches surface at compile time, not at runtime.
+/// SAFETY (caller contract): `out` must point to a writable
+/// `struct sched_model_status` (`SchedModelStatusC`). Layout is
+/// asserted via `const _: () = assert!` at module scope; mismatches
+/// surface at compile time, not at runtime.
 #[no_mangle]
-pub unsafe extern "C" fn rust_sched_xgb_status(
-    out: *mut SchedModelStatusC,
-) -> i32 {
+pub extern "C" fn rust_sched_xgb_status(out: *mut SchedModelStatusC) -> i32 {
     if out.is_null() {
         return -1;
     }
-    unsafe { *out = status(); }
+    // SAFETY: caller-contract; validated above.
+    unsafe {
+        *out = status();
+    }
     0
 }
 
@@ -639,10 +684,10 @@ pub extern "C" fn rust_sched_xgb_is_active() -> i32 {
 /// output pointers and returns 0. Returns -1 if no cascade is active
 /// or any of the pointers is NULL.
 ///
-/// SAFETY: `state` must point to `STATE_DIM` floats; `out_*` must be
-/// non-null and writable.
+/// SAFETY (caller contract): `state` must point to `STATE_DIM`
+/// floats; `out_*` must be non-null and writable.
 #[no_mangle]
-pub unsafe extern "C" fn rust_sched_xgb_predict(
+pub extern "C" fn rust_sched_xgb_predict(
     state: *const f32,
     out_core: *mut i32,
     out_priority: *mut i32,
@@ -655,10 +700,15 @@ pub unsafe extern "C" fn rust_sched_xgb_predict(
     {
         return -1;
     }
-    let buf: &[f32; STATE_DIM] = unsafe {
-        &*(state as *const [f32; STATE_DIM])
+    // SAFETY: caller-contract; non-null + STATE_DIM floats validated
+    // by the FFI documentation. The cast to a fixed-size array
+    // borrow is safe because the caller promised at least STATE_DIM
+    // contiguous floats.
+    let buf: &[f32; STATE_DIM] = unsafe { &*(state as *const [f32; STATE_DIM]) };
+    let Some(out) = predict(buf) else {
+        return -1;
     };
-    let Some(out) = predict(buf) else { return -1 };
+    // SAFETY: caller-contract; out_* validated non-null above.
     unsafe {
         *out_core = out.core;
         *out_priority = out.priority;


### PR DESCRIPTION
## Summary

Sub-ticket [#855](https://github.com/SLM-OS/SLM-Operating-System/issues/855)
of the XGBoost scheduler policy umbrella
[#58](https://github.com/SLM-OS/SLM-Operating-System/issues/58).

Adds the 6th scheduler blob kind, the Rust 3-classifier cascade
predictor, the C policy vtable, and the Lua/shell wiring needed to
runtime-load the trained XGBoost cascade emitted by sibling-repo
[#850](https://github.com/SLM-OS/SLM-Operating-System/issues/850).

### Pieces

- **`SCHED_MODEL_KIND_XGBOOST = 0x1006u`** in
  `kernel/sched/ai/runtime_model.h`. Storage lives Rust-side
  because the trained cascade is ~9 MB — too large for the
  528 KB-per-slot static dense pool used by the existing kinds.
  Five existing kinds keep their static-pool path unchanged; new
  kind shortcuts at the top of every public `sched_model_*`
  function in `runtime_model.c` forward to the Rust FFI.
- **New module `runtime/src/sched/xgb.rs`** — staged / active /
  rollback slots, SEMB outer-header parse, FFI surface
  (`rust_sched_xgb_{validate,stage,activate,rollback,clear,status,
  is_active,predict}_*`), and the 5 derived features ported
  term-for-term from `slm-os-scheduler-ai/training/xgboost/features.py`.
- **New file `kernel/sched/ai/sched_xgb.c`** — mirrors
  `sched_policy_ai_mlp` shape (FP context save/restore, heuristic
  fallback). Two new behaviours specific to the cascade:

   - **CPU-id clamping.** XGBoost was trained on 6 cores; on Pi 5
     (`cpu_count == 4`) the core classifier can emit 4 or 5. The
     policy clamps via modulo and continues, with one-shot WARN.
   - **No self-test inference.** `predict()` returns failure
     cleanly when no cascade is active, so the policy registers
     before the operator stages a blob — assign_cpu falls back to
     heuristic in the meantime.

- Lua + shell name maps updated (`xgboost` ↔ `0x1006`); status
  loop and autoload kind table extended.

### Cascade ordering

Matches `TripleClassifier.predict` exactly:

```
core_clf      reads 113 features (108 raw + 5 derived)
priority_clf  reads 114 features (113 + predicted core)
preempt_clf   reads 115 features (114 + predicted priority)
```

### Tests (extending `rust_run_tests` — runs under `make test`)

- `[PASS] sched_xgb_stage_synthetic`
- `[PASS] sched_xgb_activate`
- `[PASS] sched_xgb_is_active_after_activate`
- `[PASS] sched_xgb_predict`
- `[PASS] sched_xgb_labels_match_synthetic`
- `[PASS] sched_xgb_rejects_bad_checksum`

Runtime-side `cargo test` covers parser edge cases (kind /
checksum / bounds) and the derived-feature math.

### Dependencies

- Depends on [#883](https://github.com/SLM-OS/SLM-Operating-System/pull/883)
  (#854 — shared traversal engine). Must merge first.
- Depends on
  [slm-os-scheduler-ai PR for #850](https://github.com/SLM-OS/slm-os-scheduler-ai/pull/2)
  (sibling repo) for the matching binary blob format.

## Test plan

- [x] `make test` (QEMU) — green
- [x] `make kernel PLATFORM=RASPI5 AI_SCHED=ON` — clean
- [ ] `make kernel PLATFORM=JETSON_ORIN_NANO AI_SCHED=ON` —
  pre-existing fails "Kernel image too large" in
  `kernel/kernel-jetson.ld`; out of scope
- [ ] On-target end-to-end with the actual trained `xgb_sched.smb`
  is captured by [#851](https://github.com/SLM-OS/SLM-Operating-System/issues/851)
  (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)