### PR TITLE
ai-runtime: software prefetch hints in matmul_tiled (#56)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -348,6 +348,22 @@ The 4×4 kernel keeps the C accumulator block resident in 4 NEON registers acros
 
 Jetson hardware run deferred until lab tooling for non-SD-card deploy is in this agent's reach; the change is platform-agnostic Rust + NEON intrinsics and cross-builds clean for `PLATFORM=JETSON_ORIN_NANO`.
 
+**After PR 3 (software prefetch hints):**
+
+PR 3 adds `prfm pldl1keep` hints to `matmul_tiled`. Two prefetch sites were tested:
+
+1. **Tile-level A-row prefetch** — issued once per 4-row group, ahead of the next ib-block's first call into `matmul_4x4_kernel_neon`. Prefetches the first cache line of each of the next 4 A rows.
+2. **In-kernel B-row prefetch** (initial design, *reverted*) — `prfm pldl1keep` inside the 4×4 kernel's K-loop, 8 K-steps ahead of the consuming `vld1q_f32(B)`.
+
+| Op | Calls | Avg | Min | Max | Δ vs PR 2 |
+|----|-------|-----|-----|-----|-----------|
+| Conv | 400 | **170 µs** | 141 µs | 202 µs | +0.6% (jitter) |
+| End-to-end MNIST | — | **486 µs** | 484 | 513 | +0.6% (jitter) |
+
+The in-kernel B prefetch (variant 2 above) measured **3% slower** (483 → 500 µs) on Cortex-A76 — the address arithmetic for the prefetch target (`bp_block + (kki + PFDIST_K) * n_stride`) added an integer multiply and a compare per K iteration that the A76 hardware prefetcher already covers. The matmul tile working set (~12 KB) fits in the 64 KB L1D with comfortable headroom, so cold-line misses are not a meaningful cost on this CPU. That variant was reverted; only the tile-level A-row prefetch ships.
+
+Conclusion: software prefetch is a net **no-op on Cortex-A76**. The infrastructure (a portable `prefetch_l1_read` helper and the tile-level hook) is kept in place because (a) the A78AE in Jetson Orin Nano has a different prefetcher and may behave differently, and (b) tighter inner loops on the same path (e.g. an 8×4 micro-kernel) will have more arithmetic per cache line and benefit more.
+
 ### Model Memory Utilization
 
 | Model | Weight Blocks | Workspace Blocks | Actual Weights |

--- a/runtime/src/inference/ops.rs
+++ b/runtime/src/inference/ops.rs
@@ -1000,18 +1000,8 @@ unsafe fn matmul_4x4_kernel_neon(
     let ap3 = ap_block.add(3 * k_stride);
 
     for kki in 0..kn {
-        // Note (#56 PR 3): an in-loop B-row prefetch was tried here
-        // (`prfm pldl1keep` with PFDIST_K = 4 / 8 / 16 lookaheads) and
-        // measured ~3% SLOWER on Pi 5 / Cortex-A76, MNIST 200-iter
-        // bench: 483 µs → 500 µs avg. The address arithmetic
-        // (`bp_block + (kki + PFDIST_K) * n_stride`) added a multiply
-        // and a compare per K-step that the Cortex-A76 hardware
-        // prefetcher already covers — the matmul tile working set
-        // (12 KB) fits in 64 KB L1D with comfortable headroom. The
-        // in-loop prefetch is intentionally NOT included. The
-        // tile-level A-row prefetch in `matmul_tiled` runs only once
-        // per 4-row group and remained neutral-to-positive, so it
-        // was kept.
+        // No in-loop B-row prefetch — tried and reverted (3% Pi 5
+        // regression). See "After PR 3" in `docs/benchmarks.md`.
         let b_row = vld1q_f32(bp_block.add(kki * n_stride));
 
         let a0 = vdupq_n_f32(*ap_block.add(kki));

--- a/runtime/src/inference/ops.rs
+++ b/runtime/src/inference/ops.rs
@@ -68,6 +68,50 @@ impl Drop for OpsGuard {
 }
 
 // =============================================================================
+// Software prefetch helper (#56 PR 3)
+// =============================================================================
+
+/// Prefetch one cache line into L1 for a future read (aarch64 `prfm
+/// pldl1keep`). On other targets this is a no-op.
+///
+/// Used by `matmul_tiled` and the 4×4 micro-kernel to hide L1 miss
+/// latency on the B-row stride. `prfm pldl1keep` is part of the ARMv8
+/// mandatory base ISA and is a hint, not a fault-on-miss: an address
+/// that's out of bounds, unmapped, or even invalid produces no fault,
+/// no architectural state change, and (worst case) just wastes the
+/// instruction slot.
+///
+/// `locality = "keep"` (PLDL1KEEP) tells the prefetcher the line
+/// should be kept in L1 after first use; the alternative `pldl1strm`
+/// hints that the line is streaming and can be evicted. Matmul
+/// accumulators stay in L1 long enough that "keep" is the right
+/// hint.
+///
+/// # Safety
+///
+/// `addr` is treated as a hint — the caller does not need to
+/// guarantee the address is mapped or readable. The function is
+/// `unsafe` only because it takes a raw pointer; calling it with a
+/// non-canonical address on aarch64 is fine.
+#[inline(always)]
+#[cfg(target_arch = "aarch64")]
+unsafe fn prefetch_l1_read(addr: *const i8) {
+    core::arch::asm!(
+        "prfm pldl1keep, [{0}]",
+        in(reg) addr,
+        options(nostack, readonly, preserves_flags),
+    );
+}
+
+#[inline(always)]
+#[cfg(not(target_arch = "aarch64"))]
+unsafe fn prefetch_l1_read(_addr: *const i8) {
+    // No portable prefetch in core for x86-64-unknown-none here; the
+    // x86-64 C SSE kernels can issue PREFETCHT0 themselves once #847
+    // wires them up. RISC-V and other archs: no-op.
+}
+
+// =============================================================================
 // FP16 helpers
 // =============================================================================
 
@@ -795,6 +839,24 @@ unsafe fn matmul_tiled(ap: *const f32, bp: *const f32, cp: *mut f32,
                     // 4×4-aligned interior — fastest path.
                     let mut ib = 0;
                     while ib < i_blocks {
+                        // Prefetch the head of the next 4-row group's
+                        // A rows (#56 PR 3). Each 4×4 kernel call
+                        // sweeps `kn` elements of A starting at
+                        // A[(ii+ib+next)*k + kk]; prefetching the
+                        // first cache line of each of the 4 rows
+                        // hides the cold-line miss when we move to
+                        // the next `ib` group. The prefetched
+                        // address may walk past the M dimension on
+                        // the last iteration — `prfm` ignores that.
+                        let next_ib = ib + 4;
+                        if next_ib < i_blocks {
+                            let a_next = ap.add((ii + next_ib) * k + kk);
+                            prefetch_l1_read(a_next as *const i8);
+                            prefetch_l1_read(a_next.add(k) as *const i8);
+                            prefetch_l1_read(a_next.add(2 * k) as *const i8);
+                            prefetch_l1_read(a_next.add(3 * k) as *const i8);
+                        }
+
                         let mut jb = 0;
                         while jb < j_blocks {
                             matmul_4x4_kernel_neon(
@@ -926,6 +988,18 @@ unsafe fn matmul_4x4_kernel_neon(
     let ap3 = ap_block.add(3 * k_stride);
 
     for kki in 0..kn {
+        // Note (#56 PR 3): an in-loop B-row prefetch was tried here
+        // (`prfm pldl1keep` with PFDIST_K = 4 / 8 / 16 lookaheads) and
+        // measured ~3% SLOWER on Pi 5 / Cortex-A76, MNIST 200-iter
+        // bench: 483 µs → 500 µs avg. The address arithmetic
+        // (`bp_block + (kki + PFDIST_K) * n_stride`) added a multiply
+        // and a compare per K-step that the Cortex-A76 hardware
+        // prefetcher already covers — the matmul tile working set
+        // (12 KB) fits in 64 KB L1D with comfortable headroom. The
+        // in-loop prefetch is intentionally NOT included. The
+        // tile-level A-row prefetch in `matmul_tiled` runs only once
+        // per 4-row group and remained neutral-to-positive, so it
+        // was kept.
         let b_row = vld1q_f32(bp_block.add(kki * n_stride));
 
         let a0 = vdupq_n_f32(*ap_block.add(kki));

--- a/runtime/src/inference/ops.rs
+++ b/runtime/src/inference/ops.rs
@@ -74,12 +74,16 @@ impl Drop for OpsGuard {
 /// Prefetch one cache line into L1 for a future read (aarch64 `prfm
 /// pldl1keep`). On other targets this is a no-op.
 ///
-/// Used by `matmul_tiled` and the 4×4 micro-kernel to hide L1 miss
-/// latency on the B-row stride. `prfm pldl1keep` is part of the ARMv8
-/// mandatory base ISA and is a hint, not a fault-on-miss: an address
-/// that's out of bounds, unmapped, or even invalid produces no fault,
-/// no architectural state change, and (worst case) just wastes the
-/// instruction slot.
+/// Only call site as of #56 PR 3 is `matmul_tiled`, which issues four
+/// of these once per 4-row group to warm the next A-block. The
+/// in-kernel B-row variant was tried and reverted (see the comment
+/// in `matmul_4x4_kernel_neon` and `docs/benchmarks.md` for the
+/// experiment record).
+///
+/// `prfm pldl1keep` is part of the ARMv8 mandatory base ISA and is a
+/// hint, not a fault-on-miss: an address that's out of bounds,
+/// unmapped, or even invalid produces no fault, no architectural
+/// state change, and (worst case) just wastes the instruction slot.
 ///
 /// `locality = "keep"` (PLDL1KEEP) tells the prefetcher the line
 /// should be kept in L1 after first use; the alternative `pldl1strm`
@@ -96,6 +100,14 @@ impl Drop for OpsGuard {
 #[inline(always)]
 #[cfg(target_arch = "aarch64")]
 unsafe fn prefetch_l1_read(addr: *const i8) {
+    // `readonly` (not `nomem`) is intentional: it lets the compiler
+    // assume the asm doesn't write memory but still treats it as
+    // reading memory, so the prefetch can't be reordered past an
+    // aliasing store. `nomem` would invite the compiler to hoist the
+    // prefetch above stores that might invalidate the same cache
+    // line — saving zero cycles and risking re-fetching the wrong
+    // line. `pure` is intentionally omitted so distinct-address
+    // prefetches are not deduplicated.
     core::arch::asm!(
         "prfm pldl1keep, [{0}]",
         in(reg) addr,


### PR DESCRIPTION
**Successor to #861** (auto-closed when its base branch was deleted on #876 merge). Final PR for #56, now rebased onto main.

## Summary

Implements the third deliverable for #56: software prefetch hints (\`prfm pldl1keep\`) in the matmul tiled path.

**Honest measurement result: net neutral on Pi 5 Cortex-A76.** The A76 hardware prefetcher already covers the matmul stride pattern — the tile working set fits in L1D with headroom and cold-line misses are not a meaningful cost. Implementation details:

- New \`prefetch_l1_read\` helper — aarch64 inline-asm \`prfm pldl1keep\`; other archs no-op.
- Tile-level A-row prefetch in \`matmul_tiled\` (issued once per 4-row group). **Kept** — 0.6% slower than PR 2 (#876), within jitter.
- In-kernel B-row prefetch with PFDIST_K=8 lookahead. **Reverted before commit** — measured 3% slower (483 → 500 µs); the per-K-step address-multiply overhead exceeded any prefetcher benefit on A76.

The tile-level hook is kept in place because:
1. The Jetson Orin Nano's Cortex-A78AE has a different prefetcher and may benefit (no hardware run available in this agent's lab session).
2. Future 8×4 or 4×8 micro-kernel expansions have more arithmetic per cache line and stand to benefit more from look-ahead.

## Measurement table (pi-5-2, MNIST 200 iters, BUILD_TYPE=Release)

| Variant | End-to-end avg | Conv avg | Δ vs #876 |
|---|---|---|---|
| #876 baseline (no prefetch) | 483 µs | 169 µs | — |
| PR 3 + in-kernel B prefetch (reverted) | 500 µs | 178 µs | **-3% slower** |
| **PR 3 final (tile-level A only)** | 486 µs | 170 µs | jitter (+0.6%) |

## Test plan

- [x] \`make test\` (QEMU ARM64) — all 620+ tests pass
- [x] \`make kernel PLATFORM=RASPI5\` — clean
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean
- [x] Pi 5 hardware (pi-5-2) — 486 µs MNIST bench, neutral vs #876
- [x] \`labctl boot_test --runs 5\` on pi-5-2 — 5/5 successful (prior to rebase)
- [ ] Jetson hardware run deferred — would actually be informative for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)