### PR TITLE
msg_router 67b: pin wildcard+exact per-subscription delivery contract (#863)

### DIFF
--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -416,9 +416,7 @@ the subscriber then sees only the second message. This case requires
 multiple publishers running concurrently against the same mailbox, which
 the standard ack-wait publish path does not produce — its loop blocks on
 ack between iterations, so a single publisher cannot back-to-back deliver
-to one mailbox. Distinct from the LAST_RECEIVED targeting case (multiple
-mailboxes per component), which is pinned by
-`test_msg_router_ack_targets_last_received` and works correctly.
+to one mailbox.
 
 The single-mailbox overwrite drop is a real limitation of the current
 single-slot design and is tracked for post-capstone follow-up as #869.

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -365,6 +365,69 @@ When space/message becomes available:
 
 ---
 
+## Topic-Based Pub/Sub (Message Router)
+
+The message router (`runtime/src/msg_router.rs`) layers a topic-based
+publish/subscribe surface on top of per-subscription mailboxes. Components
+call `msg_router_subscribe(topic, idx)` to register interest in either an
+exact topic name (`/sensors/data`) or a wildcard pattern ending in `*`
+(`/sensors/*`); publishers call `msg_router_publish(topic, data)` and the
+router fans the message out to every matching subscription.
+
+### Per-subscription delivery contract
+
+Each subscription gets its own independent mailbox. A component subscribed
+to a topic via both an exact name and a matching wildcard pattern receives
+the message **twice** — once per subscription. This matches the
+per-subscriber delivery semantics of DDS, ROS 2, ZeroMQ, nanomsg, and Linux
+notifier chains. The publish return value (`delivered`) is the count of
+mailboxes the message fanned out to, so overlapping patterns increase the
+count. Applications that want exactly-once delivery across overlapping
+subscription patterns are responsible for deduplicating at the application
+layer (typically by tagging messages with a sender-side sequence number).
+
+Regression coverage:
+`kernel/tests/test_msg_router.c::test_wildcard_exact_overlap_delivers_twice`
+and `test_wildcard_only_delivers_once` pin the contract on every
+`make test` run.
+
+### Other guarantees pinned by automated tests
+
+- **Cross-CPU publish/receive/ack** — a publisher and subscriber on
+  different CPUs round-trip N messages without router-internal deadlock
+  (`test_integration.c::test_msg_router_cross_cpu`, regression for #66).
+- **Multi-subscriber fan-out under load** — two subscribers on two
+  separate CPUs both receive every message from a third-CPU publisher;
+  every publish returns `delivered == 2`
+  (`test_msg_router_multi_subscriber`, regression for #864 / #67a).
+- **Priority ordering across mailboxes** — when both a high-priority and
+  a low-priority mailbox are ready at the moment `msg_router_receive`
+  runs its lock-held scan, the high-priority message is returned first;
+  no starvation deadlock under sustained two-publisher load
+  (`test_msg_router_priority_concurrent`, regression for #864 / #67a).
+
+### Single-slot mailbox limitation
+
+The current `Mailbox` struct is a single-slot structure (one set of
+`ready`/`ack`/`data` atomics per subscription). If two `publish_internal`
+calls target the *same* mailbox before the subscriber has acked the first
+message, the second `deliver()` overwrites the first message in place;
+the subscriber then sees only the second message. This case requires
+multiple publishers running concurrently against the same mailbox, which
+the standard ack-wait publish path does not produce — its loop blocks on
+ack between iterations, so a single publisher cannot back-to-back deliver
+to one mailbox. Distinct from the LAST_RECEIVED targeting case (multiple
+mailboxes per component), which is pinned by
+`test_msg_router_ack_targets_last_received` and works correctly.
+
+The single-mailbox overwrite drop is a real limitation of the current
+single-slot design and is tracked for post-capstone follow-up as #869.
+The concurrency-stress tests in `test_integration.c` document the
+boundary explicitly so future maintainers don't mistake a deliberate
+limitation for a regression.
+
+---
+
 ## Future Enhancements
 
 ### Phase 3 (Completed)

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -14,6 +14,10 @@ extern void msg_router_init(void);
 extern int msg_router_subscribe(const char *topic_name, int component_idx);
 extern void msg_router_unsubscribe_all(int component_idx);
 extern int msg_router_publish(const uint8_t *topic_name, const uint8_t *data);
+extern int msg_router_publish_nowait(const uint8_t *topic_name,
+                                     const uint8_t *data);
+extern const uint8_t *msg_router_receive(int component_idx, uint8_t *topic_out);
+extern void msg_router_ack(int component_idx);
 
 /*
  * Regression for GitHub issue #80: msg_router_publish hangs on Pi 5 when
@@ -207,6 +211,106 @@ static void test_subscribe_max_topics_sixteen(void)
     TEST_ASSERT_EQUAL_INT(-1, msg_router_subscribe("t16", 16));
 }
 
+/*
+ * Regression for #863 (#67b): wildcard+exact overlap delivers twice.
+ *
+ * A component subscribed via both an exact topic name and a matching
+ * wildcard pattern receives the message TWICE — once per subscription.
+ * Each subscription owns its own independent mailbox, and publish_internal
+ * fans out across every matching mailbox. This is the per-subscription
+ * delivery contract the project documents in docs/ipc.md and the message
+ * router rs source comments; it matches DDS / ROS 2 / ZeroMQ / nanomsg /
+ * Linux notifier chains. Applications that want exactly-once delivery
+ * across overlapping patterns dedupe at the application layer.
+ *
+ * This test pins the contract via `msg_router_publish_nowait`, which
+ * returns the number of mailboxes the message was dropped into without
+ * ack-wait choreography. Using the no-wait variant lets the test run
+ * single-threaded — the full ack-wait publish path is exercised by the
+ * cross-CPU concurrency tests in test_integration.c. The fan-out count
+ * is the contract being asserted; the ack-wait loop is orthogonal.
+ *
+ * Topic budget reminder: TOPIC_NAME_LEN = 16 (NUL-terminated). The names
+ * below are all ≤ 15 bytes.
+ */
+static void test_wildcard_exact_overlap_delivers_twice(void)
+{
+    msg_router_init();
+
+    /* Subscribe one component to BOTH an exact topic and a matching
+     * wildcard pattern. The wildcard prefix is "/sensors/" so it matches
+     * "/sensors/data" as well. */
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/data", 0));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/*",    0));
+
+    /* Publish to the exact name. Both the exact mailbox and the wildcard
+     * mailbox match — fan-out should be 2. */
+    int delivered = msg_router_publish_nowait(
+        (const uint8_t *)"/sensors/data", (const uint8_t *)"d1");
+    TEST_ASSERT_EQUAL_INT(2, delivered);
+
+    /* Drain both mailboxes via two receive+ack cycles. Each receive
+     * returns one mailbox; receive's lock-held scan picks one (priority
+     * tie-break order between exact + wildcard at equal priority is
+     * unspecified, so we don't assert WHICH mailbox arrives first — only
+     * that two distinct mailboxes yielded the published message). Both
+     * mailboxes carry the PUBLISHED topic name ("/sensors/data"), since
+     * deliver() copies the publisher's name into the mailbox slot. */
+    uint8_t topic_buf[16];
+    const uint8_t *m1 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NOT_NULL(m1);
+    TEST_ASSERT_EQUAL_STRING("/sensors/data", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("d1", (const char *)m1);
+    msg_router_ack(0);
+
+    const uint8_t *m2 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NOT_NULL(m2);
+    TEST_ASSERT_EQUAL_STRING("/sensors/data", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("d1", (const char *)m2);
+    msg_router_ack(0);
+
+    /* After two acks both mailboxes are cleared — a third receive
+     * returns NULL. Confirms there was no third hidden mailbox and that
+     * ack correctly clears the mailbox it targeted via LAST_RECEIVED. */
+    const uint8_t *m3 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NULL(m3);
+
+    msg_router_unsubscribe_all(0);
+}
+
+/*
+ * Regression for #863 (#67b): wildcard-only matches deliver once.
+ *
+ * Companion to the exact+wildcard overlap test above. When a published
+ * topic name matches ONLY the wildcard pattern (not the exact name),
+ * fan-out is 1 — only the wildcard mailbox receives the message.
+ */
+static void test_wildcard_only_delivers_once(void)
+{
+    msg_router_init();
+
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/data", 0));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/*",    0));
+
+    /* /sensors/temp matches only the wildcard, not the exact subscription. */
+    int delivered = msg_router_publish_nowait(
+        (const uint8_t *)"/sensors/temp", (const uint8_t *)"t1");
+    TEST_ASSERT_EQUAL_INT(1, delivered);
+
+    uint8_t topic_buf[16];
+    const uint8_t *m1 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NOT_NULL(m1);
+    TEST_ASSERT_EQUAL_STRING("/sensors/temp", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("t1", (const char *)m1);
+    msg_router_ack(0);
+
+    /* No second mailbox to drain. */
+    const uint8_t *m2 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NULL(m2);
+
+    msg_router_unsubscribe_all(0);
+}
+
 int test_suite_msg_router(void)
 {
     UNITY_BEGIN();
@@ -217,6 +321,8 @@ int test_suite_msg_router(void)
     RUN_TEST(test_subscribe_idempotent_exact);
     RUN_TEST(test_subscribe_idempotent_wildcard);
     RUN_TEST(test_subscribe_max_topics_sixteen);
+    RUN_TEST(test_wildcard_exact_overlap_delivers_twice);
+    RUN_TEST(test_wildcard_only_delivers_once);
     RUN_TEST(test_publish_times_out_without_ack);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Sub-ticket #863 of parent #67. Resolved to **option (a)**: keep current
per-subscription delivery semantics, document them as the contract, and
pin them with a test. **No behavior change in `runtime/src/msg_router.rs`.**

The decision matches the dominant embedded pub/sub convention — DDS, ROS 2,
ZeroMQ, nanomsg, Linux notifier chains all do per-subscriber fan-out;
applications wanting exactly-once delivery dedupe at the application layer.

## Changes

- **Two new tests** in `kernel/tests/test_msg_router.c`:
  - `test_wildcard_exact_overlap_delivers_twice` — subscribes one
    component to `/sensors/data` (exact) AND `/sensors/*` (wildcard),
    publishes to `/sensors/data`, asserts `delivered == 2`, drains both
    mailboxes.
  - `test_wildcard_only_delivers_once` — publishes to `/sensors/temp`
    (wildcard-only match), asserts `delivered == 1`.

  Both use `msg_router_publish_nowait` so they run single-threaded —
  the full ack-wait path's fan-out is already exercised by the
  cross-CPU tests in `test_integration.c`. The contract being pinned
  is the mailbox FAN-OUT count, identical between the two publish
  variants.

- **New "Topic-Based Pub/Sub (Message Router)" section in `docs/ipc.md`**
  captures the per-subscription delivery contract verbatim, lists the
  other guarantees pinned by automated tests, and explicitly notes the
  single-slot mailbox overwrite limitation (tracked as #869) so future
  maintainers don't mistake a deliberate design choice for a regression.

## Base branch

Stacked on top of `ipc-67a-multisub-prio` (#878). Will rebase / re-target
to `main` after #878 merges.

## Test plan

- [x] `make test` — both new tests PASS; full suite green.
- [x] `make kernel PLATFORM=RASPI5` — clean build.
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build.
- [ ] Hardware verification on pi-5-2 / jetson-nano-1 — done in #868.

Refs #67. Closes #863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)