### PR TITLE
msg_router 67c: pin LAST_RECEIVED ack-targeting contract (#867)

### DIFF
--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -416,9 +416,7 @@ the subscriber then sees only the second message. This case requires
 multiple publishers running concurrently against the same mailbox, which
 the standard ack-wait publish path does not produce — its loop blocks on
 ack between iterations, so a single publisher cannot back-to-back deliver
-to one mailbox. Distinct from the LAST_RECEIVED targeting case (multiple
-mailboxes per component), which is pinned by
-`test_msg_router_ack_targets_last_received` and works correctly.
+to one mailbox.
 
 The single-mailbox overwrite drop is a real limitation of the current
 single-slot design and is tracked for post-capstone follow-up as #869.

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -405,6 +405,14 @@ and `test_wildcard_only_delivers_once` pin the contract on every
   runs its lock-held scan, the high-priority message is returned first;
   no starvation deadlock under sustained two-publisher load
   (`test_msg_router_priority_concurrent`, regression for #864 / #67a).
+- **LAST_RECEIVED ack-targeting** — `msg_router_ack` clears exactly the
+  mailbox returned by the most recent `msg_router_receive` call for the
+  component, even when a newer message lands in a different mailbox
+  between the two. Verified single-CPU
+  (`test_msg_router.c::test_msg_router_ack_targets_last_received`) and
+  cross-CPU
+  (`test_integration.c::test_msg_router_ack_targets_last_received_cross_cpu`,
+  cpu_count ≥ 2). Regression for #867 / #67c.
 
 ### Single-slot mailbox limitation
 

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -365,6 +365,69 @@ When space/message becomes available:
 
 ---
 
+## Topic-Based Pub/Sub (Message Router)
+
+The message router (`runtime/src/msg_router.rs`) layers a topic-based
+publish/subscribe surface on top of per-subscription mailboxes. Components
+call `msg_router_subscribe(topic, idx)` to register interest in either an
+exact topic name (`/sensors/data`) or a wildcard pattern ending in `*`
+(`/sensors/*`); publishers call `msg_router_publish(topic, data)` and the
+router fans the message out to every matching subscription.
+
+### Per-subscription delivery contract
+
+Each subscription gets its own independent mailbox. A component subscribed
+to a topic via both an exact name and a matching wildcard pattern receives
+the message **twice** — once per subscription. This matches the
+per-subscriber delivery semantics of DDS, ROS 2, ZeroMQ, nanomsg, and Linux
+notifier chains. The publish return value (`delivered`) is the count of
+mailboxes the message fanned out to, so overlapping patterns increase the
+count. Applications that want exactly-once delivery across overlapping
+subscription patterns are responsible for deduplicating at the application
+layer (typically by tagging messages with a sender-side sequence number).
+
+Regression coverage:
+`kernel/tests/test_msg_router.c::test_wildcard_exact_overlap_delivers_twice`
+and `test_wildcard_only_delivers_once` pin the contract on every
+`make test` run.
+
+### Other guarantees pinned by automated tests
+
+- **Cross-CPU publish/receive/ack** — a publisher and subscriber on
+  different CPUs round-trip N messages without router-internal deadlock
+  (`test_integration.c::test_msg_router_cross_cpu`, regression for #66).
+- **Multi-subscriber fan-out under load** — two subscribers on two
+  separate CPUs both receive every message from a third-CPU publisher;
+  every publish returns `delivered == 2`
+  (`test_msg_router_multi_subscriber`, regression for #864 / #67a).
+- **Priority ordering across mailboxes** — when both a high-priority and
+  a low-priority mailbox are ready at the moment `msg_router_receive`
+  runs its lock-held scan, the high-priority message is returned first;
+  no starvation deadlock under sustained two-publisher load
+  (`test_msg_router_priority_concurrent`, regression for #864 / #67a).
+
+### Single-slot mailbox limitation
+
+The current `Mailbox` struct is a single-slot structure (one set of
+`ready`/`ack`/`data` atomics per subscription). If two `publish_internal`
+calls target the *same* mailbox before the subscriber has acked the first
+message, the second `deliver()` overwrites the first message in place;
+the subscriber then sees only the second message. This case requires
+multiple publishers running concurrently against the same mailbox, which
+the standard ack-wait publish path does not produce — its loop blocks on
+ack between iterations, so a single publisher cannot back-to-back deliver
+to one mailbox. Distinct from the LAST_RECEIVED targeting case (multiple
+mailboxes per component), which is pinned by
+`test_msg_router_ack_targets_last_received` and works correctly.
+
+The single-mailbox overwrite drop is a real limitation of the current
+single-slot design and is tracked for post-capstone follow-up as #869.
+The concurrency-stress tests in `test_integration.c` document the
+boundary explicitly so future maintainers don't mistake a deliberate
+limitation for a regression.
+
+---
+
 ## Future Enhancements
 
 ### Phase 3 (Completed)

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -78,8 +78,11 @@ static struct {
  * per-core L2. Cacheable BSS variables written by one CPU are invisible to
  * others. NC memory bypasses L1/L2 entirely — writes are instantly visible.
  *
- * 32 uint32_t slots at NC_MEM_SIZE - 768 (below bench stealing region at -512).
- * Each test zeroes its slots before use; tasks write, CPU 0 polls.
+ * NC_SYNC region runs from NC_MEM_SIZE - 768 up to INTEG_NC_DONE at
+ * NC_MEM_SIZE - 384, so 384 bytes / 4 = 96 uint32_t slots are available
+ * (slot 0..95). Slots 0..30 are currently in use (high-water mark below;
+ * update when adding new slot families). Each test zeroes its slots
+ * before use; tasks write, CPU 0 polls.
  */
 #if defined(PLATFORM_HAS_NC_MEMORY)
 #define NC_SYNC_BASE    (NC_MEM_BASE + NC_MEM_SIZE - 768)
@@ -1234,6 +1237,8 @@ static void test_work_stealing_distributes_load(void)
 extern void msg_router_init(void);
 extern int msg_router_subscribe(const uint8_t *topic_name, int component_idx);
 extern int msg_router_publish(const uint8_t *topic_name, const uint8_t *data);
+extern int msg_router_publish_priority(const uint8_t *topic_name,
+                                       const uint8_t *data, uint8_t priority);
 extern const uint8_t *msg_router_receive(int component_idx, uint8_t *topic_out);
 extern void msg_router_ack(int component_idx);
 extern void msg_router_unsubscribe_all(int component_idx);
@@ -1465,9 +1470,6 @@ static void ms_publisher(void *arg)
         int delivered = msg_router_publish(MS_TOPIC, payload);
         if (delivered > 0) {
             total += (uint32_t)delivered;
-#if defined(PLATFORM_HAS_NC_MEMORY)
-            NC_SYNC(NC_MSGMS_DELIVERED) = total;
-#endif
         }
     }
     ms_delivered_total = total;
@@ -1607,9 +1609,6 @@ static void test_msg_router_multi_subscriber(void)
  * acked (no starvation deadlock), subscriber receives exactly N hi + N lo,
  * total receive count matches.
  * ============================================================================ */
-
-extern int msg_router_publish_priority(const uint8_t *topic_name,
-                                       const uint8_t *data, uint8_t priority);
 
 #define PR_C_COMPONENT 22
 #define PR_MESSAGES    3

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -117,6 +117,9 @@ static struct {
 #define NC_MSGPR_SUB_DONE    28
 #define NC_MSGPR_HI_DELIVERED 29
 #define NC_MSGPR_LO_DELIVERED 30
+/* msg_router #67c: cross-CPU LAST_RECEIVED ack-targeting test. */
+#define NC_MSGAR_TRIGGER     31  /* main → helper: publish /b now */
+#define NC_MSGAR_HELPER_DONE 32  /* helper → main: publish complete */
 
 static void nc_sync_clear(uint32_t start, uint32_t count)
 {
@@ -1808,6 +1811,164 @@ static void test_msg_router_priority_concurrent(void)
 }
 
 /* ============================================================================
+ * Regression: msg_router LAST_RECEIVED ack-targeting under cross-CPU
+ * activity (#67c / #867)
+ *
+ * Cross-CPU variant of test_msg_router_ack_targets_last_received in
+ * test_msg_router.c. The test thread runs on the shell's CPU (CPU 0);
+ * a helper task pinned to CPU 1 publishes /ar/b after a barrier so
+ * the publish lands AFTER the test's receive() but BEFORE its ack().
+ *
+ * Sequence (with cross-CPU helper):
+ *   T0: test (CPU 0): subscribe /ar/a + /ar/b
+ *   T0: test (CPU 0): publish_nowait /ar/a (prio 5) — MA.ready=1
+ *   T0: test (CPU 0): receive — returns /ar/a, sets LAST_RECEIVED[C]
+ *   T0: test (CPU 0): NC_SYNC(TRIGGER) = 1 (signal helper)
+ *   T1: helper (CPU 1): wakes, publish_nowait /ar/b (prio 5) — MB.ready=1
+ *   T1: helper (CPU 1): NC_SYNC(HELPER_DONE) = 1
+ *   T0: test (CPU 0): spin on HELPER_DONE
+ *   T0: test (CPU 0): ack() — clears MA, NOT MB
+ *   T0: test (CPU 0): receive — returns /ar/b
+ *   T0: test (CPU 0): ack(), receive → NULL
+ *
+ * Demonstrates the ack-targeting contract under genuinely concurrent
+ * activity: the publishing CPU is serializing through MSG_ROUTER_LOCK
+ * (SpinGuard) alongside the receive/ack calls. Because publish_internal
+ * (and publish_internal_nowait) releases the lock between gather and
+ * the BSS-static ready/ack atomics, ack() can interleave with helper's
+ * publish without deadlock.
+ *
+ * Requires cpu_count >= 2 (shell + helper). The receive/ack work runs
+ * on the same CPU as the shell, so we don't need a third CPU.
+ * ============================================================================ */
+
+#define AR_COMPONENT 23
+#define AR_TOPIC_A   ((const uint8_t *)"/ar/a")
+#define AR_TOPIC_B   ((const uint8_t *)"/ar/b")
+
+extern int msg_router_publish_nowait(const uint8_t *topic_name,
+                                     const uint8_t *data);
+
+static volatile uint32_t ar_trigger;
+static volatile uint32_t ar_helper_done;
+
+static void ar_helper(void *arg)
+{
+    (void)arg;
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 5;
+    while ((timer_get_count() - start) < limit) {
+#if defined(PLATFORM_HAS_NC_MEMORY)
+        if (NC_SYNC(NC_MSGAR_TRIGGER)) break;
+#else
+        cache_invalidate((void *)&ar_trigger);
+        if (ar_trigger) break;
+#endif
+        yield();
+    }
+
+    /* Helper publishes /ar/b at the same priority as the earlier /ar/a
+     * publish. The equal-priority tie-break in receive picks /ar/a
+     * first (subscribed earlier → lower TOPICS[] index), so after ack
+     * clears /ar/a the next receive picks /ar/b. */
+    (void)msg_router_publish_nowait(AR_TOPIC_B, (const uint8_t *)"B1");
+
+    ar_helper_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGAR_HELPER_DONE) = 1;
+#else
+    cache_clean((void *)&ar_helper_done);
+#endif
+}
+
+static void test_msg_router_ack_targets_last_received_cross_cpu(void)
+{
+    /* shell on 0, helper on 1 */
+    if (cpu_count < 2) {
+        TEST_IGNORE_MESSAGE("Requires cpu_count >= 2");
+        return;
+    }
+
+    msg_router_init();
+    ar_trigger = 0;
+    ar_helper_done = 0;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    nc_sync_clear(NC_MSGAR_TRIGGER, 2);
+#else
+    cache_clean((void *)&ar_trigger);
+    cache_clean((void *)&ar_helper_done);
+#endif
+
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(AR_TOPIC_A, AR_COMPONENT));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(AR_TOPIC_B, AR_COMPONENT));
+
+    /* Spawn helper that will publish /ar/b on CPU 1 when triggered. */
+    struct task *helper = task_create("ar_helper", ar_helper, NULL);
+    TEST_ASSERT_NOT_NULL(helper);
+    scheduler_add_task_to_cpu(helper, 1);
+
+    /* Step 1: publish /ar/a on the test thread (CPU 0). MA.ready=1.
+     * publish_nowait is used so the test thread can continue to
+     * receive/ack itself — the contract being tested is ack-target
+     * routing across CPUs, not the ack-wait loop. */
+    int d_a = msg_router_publish_nowait(AR_TOPIC_A, (const uint8_t *)"A1");
+    TEST_ASSERT_EQUAL_INT(1, d_a);
+
+    /* Step 2: receive returns /ar/a; LAST_RECEIVED[AR_COMPONENT] := MA. */
+    uint8_t topic_buf[16];
+    const uint8_t *m1 = msg_router_receive(AR_COMPONENT, topic_buf);
+    TEST_ASSERT_NOT_NULL(m1);
+    TEST_ASSERT_EQUAL_STRING("/ar/a", (const char *)topic_buf);
+
+    /* Step 3: trigger helper to publish /ar/b from CPU 1, and wait for
+     * confirmation that the publish has landed. After HELPER_DONE we
+     * know MB.ready=1. */
+    ar_trigger = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGAR_TRIGGER) = 1;
+#else
+    cache_clean((void *)&ar_trigger);
+#endif
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 5;
+    while ((timer_get_count() - start) < limit) {
+#if defined(PLATFORM_HAS_NC_MEMORY)
+        if (NC_SYNC(NC_MSGAR_HELPER_DONE)) break;
+#else
+        cache_invalidate((void *)&ar_helper_done);
+        if (ar_helper_done) break;
+#endif
+        yield();
+    }
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGAR_HELPER_DONE),
+        "helper task did not complete /ar/b publish within timeout");
+#else
+    cache_invalidate((void *)&ar_helper_done);
+    TEST_ASSERT_MESSAGE(ar_helper_done,
+        "helper task did not complete /ar/b publish within timeout");
+#endif
+
+    /* Step 4: ack — targets MA (the receive's source), NOT MB. */
+    msg_router_ack(AR_COMPONENT);
+
+    /* Step 5: receive must return /ar/b. If ack had wrongly cleared MB,
+     * receive's lock-held scan would still pick /ar/a (subscribed
+     * earlier, equal priority). */
+    const uint8_t *m2 = msg_router_receive(AR_COMPONENT, topic_buf);
+    TEST_ASSERT_NOT_NULL(m2);
+    TEST_ASSERT_EQUAL_STRING("/ar/b", (const char *)topic_buf);
+
+    msg_router_ack(AR_COMPONENT);
+
+    /* Both mailboxes drained. */
+    const uint8_t *m3 = msg_router_receive(AR_COMPONENT, topic_buf);
+    TEST_ASSERT_NULL(m3);
+
+    msg_router_unsubscribe_all(AR_COMPONENT);
+}
+
+/* ============================================================================
  * smp_notify_cpu (Prereq #3) — direct functional tests
  *
  * `scheduler_add_task_to_cpu()` invokes `smp_notify_cpu(cpu)` after
@@ -1967,6 +2128,9 @@ int test_suite_integration(void)
     /* Regression: msg_router concurrency stress (#67a / #864) */
     RUN_TEST(test_msg_router_multi_subscriber);
     RUN_TEST(test_msg_router_priority_concurrent);
+
+    /* Regression: msg_router LAST_RECEIVED ack-targeting (#67c / #867) */
+    RUN_TEST(test_msg_router_ack_targets_last_received_cross_cpu);
 
     /* Prereq #3: smp_notify_cpu abstraction */
     RUN_TEST(test_smp_notify_cpu_safe);

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -100,6 +100,20 @@ static struct {
 #define NC_NOTIFY_SENTINEL   11
 #define NC_STEAL_DONE        12
 #define NC_STEAL_CPU_BASE    13  /* 13-17: steal_cpu_recorded[0-4] */
+/* msg_router #67a: multi-subscriber + priority ordering stress tests. */
+#define NC_MSGMS_A_RECEIVED  18
+#define NC_MSGMS_B_RECEIVED  19
+#define NC_MSGMS_PUB_DONE    20
+#define NC_MSGMS_SUB_A_DONE  21
+#define NC_MSGMS_SUB_B_DONE  22
+#define NC_MSGMS_DELIVERED   23  /* sum of every publish's delivered count */
+#define NC_MSGPR_HI_RECEIVED 24
+#define NC_MSGPR_LO_RECEIVED 25
+#define NC_MSGPR_PUB_HI_DONE 26
+#define NC_MSGPR_PUB_LO_DONE 27
+#define NC_MSGPR_SUB_DONE    28
+#define NC_MSGPR_HI_DELIVERED 29
+#define NC_MSGPR_LO_DELIVERED 30
 
 static void nc_sync_clear(uint32_t start, uint32_t count)
 {
@@ -1355,6 +1369,446 @@ static void test_msg_router_cross_cpu(void)
 }
 
 /* ============================================================================
+ * Regression: msg_router multi-subscriber concurrent delivery (#67a / #864)
+ *
+ * Two components (MS_A, MS_B) subscribe to the same topic. A publisher on
+ * CPU 1 emits N messages. MS_A's receive/ack loop runs on CPU 2; MS_B's on
+ * CPU 3. Assertion: both subscribers see all N messages, every publish
+ * returns delivered == 2, no task deadlocks.
+ *
+ * Why this is interesting: publish_internal serializes per-target ack waits
+ * (gather targets under lock, then deliver + wait-ack per target before
+ * moving to the next). Two subscribers on two CPUs exercise that loop with
+ * genuinely concurrent ack arrivals — the lock-release-before-yield
+ * discipline in runtime/src/msg_router.rs is what prevents the ack-side
+ * (msg_router_ack, which re-takes MSG_ROUTER_LOCK) from deadlocking the
+ * publisher.
+ *
+ * Pattern follows test_msg_router_cross_cpu: NC-sync slots for cross-CPU
+ * counters, CNTPCT-based wall-clock timeout, TEST_IGNORE on cpu_count < 4
+ * (shell + pub + 2 subs).
+ * ============================================================================ */
+
+#define MS_A_COMPONENT 20
+#define MS_B_COMPONENT 21
+#define MS_MESSAGES    5
+#define MS_TOPIC       ((const uint8_t *)"/ms/x")
+
+static volatile uint32_t ms_a_received = 0;
+static volatile uint32_t ms_b_received = 0;
+static volatile uint32_t ms_pub_done = 0;
+static volatile uint32_t ms_sub_a_done = 0;
+static volatile uint32_t ms_sub_b_done = 0;
+static volatile uint32_t ms_delivered_total = 0;
+
+static void ms_subscriber(void *arg)
+{
+    uintptr_t which = (uintptr_t)arg;  /* 0 = A, 1 = B */
+    int component = (which == 0) ? MS_A_COMPONENT : MS_B_COMPONENT;
+    uint8_t topic_buf[16];
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 10;
+    uint32_t count = 0;
+
+    while (count < MS_MESSAGES) {
+        if ((timer_get_count() - start) >= limit) break;
+        const uint8_t *data = msg_router_receive(component, topic_buf);
+        if (data) {
+            count++;
+            if (which == 0) {
+                ms_a_received = count;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+                NC_SYNC(NC_MSGMS_A_RECEIVED) = count;
+#else
+                cache_clean((void *)&ms_a_received);
+#endif
+            } else {
+                ms_b_received = count;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+                NC_SYNC(NC_MSGMS_B_RECEIVED) = count;
+#else
+                cache_clean((void *)&ms_b_received);
+#endif
+            }
+            msg_router_ack(component);
+        } else {
+            yield();
+        }
+    }
+
+    if (which == 0) {
+        ms_sub_a_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+        NC_SYNC(NC_MSGMS_SUB_A_DONE) = 1;
+#else
+        cache_clean((void *)&ms_sub_a_done);
+#endif
+    } else {
+        ms_sub_b_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+        NC_SYNC(NC_MSGMS_SUB_B_DONE) = 1;
+#else
+        cache_clean((void *)&ms_sub_b_done);
+#endif
+    }
+}
+
+static void ms_publisher(void *arg)
+{
+    (void)arg;
+    /* Small delay so both subscribers are scheduled and ready to drain. */
+    delay(50000);
+
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < MS_MESSAGES; i++) {
+        uint8_t payload[4] = { (uint8_t)('a' + i), 0, 0, 0 };
+        int delivered = msg_router_publish(MS_TOPIC, payload);
+        if (delivered > 0) {
+            total += (uint32_t)delivered;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+            NC_SYNC(NC_MSGMS_DELIVERED) = total;
+#endif
+        }
+    }
+    ms_delivered_total = total;
+    ms_pub_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGMS_DELIVERED) = total;
+    NC_SYNC(NC_MSGMS_PUB_DONE) = 1;
+#else
+    cache_clean((void *)&ms_delivered_total);
+    cache_clean((void *)&ms_pub_done);
+#endif
+}
+
+static void test_msg_router_multi_subscriber(void)
+{
+    /* shell on 0, pub on 1, sub_a on 2, sub_b on 3 */
+    if (cpu_count < 4) {
+        TEST_IGNORE_MESSAGE("Requires cpu_count >= 4");
+        return;
+    }
+
+    msg_router_init();
+    ms_a_received = 0;
+    ms_b_received = 0;
+    ms_pub_done = 0;
+    ms_sub_a_done = 0;
+    ms_sub_b_done = 0;
+    ms_delivered_total = 0;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    nc_sync_clear(NC_MSGMS_A_RECEIVED, 6);
+#else
+    cache_clean((void *)&ms_a_received);
+    cache_clean((void *)&ms_b_received);
+    cache_clean((void *)&ms_pub_done);
+    cache_clean((void *)&ms_sub_a_done);
+    cache_clean((void *)&ms_sub_b_done);
+    cache_clean((void *)&ms_delivered_total);
+#endif
+
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(MS_TOPIC, MS_A_COMPONENT));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(MS_TOPIC, MS_B_COMPONENT));
+
+    struct task *sub_a = task_create("ms_sub_a", ms_subscriber, (void *)0);
+    struct task *sub_b = task_create("ms_sub_b", ms_subscriber, (void *)1);
+    struct task *pub = task_create("ms_pub", ms_publisher, NULL);
+    TEST_ASSERT_NOT_NULL(sub_a);
+    TEST_ASSERT_NOT_NULL(sub_b);
+    TEST_ASSERT_NOT_NULL(pub);
+
+    scheduler_add_task_to_cpu(sub_a, 2);
+    scheduler_add_task_to_cpu(sub_b, 3);
+    scheduler_add_task_to_cpu(pub, 1);
+
+    /*
+     * Generous timeout: Pi 5 ships cooperative preempt by default so
+     * ack-wait yield-loops pace at the scheduler tick rate (10 ms).
+     * 5 messages × 2 subscribers × per-ack handoff costs ~hundreds of
+     * milliseconds in the worst case; 15 s leaves abundant headroom.
+     */
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 15;
+    while ((timer_get_count() - start) < limit) {
+#if defined(PLATFORM_HAS_NC_MEMORY)
+        if (NC_SYNC(NC_MSGMS_PUB_DONE) &&
+            NC_SYNC(NC_MSGMS_SUB_A_DONE) &&
+            NC_SYNC(NC_MSGMS_SUB_B_DONE)) break;
+#else
+        cache_invalidate((void *)&ms_pub_done);
+        cache_invalidate((void *)&ms_sub_a_done);
+        cache_invalidate((void *)&ms_sub_b_done);
+        if (ms_pub_done && ms_sub_a_done && ms_sub_b_done) break;
+#endif
+        yield();
+    }
+
+    msg_router_unsubscribe_all(MS_A_COMPONENT);
+    msg_router_unsubscribe_all(MS_B_COMPONENT);
+
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGMS_PUB_DONE),
+        "publisher did not finish all publishes");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGMS_SUB_A_DONE),
+        "subscriber A did not finish");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGMS_SUB_B_DONE),
+        "subscriber B did not finish");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGMS_A_RECEIVED) == MS_MESSAGES,
+        "subscriber A did not receive all messages");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGMS_B_RECEIVED) == MS_MESSAGES,
+        "subscriber B did not receive all messages");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGMS_DELIVERED) == MS_MESSAGES * 2u,
+        "publisher: not every message reached both subscribers (delivered != 2*N)");
+#else
+    cache_invalidate((void *)&ms_a_received);
+    cache_invalidate((void *)&ms_b_received);
+    cache_invalidate((void *)&ms_pub_done);
+    cache_invalidate((void *)&ms_sub_a_done);
+    cache_invalidate((void *)&ms_sub_b_done);
+    cache_invalidate((void *)&ms_delivered_total);
+    TEST_ASSERT_MESSAGE(ms_pub_done, "publisher did not finish all publishes");
+    TEST_ASSERT_MESSAGE(ms_sub_a_done, "subscriber A did not finish");
+    TEST_ASSERT_MESSAGE(ms_sub_b_done, "subscriber B did not finish");
+    TEST_ASSERT_MESSAGE(ms_a_received == MS_MESSAGES,
+        "subscriber A did not receive all messages");
+    TEST_ASSERT_MESSAGE(ms_b_received == MS_MESSAGES,
+        "subscriber B did not receive all messages");
+    TEST_ASSERT_MESSAGE(ms_delivered_total == MS_MESSAGES * 2u,
+        "publisher: not every message reached both subscribers (delivered != 2*N)");
+#endif
+}
+
+/* ============================================================================
+ * Regression: msg_router priority ordering under concurrent load (#67a / #864)
+ *
+ * Component C subscribes to /pr/lo and /pr/hi. Two publishers run in parallel:
+ *   - pub_lo (CPU 1): publish_priority(/pr/lo, ..., 0)
+ *   - pub_hi (CPU 2): publish_priority(/pr/hi, ..., 5)
+ * C drains on CPU 3.
+ *
+ * What this pins: msg_router_receive's lock-held priority scan
+ * (runtime/src/msg_router.rs:840-917). When both mailboxes are ready,
+ * receive returns /pr/hi first. Each receive call therefore prefers /pr/hi
+ * whenever it's available — /pr/lo only flows through during windows where
+ * pub_hi is between publishes (ack-waiting or briefly between iterations).
+ * Under sustained load every iteration of pub_hi forces this scan to compare
+ * priorities with a ready /pr/lo present.
+ *
+ * Caveat: mailboxes are single-slot. Because each publish_internal call
+ * blocks on ack before returning, this test never has two unacked messages
+ * in the SAME mailbox at once, so the single-slot overwrite issue isn't
+ * exercised here. That case (back-to-back delivery to one mailbox with no
+ * intervening ack) is a real limitation of the current design and is filed
+ * as #869 for post-capstone follow-up — explicitly NOT in scope for this
+ * test. The assertion is about CROSS-MAILBOX priority comparison at receive
+ * time, not within-mailbox queueing.
+ *
+ * Acceptance: both publishers complete all N publishes with every message
+ * acked (no starvation deadlock), subscriber receives exactly N hi + N lo,
+ * total receive count matches.
+ * ============================================================================ */
+
+extern int msg_router_publish_priority(const uint8_t *topic_name,
+                                       const uint8_t *data, uint8_t priority);
+
+#define PR_C_COMPONENT 22
+#define PR_MESSAGES    3
+#define PR_TOPIC_HI    ((const uint8_t *)"/pr/hi")
+#define PR_TOPIC_LO    ((const uint8_t *)"/pr/lo")
+#define PR_PRIO_HI     5
+#define PR_PRIO_LO     0
+
+static volatile uint32_t pr_hi_received = 0;
+static volatile uint32_t pr_lo_received = 0;
+static volatile uint32_t pr_pub_hi_done = 0;
+static volatile uint32_t pr_pub_lo_done = 0;
+static volatile uint32_t pr_sub_done = 0;
+static volatile uint32_t pr_hi_delivered = 0;
+static volatile uint32_t pr_lo_delivered = 0;
+
+static void pr_publisher_hi(void *arg)
+{
+    (void)arg;
+    delay(50000);
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < PR_MESSAGES; i++) {
+        uint8_t payload[4] = { 'H', (uint8_t)('0' + i), 0, 0 };
+        int delivered = msg_router_publish_priority(PR_TOPIC_HI, payload, PR_PRIO_HI);
+        if (delivered > 0) total += (uint32_t)delivered;
+    }
+    pr_hi_delivered = total;
+    pr_pub_hi_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGPR_HI_DELIVERED) = total;
+    NC_SYNC(NC_MSGPR_PUB_HI_DONE) = 1;
+#else
+    cache_clean((void *)&pr_hi_delivered);
+    cache_clean((void *)&pr_pub_hi_done);
+#endif
+}
+
+static void pr_publisher_lo(void *arg)
+{
+    (void)arg;
+    delay(50000);
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < PR_MESSAGES; i++) {
+        uint8_t payload[4] = { 'L', (uint8_t)('0' + i), 0, 0 };
+        int delivered = msg_router_publish_priority(PR_TOPIC_LO, payload, PR_PRIO_LO);
+        if (delivered > 0) total += (uint32_t)delivered;
+    }
+    pr_lo_delivered = total;
+    pr_pub_lo_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGPR_LO_DELIVERED) = total;
+    NC_SYNC(NC_MSGPR_PUB_LO_DONE) = 1;
+#else
+    cache_clean((void *)&pr_lo_delivered);
+    cache_clean((void *)&pr_pub_lo_done);
+#endif
+}
+
+static void pr_subscriber(void *arg)
+{
+    (void)arg;
+    uint8_t topic_buf[16];
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 10;
+    uint32_t hi = 0;
+    uint32_t lo = 0;
+
+    while (hi + lo < PR_MESSAGES * 2u) {
+        if ((timer_get_count() - start) >= limit) break;
+        const uint8_t *data = msg_router_receive(PR_C_COMPONENT, topic_buf);
+        if (data) {
+            /* Distinguish via the payload's first byte rather than re-walking
+             * the topic_buf — both are valid signals; payload is cheaper. */
+            if (data[0] == 'H') {
+                hi++;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+                NC_SYNC(NC_MSGPR_HI_RECEIVED) = hi;
+#endif
+            } else if (data[0] == 'L') {
+                lo++;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+                NC_SYNC(NC_MSGPR_LO_RECEIVED) = lo;
+#endif
+            }
+            pr_hi_received = hi;
+            pr_lo_received = lo;
+#if !defined(PLATFORM_HAS_NC_MEMORY)
+            cache_clean((void *)&pr_hi_received);
+            cache_clean((void *)&pr_lo_received);
+#endif
+            msg_router_ack(PR_C_COMPONENT);
+        } else {
+            yield();
+        }
+    }
+
+    pr_sub_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGPR_SUB_DONE) = 1;
+#else
+    cache_clean((void *)&pr_sub_done);
+#endif
+}
+
+static void test_msg_router_priority_concurrent(void)
+{
+    /* shell on 0, pub_lo on 1, pub_hi on 2, sub on 3 */
+    if (cpu_count < 4) {
+        TEST_IGNORE_MESSAGE("Requires cpu_count >= 4");
+        return;
+    }
+
+    msg_router_init();
+    pr_hi_received = 0;
+    pr_lo_received = 0;
+    pr_pub_hi_done = 0;
+    pr_pub_lo_done = 0;
+    pr_sub_done = 0;
+    pr_hi_delivered = 0;
+    pr_lo_delivered = 0;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    nc_sync_clear(NC_MSGPR_HI_RECEIVED, 7);
+#else
+    cache_clean((void *)&pr_hi_received);
+    cache_clean((void *)&pr_lo_received);
+    cache_clean((void *)&pr_pub_hi_done);
+    cache_clean((void *)&pr_pub_lo_done);
+    cache_clean((void *)&pr_sub_done);
+    cache_clean((void *)&pr_hi_delivered);
+    cache_clean((void *)&pr_lo_delivered);
+#endif
+
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(PR_TOPIC_HI, PR_C_COMPONENT));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(PR_TOPIC_LO, PR_C_COMPONENT));
+
+    struct task *sub = task_create("pr_sub", pr_subscriber, NULL);
+    struct task *pub_lo = task_create("pr_pub_lo", pr_publisher_lo, NULL);
+    struct task *pub_hi = task_create("pr_pub_hi", pr_publisher_hi, NULL);
+    TEST_ASSERT_NOT_NULL(sub);
+    TEST_ASSERT_NOT_NULL(pub_lo);
+    TEST_ASSERT_NOT_NULL(pub_hi);
+
+    scheduler_add_task_to_cpu(pub_lo, 1);
+    scheduler_add_task_to_cpu(pub_hi, 2);
+    scheduler_add_task_to_cpu(sub, 3);
+
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 15;
+    while ((timer_get_count() - start) < limit) {
+#if defined(PLATFORM_HAS_NC_MEMORY)
+        if (NC_SYNC(NC_MSGPR_PUB_HI_DONE) &&
+            NC_SYNC(NC_MSGPR_PUB_LO_DONE) &&
+            NC_SYNC(NC_MSGPR_SUB_DONE)) break;
+#else
+        cache_invalidate((void *)&pr_pub_hi_done);
+        cache_invalidate((void *)&pr_pub_lo_done);
+        cache_invalidate((void *)&pr_sub_done);
+        if (pr_pub_hi_done && pr_pub_lo_done && pr_sub_done) break;
+#endif
+        yield();
+    }
+
+    msg_router_unsubscribe_all(PR_C_COMPONENT);
+
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGPR_PUB_HI_DONE), "hi publisher hung");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGPR_PUB_LO_DONE), "lo publisher hung");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGPR_SUB_DONE), "subscriber hung");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGPR_HI_DELIVERED) == PR_MESSAGES,
+        "hi publisher: not every publish was acked");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGPR_LO_DELIVERED) == PR_MESSAGES,
+        "lo publisher: not every publish was acked (priority starvation?)");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGPR_HI_RECEIVED) == PR_MESSAGES,
+        "subscriber: missed at least one /pr/hi message");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGPR_LO_RECEIVED) == PR_MESSAGES,
+        "subscriber: missed at least one /pr/lo message");
+#else
+    cache_invalidate((void *)&pr_hi_received);
+    cache_invalidate((void *)&pr_lo_received);
+    cache_invalidate((void *)&pr_pub_hi_done);
+    cache_invalidate((void *)&pr_pub_lo_done);
+    cache_invalidate((void *)&pr_sub_done);
+    cache_invalidate((void *)&pr_hi_delivered);
+    cache_invalidate((void *)&pr_lo_delivered);
+    TEST_ASSERT_MESSAGE(pr_pub_hi_done, "hi publisher hung");
+    TEST_ASSERT_MESSAGE(pr_pub_lo_done, "lo publisher hung");
+    TEST_ASSERT_MESSAGE(pr_sub_done, "subscriber hung");
+    TEST_ASSERT_MESSAGE(pr_hi_delivered == PR_MESSAGES,
+        "hi publisher: not every publish was acked");
+    TEST_ASSERT_MESSAGE(pr_lo_delivered == PR_MESSAGES,
+        "lo publisher: not every publish was acked (priority starvation?)");
+    TEST_ASSERT_MESSAGE(pr_hi_received == PR_MESSAGES,
+        "subscriber: missed at least one /pr/hi message");
+    TEST_ASSERT_MESSAGE(pr_lo_received == PR_MESSAGES,
+        "subscriber: missed at least one /pr/lo message");
+#endif
+}
+
+/* ============================================================================
  * smp_notify_cpu (Prereq #3) — direct functional tests
  *
  * `scheduler_add_task_to_cpu()` invokes `smp_notify_cpu(cpu)` after
@@ -1510,6 +1964,10 @@ int test_suite_integration(void)
 
     /* Regression: msg_router cross-CPU publish/receive/ack (#66) */
     RUN_TEST(test_msg_router_cross_cpu);
+
+    /* Regression: msg_router concurrency stress (#67a / #864) */
+    RUN_TEST(test_msg_router_multi_subscriber);
+    RUN_TEST(test_msg_router_priority_concurrent);
 
     /* Prereq #3: smp_notify_cpu abstraction */
     RUN_TEST(test_smp_notify_cpu_safe);

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -311,6 +311,84 @@ static void test_wildcard_only_delivers_once(void)
     msg_router_unsubscribe_all(0);
 }
 
+/*
+ * Regression for #867 (#67c): msg_router_ack targets the mailbox returned
+ * by the most recent msg_router_receive() call, even when a newer message
+ * arrives in a DIFFERENT mailbox between receive() and ack().
+ *
+ * This is the LAST_RECEIVED machinery at runtime/src/msg_router.rs:232 +
+ * the ack-side targeting logic at lines 923-947. Without LAST_RECEIVED,
+ * ack would clear "the highest-priority ready mailbox", which could be a
+ * different mailbox than the one receive just returned — losing a message.
+ *
+ * Sequence:
+ *   1. publish_nowait /a (prio 5) — MA.ready=1
+ *   2. receive() — returns /a, sets LAST_RECEIVED[C] = (idx of /a)
+ *   3. publish_nowait /b (prio 5) — MB.ready=1 (still pre-ack)
+ *   4. ack() — must clear MA (the receive's source), NOT MB
+ *   5. receive() — must return /b (MA is cleared; MB is still ready)
+ *   6. ack() — clears MB
+ *   7. receive() — NULL (both mailboxes drained)
+ *
+ * The critical assertion is step 5: if ack had cleared the wrong mailbox
+ * (MB instead of MA), step 5 would still see MA ready and return /a.
+ *
+ * Scope note: this test covers LAST_RECEIVED targeting across MULTIPLE
+ * mailboxes (one component, two distinct topics). It does NOT cover the
+ * single-mailbox-overwrite-drop case (two messages arrive in the SAME
+ * mailbox before ack — second overwrites first) — that is a real
+ * limitation of the single-slot mailbox design tracked separately as
+ * #869.
+ */
+static void test_msg_router_ack_targets_last_received(void)
+{
+    msg_router_init();
+
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/a", 5));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/b", 5));
+
+    /* Step 1: publish to /a. MA.ready=1. publish_nowait is used so the
+     * test runs single-threaded — the full ack-wait publish path is
+     * exercised by the cross-CPU variant in test_integration.c. */
+    int d_a = msg_router_publish_nowait((const uint8_t *)"/a",
+                                        (const uint8_t *)"A1");
+    TEST_ASSERT_EQUAL_INT(1, d_a);
+
+    /* Step 2: receive returns /a; LAST_RECEIVED[5] := /a's mailbox. */
+    uint8_t topic_buf[16];
+    const uint8_t *m1 = msg_router_receive(5, topic_buf);
+    TEST_ASSERT_NOT_NULL(m1);
+    TEST_ASSERT_EQUAL_STRING("/a", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("A1", (const char *)m1);
+
+    /* Step 3: publish to /b BEFORE acking /a. MB.ready=1. */
+    int d_b = msg_router_publish_nowait((const uint8_t *)"/b",
+                                        (const uint8_t *)"B1");
+    TEST_ASSERT_EQUAL_INT(1, d_b);
+
+    /* Step 4: ack. LAST_RECEIVED says /a, so MA is cleared and MB is
+     * untouched. There's no public read of MA.ready / MB.ready, so we
+     * verify the outcome via the next receive: if step 5 returns /b,
+     * then MA was cleared (otherwise the equal-priority scan would
+     * pick MA first because TOPICS[0]=/a was subscribed earlier). */
+    msg_router_ack(5);
+
+    /* Step 5: receive returns /b — the still-ready mailbox. THIS is
+     * the load-bearing assertion. If ack had wrongly cleared MB,
+     * we'd see /a returned again here. */
+    const uint8_t *m2 = msg_router_receive(5, topic_buf);
+    TEST_ASSERT_NOT_NULL(m2);
+    TEST_ASSERT_EQUAL_STRING("/b", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("B1", (const char *)m2);
+
+    /* Step 6: ack /b. Step 7: receive returns NULL. */
+    msg_router_ack(5);
+    const uint8_t *m3 = msg_router_receive(5, topic_buf);
+    TEST_ASSERT_NULL(m3);
+
+    msg_router_unsubscribe_all(5);
+}
+
 int test_suite_msg_router(void)
 {
     UNITY_BEGIN();
@@ -323,6 +401,7 @@ int test_suite_msg_router(void)
     RUN_TEST(test_subscribe_max_topics_sixteen);
     RUN_TEST(test_wildcard_exact_overlap_delivers_twice);
     RUN_TEST(test_wildcard_only_delivers_once);
+    RUN_TEST(test_msg_router_ack_targets_last_received);
     RUN_TEST(test_publish_times_out_without_ack);
     return UNITY_END();
 }

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -14,6 +14,10 @@ extern void msg_router_init(void);
 extern int msg_router_subscribe(const char *topic_name, int component_idx);
 extern void msg_router_unsubscribe_all(int component_idx);
 extern int msg_router_publish(const uint8_t *topic_name, const uint8_t *data);
+extern int msg_router_publish_nowait(const uint8_t *topic_name,
+                                     const uint8_t *data);
+extern const uint8_t *msg_router_receive(int component_idx, uint8_t *topic_out);
+extern void msg_router_ack(int component_idx);
 
 /*
  * Regression for GitHub issue #80: msg_router_publish hangs on Pi 5 when
@@ -207,6 +211,106 @@ static void test_subscribe_max_topics_sixteen(void)
     TEST_ASSERT_EQUAL_INT(-1, msg_router_subscribe("t16", 16));
 }
 
+/*
+ * Regression for #863 (#67b): wildcard+exact overlap delivers twice.
+ *
+ * A component subscribed via both an exact topic name and a matching
+ * wildcard pattern receives the message TWICE — once per subscription.
+ * Each subscription owns its own independent mailbox, and publish_internal
+ * fans out across every matching mailbox. This is the per-subscription
+ * delivery contract the project documents in docs/ipc.md and the message
+ * router rs source comments; it matches DDS / ROS 2 / ZeroMQ / nanomsg /
+ * Linux notifier chains. Applications that want exactly-once delivery
+ * across overlapping patterns dedupe at the application layer.
+ *
+ * This test pins the contract via `msg_router_publish_nowait`, which
+ * returns the number of mailboxes the message was dropped into without
+ * ack-wait choreography. Using the no-wait variant lets the test run
+ * single-threaded — the full ack-wait publish path is exercised by the
+ * cross-CPU concurrency tests in test_integration.c. The fan-out count
+ * is the contract being asserted; the ack-wait loop is orthogonal.
+ *
+ * Topic budget reminder: TOPIC_NAME_LEN = 16 (NUL-terminated). The names
+ * below are all ≤ 15 bytes.
+ */
+static void test_wildcard_exact_overlap_delivers_twice(void)
+{
+    msg_router_init();
+
+    /* Subscribe one component to BOTH an exact topic and a matching
+     * wildcard pattern. The wildcard prefix is "/sensors/" so it matches
+     * "/sensors/data" as well. */
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/data", 0));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/*",    0));
+
+    /* Publish to the exact name. Both the exact mailbox and the wildcard
+     * mailbox match — fan-out should be 2. */
+    int delivered = msg_router_publish_nowait(
+        (const uint8_t *)"/sensors/data", (const uint8_t *)"d1");
+    TEST_ASSERT_EQUAL_INT(2, delivered);
+
+    /* Drain both mailboxes via two receive+ack cycles. Each receive
+     * returns one mailbox; receive's lock-held scan picks one (priority
+     * tie-break order between exact + wildcard at equal priority is
+     * unspecified, so we don't assert WHICH mailbox arrives first — only
+     * that two distinct mailboxes yielded the published message). Both
+     * mailboxes carry the PUBLISHED topic name ("/sensors/data"), since
+     * deliver() copies the publisher's name into the mailbox slot. */
+    uint8_t topic_buf[16];
+    const uint8_t *m1 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NOT_NULL(m1);
+    TEST_ASSERT_EQUAL_STRING("/sensors/data", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("d1", (const char *)m1);
+    msg_router_ack(0);
+
+    const uint8_t *m2 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NOT_NULL(m2);
+    TEST_ASSERT_EQUAL_STRING("/sensors/data", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("d1", (const char *)m2);
+    msg_router_ack(0);
+
+    /* After two acks both mailboxes are cleared — a third receive
+     * returns NULL. Confirms there was no third hidden mailbox and that
+     * ack correctly clears the mailbox it targeted via LAST_RECEIVED. */
+    const uint8_t *m3 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NULL(m3);
+
+    msg_router_unsubscribe_all(0);
+}
+
+/*
+ * Regression for #863 (#67b): wildcard-only matches deliver once.
+ *
+ * Companion to the exact+wildcard overlap test above. When a published
+ * topic name matches ONLY the wildcard pattern (not the exact name),
+ * fan-out is 1 — only the wildcard mailbox receives the message.
+ */
+static void test_wildcard_only_delivers_once(void)
+{
+    msg_router_init();
+
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/data", 0));
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/sensors/*",    0));
+
+    /* /sensors/temp matches only the wildcard, not the exact subscription. */
+    int delivered = msg_router_publish_nowait(
+        (const uint8_t *)"/sensors/temp", (const uint8_t *)"t1");
+    TEST_ASSERT_EQUAL_INT(1, delivered);
+
+    uint8_t topic_buf[16];
+    const uint8_t *m1 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NOT_NULL(m1);
+    TEST_ASSERT_EQUAL_STRING("/sensors/temp", (const char *)topic_buf);
+    TEST_ASSERT_EQUAL_STRING("t1", (const char *)m1);
+    msg_router_ack(0);
+
+    /* No second mailbox to drain. */
+    const uint8_t *m2 = msg_router_receive(0, topic_buf);
+    TEST_ASSERT_NULL(m2);
+
+    msg_router_unsubscribe_all(0);
+}
+
 int test_suite_msg_router(void)
 {
     UNITY_BEGIN();
@@ -217,6 +321,8 @@ int test_suite_msg_router(void)
     RUN_TEST(test_subscribe_idempotent_exact);
     RUN_TEST(test_subscribe_idempotent_wildcard);
     RUN_TEST(test_subscribe_max_topics_sixteen);
+    RUN_TEST(test_wildcard_exact_overlap_delivers_twice);
+    RUN_TEST(test_wildcard_only_delivers_once);
     RUN_TEST(test_publish_times_out_without_ack);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Sub-ticket #867 of parent #67. Two new tests pin the contract that
`msg_router_ack` clears exactly the mailbox returned by the most recent
`msg_router_receive` for that component, even when a newer message lands
in a different mailbox between the two calls. **No behavior change in
`runtime/src/msg_router.rs`** — the LAST_RECEIVED machinery already
works; these tests just pin it against future regressions.

## Changes

- `test_msg_router_ack_targets_last_received` (`test_msg_router.c`) —
  single-task sequence. Publishes /a, receives, publishes /b before
  acking, acks, then re-receives. Must return /b (proves ack cleared
  /a, not /b).
- `test_msg_router_ack_targets_last_received_cross_cpu`
  (`test_integration.c`) — cross-CPU variant. Helper task on CPU 1
  publishes /ar/b on a trigger barrier so the publish interleaves
  between the test thread's receive and ack. Requires `cpu_count >= 2`;
  cleanly `TEST_IGNORE`s otherwise.

Both tests use `msg_router_publish_nowait` so they run without a
concurrent acker task. The contract being pinned is *which* mailbox
ack clears, not the ack-wait loop (already covered by #67a tests).

## Out of scope

- Single-mailbox-overwrite-drop (#869): explicitly documented in both
  test docstrings.
- Pi 5 + Jetson hardware verification → #868 (67d).

## Base branch

Stacked on `ipc-67b-wildcard-overlap` (#888). Will rebase / re-target
after the dependency PRs merge.

## Test plan

- [x] `make test` — both new tests PASS; full suite green.
- [x] `make kernel PLATFORM=RASPI5` — clean build.
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build.
- [ ] Hardware verification on pi-5-2 / jetson-nano-1 — done in #868.

Refs #67. Closes #867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)