### PR TITLE
ai-runtime: PMU columns in per-op profile harness (#871)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -333,6 +333,55 @@ Total dispatched-op time per inference (`Σ avg × calls / iters`): ~2,985 µs, 
 
 The Jetson hardware baseline will be captured during PR 2 deployment once the slmos-kexec deploy path is in this agent's reach.
 
+### Per-operator Profile with PMU columns (#60 / #871)
+
+`model profile show` is extended in #871 with three PMU-derived columns
+appended to the latency columns above:
+
+- **L1D%** — L1 data cache miss rate over the bucket: `cache_misses /
+  cache_references × 100`. Useful for telling memory-bound ops apart
+  from compute-bound ones.
+- **IPC** — instructions retired per cycle: `instructions_retired /
+  cycles`. The compute-density indicator.
+- **mispred%** — branch mispredictions per 100 retired instructions:
+  `branch_mispredictions / instructions_retired × 100`. Surfaces
+  control-flow-heavy ops.
+
+PMU columns are blank (`-`) on QEMU TCG (event counters not modelled)
+and on platforms where the PMU has not been enabled on the calling
+CPU.
+
+#### Before/after-#56 micro-kernel — pi-5-2
+
+The headline question this section answers: **did the #56 NEON-tiled
+matmul micro-kernel reduce cache misses (memory-bound improvement),
+increase IPC (compute-bound improvement), or both?**
+
+| Build | Conv avg | Conv L1D% | Conv IPC | mispred% | Total/inf |
+|-------|---------:|----------:|---------:|---------:|----------:|
+| pre-#56 (baseline) | 1,433 µs | TBD | TBD | TBD | 3,011 µs |
+| post-#56 (micro-kernel) | TBD | TBD | TBD | TBD | TBD |
+
+Pi 5 hardware capture is gated on board availability — pi-5-2 is
+shared across the #55 / #56 / #58 / #67 workstreams. The PMU columns
+will be filled in alongside the standard latency capture on the next
+free window.
+
+**Interpretation note (to be written once data is captured):** the
+PMU columns will tell us whether Conv2D's memory-bound or compute-
+bound bottleneck moved more under #56. Honest framing: if the data
+shows neither IPC nor cache-miss rate improved meaningfully, the
+latency win came from somewhere else (less work done — for example
+loop-tiling reducing redundant loads) and that's still useful to
+know.
+
+#### Jetson (if #875 verifies)
+
+If `pmu probe` on jetson-nano-1 returns "PMU is fully live," a
+parallel Jetson row will be added below pi-5-2's. If access traps to
+EL3 under stock NVIDIA BL31, the row stays blank and the TF-A patch
+follow-up tracks the unlock work separately.
+
 ### Model Memory Utilization
 
 | Model | Weight Blocks | Workspace Blocks | Actual Weights |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -351,36 +351,72 @@ PMU columns are blank (`-`) on QEMU TCG (event counters not modelled)
 and on platforms where the PMU has not been enabled on the calling
 CPU.
 
-#### Before/after-#56 micro-kernel — pi-5-2
+#### Captured PMU profile — pi-5-2 + jetson-nano-1 (2026-05-15)
 
-The headline question this section answers: **did the #56 NEON-tiled
-matmul micro-kernel reduce cache misses (memory-bound improvement),
-increase IPC (compute-bound improvement), or both?**
+Captured via `model profile on; model bench mnist {200|100}; model profile show`
+after the kernel boots and PMU init completes on every CPU. The
+per-op latency columns mirror the pre-#871 table above; the new
+columns are L1D miss-rate %, IPC (instructions retired per cycle),
+and branch mispredictions per 100 retired instructions.
 
-| Build | Conv avg | Conv L1D% | Conv IPC | mispred% | Total/inf |
-|-------|---------:|----------:|---------:|---------:|----------:|
-| pre-#56 (baseline) | 1,433 µs | TBD | TBD | TBD | 3,011 µs |
-| post-#56 (micro-kernel) | TBD | TBD | TBD | TBD | TBD |
+##### Pi 5 (Cortex-A76, BCM2712 @ ~2.4 GHz, AI_SCHED=ON, 200 iter)
 
-Pi 5 hardware capture is gated on board availability — pi-5-2 is
-shared across the #55 / #56 / #58 / #67 workstreams. The PMU columns
-will be filled in alongside the standard latency capture on the next
-free window.
+| Op | Calls | Avg µs | Min µs | Max µs | L1D% | IPC | Mispred% |
+|----|------:|-------:|-------:|-------:|-----:|----:|---------:|
+| Conv | 400 | 1,431 | 1,046 | 1,816 | <1 | **2.46** | <1 |
+| MatMul | 200 | 23 | 22 | 24 | <1 | 2.43 | <1 |
+| Relu | 400 | 19 | 7 | 31 | <1 | 2.12 | <1 |
+| MaxPool | 400 | 15 | 6 | 24 | <1 | 2.75 | <1 |
+| Add | 600 | 9 | 2 | 21 | <1 | 1.75 | <1 |
+| Reshape | 400 | 1 | 1 | 2 | <1 | 2.09 | <1 |
 
-**Interpretation note (to be written once data is captured):** the
-PMU columns will tell us whether Conv2D's memory-bound or compute-
-bound bottleneck moved more under #56. Honest framing: if the data
-shows neither IPC nor cache-miss rate improved meaningfully, the
-latency win came from somewhere else (less work done — for example
-loop-tiling reducing redundant loads) and that's still useful to
-know.
+Total/inf: 3,008 µs.
 
-#### Jetson (if #875 verifies)
+##### Jetson Orin Nano (Cortex-A78AE @ 1.5 GHz, 100 iter)
 
-If `pmu probe` on jetson-nano-1 returns "PMU is fully live," a
-parallel Jetson row will be added below pi-5-2's. If access traps to
-EL3 under stock NVIDIA BL31, the row stays blank and the TF-A patch
-follow-up tracks the unlock work separately.
+| Op | Calls | Avg µs | Min µs | Max µs | L1D% | IPC | Mispred% |
+|----|------:|-------:|-------:|-------:|-----:|----:|---------:|
+| Conv | 200 | 1,990 | 1,450 | 2,533 | <1 | **3.63** | <1 |
+| MatMul | 100 | 32 | 31 | 34 | <1 | 3.72 | <1 |
+| Relu | 200 | 24 | 9 | 39 | <1 | 3.49 | <1 |
+| MaxPool | 200 | 17 | 7 | 31 | <1 | 5.00 | <1 |
+| Add | 300 | 17 | 2 | 42 | <1 | 1.92 | <1 |
+| Reshape | 200 | 2 | 1 | 3 | <1 | 3.67 | <1 |
+
+Total/inf: 4,181 µs.
+
+Integer division renders L1D% / Mispred% as 0 when the true rate is
+below 1 %; both columns are <1 % across every op on both platforms —
+MNIST weights + working set fit comfortably in L1D after warmup.
+
+##### Interpretation
+
+**Where the latency goes is unambiguous: Conv2D dominates at ~95% of
+inference on both platforms.** L1D miss rate stays below 1% across
+every op on both Cortex-A76 and Cortex-A78AE — MNIST is small enough
+that the working set fits in L1D after warmup, so inference is
+**compute-bound, not memory-bound**. The `cache_pressure` feature
+fed into the AI scheduler (#872) therefore reads low under MNIST and
+will only spike under larger models whose working set spills L2.
+
+The IPC delta between the two cores tells the second-order story:
+Cortex-A78AE retires 1.5× more instructions per cycle than
+Cortex-A76 on Conv2D (3.63 vs 2.46), but Pi 5's higher clock
+(2.4 vs 1.5 GHz) more than compensates — Pi 5 finishes Conv2D in
+1,431 µs vs Jetson's 1,990 µs. A78AE also accumulates ~2× more
+backend-stall cycles than A76 on the same loop (see
+`docs/pmu-bringup.md` reference output) — its wider issue width
+isn't fully utilised by the current matmul kernel, leaving headroom
+for future per-microarch tuning.
+
+**Honest framing on "before/after #56".** The per-op profile harness
+*itself* landed under issue #56 (PR #849), so true pre-#56 PMU
+numbers don't exist on this codebase — we only have post-#56 PMU
+data. What the table demonstrates is that whatever #56's improvements
+were, the workload remains firmly compute-bound on both platforms;
+further latency gains from this point will come from either a wider
+matmul micro-kernel (push IPC higher) or moving Conv2D off the CPU
+(Hailo on Pi 5, GA10B GPU on Jetson).
 
 ### Model Memory Utilization
 

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -746,8 +746,13 @@ extern int rust_infer_bench(uint32_t model_index, uint32_t iterations);
  *   backend_stalls        — STALL_BACKEND
  *   cycles                — PMCCNTR_EL0 delta (denominator for IPC)
  *
- * The PMU fields are zero on QEMU (event counters not modelled by TCG)
- * and zero on any platform where `CONFIG_PMU_PROFILE` is undefined.
+ * The PMU fields are zero on PLATFORM_X86_64 (RDPMC sibling tracked
+ * as #870), zero on QEMU TCG ARM (event counters not modelled — the
+ * cycle counter ticks but every event reads 0), and zero on any CPU
+ * where `pmu_enable_self` has not yet run. There is no build-flag
+ * gate: the PMU read overhead is amortized inside the existing
+ * `model profile on/off` runtime toggle (the harness only reads PMU
+ * counters when profiling is enabled).
  */
 typedef struct {
     uint8_t  op_type;

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -728,7 +728,7 @@ extern int rust_infer_stats(RustInferStats *stats);
 extern int rust_infer_bench(uint32_t model_index, uint32_t iterations);
 
 /*
- * Per-operator profile entry (#56). Layout must match
+ * Per-operator profile entry (#56 + #871). Layout must match
  * `runtime/src/inference/engine.rs::OpProfileEntry` exactly — see the
  * `_pad` comment there for the explicit-padding rationale.
  *
@@ -736,6 +736,18 @@ extern int rust_infer_bench(uint32_t model_index, uint32_t iterations);
  * `runtime/src/loader/graph.rs` (0 = MatMul, 1 = Add, …, 16 = MaxPool,
  * 255 = Unknown). The `model profile show` handler in shell_sys.c
  * does the label lookup inline.
+ *
+ * PMU fields (#871) are sums across the measurement window:
+ *   cache_misses          — L1D refills
+ *   l2_misses             — L2D refills
+ *   instructions_retired  — INST_RETIRED
+ *   branch_mispredictions — BR_MIS_PRED
+ *   cache_references      — MEM_ACCESS (denominator for miss-rate)
+ *   backend_stalls        — STALL_BACKEND
+ *   cycles                — PMCCNTR_EL0 delta (denominator for IPC)
+ *
+ * The PMU fields are zero on QEMU (event counters not modelled by TCG)
+ * and zero on any platform where `CONFIG_PMU_PROFILE` is undefined.
  */
 typedef struct {
     uint8_t  op_type;
@@ -744,6 +756,13 @@ typedef struct {
     uint64_t total_ns;
     uint64_t min_ns;
     uint64_t max_ns;
+    uint64_t cache_misses;
+    uint64_t l2_misses;
+    uint64_t instructions_retired;
+    uint64_t branch_mispredictions;
+    uint64_t cache_references;
+    uint64_t backend_stalls;
+    uint64_t cycles;
 } RustOpProfileEntry;
 
 /*
@@ -752,6 +771,46 @@ typedef struct {
  * variant, bump both at once.
  */
 #define RUST_INFER_PROFILE_NUM_OPS 18
+
+/*
+ * Read the PMU cycle counter (PMCCNTR_EL0 on ARM64) for the calling CPU.
+ *
+ * Returns 0 on platforms where the PMU is not available (PLATFORM_X86_64
+ * — tracked separately as #870) or where pmu_enable_self has not yet
+ * completed on the calling CPU. On ARM64 the value is the 64-bit cycle
+ * counter; the profile harness in #871 uses the delta between two
+ * adjacent calls as the per-op cycle cost.
+ */
+uint64_t slm_pmu_read_cycles(void);
+
+/*
+ * Read one of the six preset PMU event counters (#874). `idx` order:
+ *   0 = L1D_CACHE_REFILL   (cache_misses bucket)
+ *   1 = L2D_CACHE_REFILL   (l2_misses bucket)
+ *   2 = INST_RETIRED       (instructions_retired bucket)
+ *   3 = BR_MIS_PRED        (branch_mispredictions bucket)
+ *   4 = MEM_ACCESS         (cache_references bucket)
+ *   5 = STALL_BACKEND      (backend_stalls bucket)
+ *
+ * Returns 0 if idx is out of range, the PMU is not available, or PMU
+ * init has not run on the calling CPU.
+ */
+uint32_t slm_pmu_read_event(uint32_t idx);
+
+/*
+ * Reset the cycle counter and all six event counters to zero on the
+ * calling CPU. Called by the profile harness at the start of each
+ * `execute_node` invocation to bound counter-overflow exposure to
+ * single-op windows.
+ */
+void slm_pmu_reset(void);
+
+/*
+ * Has the PMU been enabled on the calling CPU yet? Profile harness
+ * uses this to skip PMU reads cleanly on a CPU where secondary boot
+ * hasn't reached pmu_enable_self. Returns 0 on PLATFORM_X86_64.
+ */
+int slm_pmu_is_ready(void);
 
 /*
  * Enable or disable per-operator profiling.

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -3157,8 +3157,18 @@ int cmd_model(int argc, char *argv[])
                 shell_puts("model profile: no data\r\n");
                 return 0;
             }
-            shell_puts("Per-op profile (count / avg us / min us / max us)\r\n");
-            shell_puts("---------------------------------------------------\r\n");
+            /*
+             * Print latency columns first (cnt / avg_us / min_us /
+             * max_us), then PMU-derived columns (L1D miss-rate %, IPC,
+             * branch-mispred %). The PMU columns are blank on QEMU TCG
+             * and pre-init CPUs — Rust hands us zero for every PMU
+             * field there, and we print "-" instead of bogus zeros so
+             * the reader knows "no PMU data" vs "true zero events."
+             */
+            shell_puts("Per-op profile (count / avg us / min us / max us"
+                       " / L1D% / IPC / mispred%)\r\n");
+            shell_puts("-------------------------------------------------"
+                       "----------------------------\r\n");
             int printed = 0;
             for (int i = 0; i < n; i++) {
                 if (entries[i].count == 0) {
@@ -3176,12 +3186,55 @@ int cmd_model(int argc, char *argv[])
                 }
                 unsigned long avg_us = (unsigned long)(
                     entries[i].total_ns / entries[i].count / 1000u);
-                shell_printf("  %-10s  %8lu  %6lu  %6lu  %6lu\r\n",
+                /* L1D miss-rate %, IPC ×100, branch-mispred %. Compute
+                 * in integer math — IPC × 100 keeps two decimal places
+                 * worth of resolution without floats. */
+                bool have_pmu = entries[i].cache_references > 0
+                             || entries[i].cycles > 0;
+                char l1d_buf[16];
+                char ipc_buf[16];
+                char mispred_buf[16];
+                if (have_pmu && entries[i].cache_references > 0) {
+                    unsigned long l1d_pct = (unsigned long)(
+                        entries[i].cache_misses * 100u
+                        / entries[i].cache_references);
+                    /* Cap at 100 — defensive against counter races
+                     * where a refill is double-counted vs a reference.
+                     */
+                    if (l1d_pct > 100) l1d_pct = 100;
+                    uart_snprintf(l1d_buf, sizeof(l1d_buf),
+                                   "%lu", l1d_pct);
+                } else {
+                    l1d_buf[0] = '-'; l1d_buf[1] = '\0';
+                }
+                if (have_pmu && entries[i].cycles > 0) {
+                    unsigned long ipc_x100 = (unsigned long)(
+                        entries[i].instructions_retired * 100u
+                        / entries[i].cycles);
+                    uart_snprintf(ipc_buf, sizeof(ipc_buf),
+                                   "%lu.%02lu",
+                                   ipc_x100 / 100u, ipc_x100 % 100u);
+                } else {
+                    ipc_buf[0] = '-'; ipc_buf[1] = '\0';
+                }
+                if (have_pmu && entries[i].instructions_retired > 0) {
+                    /* Mispred per 100 instructions — interpretable
+                     * cross-platform. */
+                    unsigned long mp_pct = (unsigned long)(
+                        entries[i].branch_mispredictions * 100u
+                        / entries[i].instructions_retired);
+                    uart_snprintf(mispred_buf, sizeof(mispred_buf),
+                                   "%lu", mp_pct);
+                } else {
+                    mispred_buf[0] = '-'; mispred_buf[1] = '\0';
+                }
+                shell_printf("  %-10s  %8lu  %6lu  %6lu  %6lu  %4s  %5s  %5s\r\n",
                     label,
                     (unsigned long)entries[i].count,
                     avg_us,
                     (unsigned long)(entries[i].min_ns / 1000u),
-                    (unsigned long)(entries[i].max_ns / 1000u));
+                    (unsigned long)(entries[i].max_ns / 1000u),
+                    l1d_buf, ipc_buf, mispred_buf);
                 printed++;
             }
             if (printed == 0) {

--- a/kernel/src/slm_ffi.c
+++ b/kernel/src/slm_ffi.c
@@ -160,6 +160,29 @@ uint64_t slm_get_time_ns(void)
 }
 
 /*
+ * PMU FFI wrappers (#871). On PLATFORM_X86_64 the PMU primitives don't
+ * compile (RDPMC tracking is #870); the FFI calls return zero so the
+ * Rust profile harness doesn't need a separate cfg branch — it just
+ * sees "no PMU available" the same way it sees an uninitialised CPU.
+ */
+#if !defined(PLATFORM_X86_64)
+#include "pmu.h"
+
+uint64_t slm_pmu_read_cycles(void) { return pmu_read_cycles(); }
+uint32_t slm_pmu_read_event(uint32_t idx) { return pmu_read_event(idx); }
+void     slm_pmu_reset(void) { pmu_reset(); }
+int      slm_pmu_is_ready(void) { return pmu_is_ready() ? 1 : 0; }
+
+#else /* PLATFORM_X86_64 */
+
+uint64_t slm_pmu_read_cycles(void) { return 0; }
+uint32_t slm_pmu_read_event(uint32_t idx) { (void)idx; return 0; }
+void     slm_pmu_reset(void) { }
+int      slm_pmu_is_ready(void) { return 0; }
+
+#endif
+
+/*
  * Sleep the current task for the given number of milliseconds.
  */
 void slm_sleep_ms(uint32_t ms)

--- a/runtime/src/inference/engine.rs
+++ b/runtime/src/inference/engine.rs
@@ -121,6 +121,16 @@ pub struct OpProfileEntry {
     pub total_ns: u64,
     pub min_ns: u64,
     pub max_ns: u64,
+    // PMU sums (#871). Zero on x86-64 (#870) and on QEMU TCG (event
+    // counters not modelled). See `kernel/include/slm_ffi.h` for the
+    // bucket-to-event mapping.
+    pub cache_misses: u64,
+    pub l2_misses: u64,
+    pub instructions_retired: u64,
+    pub branch_mispredictions: u64,
+    pub cache_references: u64,
+    pub backend_stalls: u64,
+    pub cycles: u64,
 }
 
 impl OpProfileEntry {
@@ -131,6 +141,13 @@ impl OpProfileEntry {
         total_ns: 0,
         min_ns: 0,
         max_ns: 0,
+        cache_misses: 0,
+        l2_misses: 0,
+        instructions_retired: 0,
+        branch_mispredictions: 0,
+        cache_references: 0,
+        backend_stalls: 0,
+        cycles: 0,
     };
 }
 
@@ -155,6 +172,19 @@ static PROF_MAX_NS: [AtomicU64; PROFILE_NUM_OPS] = {
     const Z: AtomicU64 = AtomicU64::new(0);
     [Z; PROFILE_NUM_OPS]
 };
+// PMU per-bucket accumulators (#871). Same shape as the timing fields;
+// snapshot reads use Relaxed loads, recorder uses fetch_add.
+const fn z_arr() -> [AtomicU64; PROFILE_NUM_OPS] {
+    const Z: AtomicU64 = AtomicU64::new(0);
+    [Z; PROFILE_NUM_OPS]
+}
+static PROF_CACHE_MISSES: [AtomicU64; PROFILE_NUM_OPS] = z_arr();
+static PROF_L2_MISSES: [AtomicU64; PROFILE_NUM_OPS] = z_arr();
+static PROF_INST_RETIRED: [AtomicU64; PROFILE_NUM_OPS] = z_arr();
+static PROF_BR_MISPRED: [AtomicU64; PROFILE_NUM_OPS] = z_arr();
+static PROF_CACHE_REFS: [AtomicU64; PROFILE_NUM_OPS] = z_arr();
+static PROF_BACKEND_STALLS: [AtomicU64; PROFILE_NUM_OPS] = z_arr();
+static PROF_CYCLES: [AtomicU64; PROFILE_NUM_OPS] = z_arr();
 
 /// Map an `OpType` discriminant into the `[0, PROFILE_NUM_OPS)` index
 /// space the profile arrays use. `OpType::Unknown` is intentionally
@@ -238,13 +268,61 @@ pub fn op_profile_reset() {
         PROF_TOTAL_NS[i].store(0, Ordering::Relaxed);
         PROF_MIN_NS[i].store(u64::MAX, Ordering::Relaxed);
         PROF_MAX_NS[i].store(0, Ordering::Relaxed);
+        PROF_CACHE_MISSES[i].store(0, Ordering::Relaxed);
+        PROF_L2_MISSES[i].store(0, Ordering::Relaxed);
+        PROF_INST_RETIRED[i].store(0, Ordering::Relaxed);
+        PROF_BR_MISPRED[i].store(0, Ordering::Relaxed);
+        PROF_CACHE_REFS[i].store(0, Ordering::Relaxed);
+        PROF_BACKEND_STALLS[i].store(0, Ordering::Relaxed);
+        PROF_CYCLES[i].store(0, Ordering::Relaxed);
+    }
+}
+
+/// PMU counter snapshot captured at op start (#871). Built from the
+/// FFI `slm_pmu_*` reads after `slm_pmu_reset`, so every field is a
+/// delta-from-zero for the wrapped op.
+///
+/// On x86-64 and on platforms where the PMU has not been enabled on
+/// the calling CPU, every field reads as zero — the harness records
+/// zero per-op deltas and the snapshot consumer sees blank PMU columns
+/// instead of garbage. This matches how QEMU TCG behaves (cycle counter
+/// works but event counters return zero).
+#[derive(Default, Clone, Copy)]
+struct PmuSnapshot {
+    cycles: u64,
+    cache_misses: u64,
+    l2_misses: u64,
+    instructions_retired: u64,
+    branch_mispredictions: u64,
+    cache_references: u64,
+    backend_stalls: u64,
+}
+
+impl PmuSnapshot {
+    fn capture() -> Self {
+        // SAFETY: every FFI call is a pure register read with no
+        // pointer arguments. On platforms without a PMU the C wrappers
+        // return zero.
+        unsafe {
+            Self {
+                cycles: kernel_ffi::slm_pmu_read_cycles(),
+                cache_misses: kernel_ffi::slm_pmu_read_event(0) as u64,
+                l2_misses: kernel_ffi::slm_pmu_read_event(1) as u64,
+                instructions_retired: kernel_ffi::slm_pmu_read_event(2) as u64,
+                branch_mispredictions: kernel_ffi::slm_pmu_read_event(3) as u64,
+                cache_references: kernel_ffi::slm_pmu_read_event(4) as u64,
+                backend_stalls: kernel_ffi::slm_pmu_read_event(5) as u64,
+            }
+        }
     }
 }
 
 /// Record one op invocation. Called from `execute_node` only when
 /// profiling is enabled — the caller does the enable check so that the
-/// disabled path doesn't even read `OP_PROFILE_ENABLED`.
-fn op_profile_record(op_type: OpType, ns: u64) {
+/// disabled path doesn't even read `OP_PROFILE_ENABLED`. The `pmu`
+/// snapshot is the delta captured between `pmu_reset` and the
+/// post-dispatch read.
+fn op_profile_record(op_type: OpType, ns: u64, pmu: &PmuSnapshot) {
     let i = op_type_to_index(op_type);
     PROF_COUNT[i].fetch_add(1, Ordering::Relaxed);
     PROF_TOTAL_NS[i].fetch_add(ns, Ordering::Relaxed);
@@ -266,6 +344,13 @@ fn op_profile_record(op_type: OpType, ns: u64) {
             Err(actual) => cur = actual,
         }
     }
+    PROF_CACHE_MISSES[i].fetch_add(pmu.cache_misses, Ordering::Relaxed);
+    PROF_L2_MISSES[i].fetch_add(pmu.l2_misses, Ordering::Relaxed);
+    PROF_INST_RETIRED[i].fetch_add(pmu.instructions_retired, Ordering::Relaxed);
+    PROF_BR_MISPRED[i].fetch_add(pmu.branch_mispredictions, Ordering::Relaxed);
+    PROF_CACHE_REFS[i].fetch_add(pmu.cache_references, Ordering::Relaxed);
+    PROF_BACKEND_STALLS[i].fetch_add(pmu.backend_stalls, Ordering::Relaxed);
+    PROF_CYCLES[i].fetch_add(pmu.cycles, Ordering::Relaxed);
 }
 
 /// Copy at most `max_entries` rows into `out` (one per op bucket, in
@@ -306,6 +391,13 @@ pub unsafe fn op_profile_snapshot(
             // instead of as a 64-bit poison value.
             min_ns: if count == 0 || min == u64::MAX { 0 } else { min },
             max_ns: PROF_MAX_NS[i].load(Ordering::Relaxed),
+            cache_misses: PROF_CACHE_MISSES[i].load(Ordering::Relaxed),
+            l2_misses: PROF_L2_MISSES[i].load(Ordering::Relaxed),
+            instructions_retired: PROF_INST_RETIRED[i].load(Ordering::Relaxed),
+            branch_mispredictions: PROF_BR_MISPRED[i].load(Ordering::Relaxed),
+            cache_references: PROF_CACHE_REFS[i].load(Ordering::Relaxed),
+            backend_stalls: PROF_BACKEND_STALLS[i].load(Ordering::Relaxed),
+            cycles: PROF_CYCLES[i].load(Ordering::Relaxed),
         };
         unsafe { *out.add(i) = entry; }
     }
@@ -554,14 +646,22 @@ impl InferenceEngine {
         let node = self.graph.nodes[node_idx];
 
         if op_profile_is_enabled() {
+            // Reset PMU counters so the post-op reads are absolute
+            // per-op deltas — no subtraction-with-overflow corner case
+            // even though event counters are only 32-bit. PMU pre-reset
+            // is cheap (one MSR) compared to a typical op latency (µs+).
+            // SAFETY: pure register write on the calling CPU; no-op on
+            // platforms without PMU.
+            unsafe { kernel_ffi::slm_pmu_reset(); }
             let start = kernel_ffi::get_time_ns();
             let result = self.dispatch_node(&node);
             let elapsed = kernel_ffi::get_time_ns().saturating_sub(start);
+            let pmu = PmuSnapshot::capture();
             // Record the timing even on error so the profile reflects
             // wall-clock cost paid by the engine, not just successful
             // ops. Callers that want success-only numbers can filter
             // by `result.is_ok()` themselves.
-            op_profile_record(node.op_type, elapsed);
+            op_profile_record(node.op_type, elapsed, &pmu);
             result
         } else {
             self.dispatch_node(&node)

--- a/runtime/src/kernel_ffi.rs
+++ b/runtime/src/kernel_ffi.rs
@@ -300,6 +300,22 @@ extern "C" {
     pub fn slm_get_time_ns() -> u64;
 
     // -------------------------------------------------------------------------
+    // PMU (#871) — read primitives for the per-op profile harness
+    // -------------------------------------------------------------------------
+
+    /// Read PMCCNTR_EL0 on ARM64; returns 0 on x86-64 / pre-init CPUs.
+    pub fn slm_pmu_read_cycles() -> u64;
+
+    /// Read one of the six preset event counters; idx in [0,6).
+    pub fn slm_pmu_read_event(idx: u32) -> u32;
+
+    /// Reset every PMU counter on the calling CPU (cycle + events).
+    pub fn slm_pmu_reset();
+
+    /// Returns 1 if PMU init has completed on the calling CPU, else 0.
+    pub fn slm_pmu_is_ready() -> i32;
+
+    // -------------------------------------------------------------------------
     // GPU Cache Coherency
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Sub-ticket of #60 (depends on #874 / PR #890 and #875 / PR #898).

Extends PR #849's per-op profile harness to capture PMU counter deltas
alongside the existing CNTPCT timing. The headline capstone artifact
this unlocks is the before/after-#56 micro-kernel row in
\`docs/benchmarks.md\` — does the matmul speedup come from reduced
cache misses (memory-bound improvement) or increased IPC (compute-
bound)?

## Changes

- \`RustOpProfileEntry\` (FFI) / \`OpProfileEntry\` (Rust) grow seven new
  u64 fields covering the #874 preset event table:
  \`cache_misses\`, \`l2_misses\`, \`instructions_retired\`,
  \`branch_mispredictions\`, \`cache_references\`, \`backend_stalls\`,
  \`cycles\`.
- \`execute_node\` calls \`slm_pmu_reset()\` before dispatch and captures
  a \`PmuSnapshot\` after — every recorded delta is therefore a
  per-op number, bounding 32-bit event-counter overflow to µs.
- Four new FFI functions: \`slm_pmu_read_cycles\`, \`slm_pmu_read_event\`,
  \`slm_pmu_reset\`, \`slm_pmu_is_ready\`. Return zero on
  \`PLATFORM_X86_64\` so the Rust harness has no cfg branch.
- \`model profile show\` prints three derived columns: L1D miss rate %,
  IPC, branch-mispred per 100 instructions. Blank (\`-\`) when no PMU
  data is available so QEMU output isn't confused for true zero events.

## Overhead

Each profiled op pays:
- 1 MSR (pmu_reset)
- 7 register reads (cycles + 6 events)
- 7 atomic fetch_adds

On Cortex-A76 that's tens of nanoseconds — negligible against the
microsecond-scale op latencies. Profiling stays opt-in via
\`model profile on\` so the disabled path is byte-for-byte unchanged.

## Test plan

- [x] \`make test\` — green, including PR #849's existing harness tests.
- [x] \`make kernel PLATFORM=RASPI5\` — clean build.
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean build.
- [ ] pi-5-2 hardware: \`model profile reset && model bench mnist 200
      && model profile show\` — capture Conv L1D%/IPC before/after #56.
      This is the headline capstone deliverable. Pending board
      availability.
- [ ] jetson-nano-1 hardware: same capture if \`pmu probe\` (#875)
      verifies. Bonus row.

\`docs/benchmarks.md\` has the placeholder before/after-#56 row ready
to fill in on the hardware window.

Part of #60.