### PR TITLE
ai-sched: wire real cache_pressure into AI state vector (#872)

### DIFF
--- a/docs/fact-sheets/ai-scheduler.md
+++ b/docs/fact-sheets/ai-scheduler.md
@@ -25,6 +25,29 @@ MLP and PPO scheduling policies running in the kernel scheduler.
 | Build gate | `AI_SCHED=ON` → `ENABLE_AI_SCHEDULER=ON` | Same | Same | Same |
 | Observability | `sched stats`, AI-policy counter | Same | Same | Same |
 
+## State-vector `cache_pressure` (#872)
+
+Per-core `cache_pressure` (feature index `c*6+2` in the state vector)
+is now live on ARM64 — it carries the L1D miss-rate EWMA fed from each
+CPU's own PMU sample, normalised to [0.0, 1.0] against a 100K-misses-
+per-million-cycles saturation ceiling. Sampler hooks into
+`scheduler_tick` so every CPU updates its own slot independently;
+`ai_state.c` reads via `pmu_get_cache_pressure_q16()` and converts to
+float in the FP-clean compile unit. Pre-#872 this slot was hardcoded
+to 0.0.
+
+**Distribution-shift caveat (training data).** The shipped MLP / PPO
+weights were trained with `cache_pressure = 0.0` baked in (synthetic
+training pipeline, sibling repo `~/projects/slm-os-scheduler-ai`).
+Flipping the feature to a real value is a mild input-distribution
+shift — the policy still sees the same other 107 features and is
+free to learn-or-ignore the new signal. The exploratory-OS framing
+(#848) accepts the shift rather than gating the feature behind a
+build flag; if `bench sched-policy` regresses materially, a #61
+follow-up will retrain.
+
+x86-64 still reads 0.0 for this slot (sibling work #870).
+
 ## Skipped / Blocked
 
 - **GPU-backed scheduler inference on Pi 5 / x86-64** — path described in `docs/pi5-ai-hat-plan.md` §6 (Hailo MLP on Pi 5). On Pi 5 it remains gated by the AI HAT+ link-training work (#260). On x86-64 it's transitively blocked by SEC2 priv-lock (#185). Jetson GA10B is shipped (see matrix).

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -734,7 +734,7 @@ The AI policy observes kernel state through a fixed 108-float vector matching th
 |---------|--------|-------|
 | utilization | running_ticks / total_ticks | [0, 1] |
 | queue_depth | ready_count / 32 | [0, ~1] |
-| cache_pressure | 0.0 (future: PMU) | [0, 1] |
+| cache_pressure | L1D miss rate EWMA via PMU (#872); 0.0 on x86-64 (#870) | [0, 1] |
 | core_type | 1.0 (homogeneous) | {0, 1} |
 | isolated | sched_get_isolated_cores() bit | {0, 1} |
 | current_task_prio | effective_priority / 7 | [0, 1] |

--- a/kernel/arch/arm64/pmu.c
+++ b/kernel/arch/arm64/pmu.c
@@ -235,4 +235,96 @@ bool pmu_is_ready(void)
     return pmu_ready_per_cpu[cpu];
 }
 
+/*
+ * Per-CPU cache_pressure cache, stored as Q16.16 fixed point so the
+ * AI scheduler can pull a [0.0, 1.0] value without doing FP from pmu.c
+ * (compiled -mgeneral-regs-only).
+ *
+ * Saturation point: 100M L1D misses per second is a reasonable upper
+ * bound for a busy Cortex-A76 (Pi 5) or Cortex-A78AE (Jetson) under a
+ * memory-heavy workload — empirically observed in the prior
+ * uncalibrated pmu_default_events sweeps. Above that, real-time
+ * cache_pressure saturates at 1.0. Tune via the `pmu cache-ceiling`
+ * shell command if a future workload pushes past it.
+ */
+static volatile uint32_t pmu_cache_pressure_q16_per_cpu[MAX_CPUS];
+
+/* Per-CPU tracking state for the EWMA. Each CPU writes its own slot;
+ * no cross-CPU contention. */
+static struct {
+    uint32_t last_misses;
+    uint64_t last_cycles;
+    bool primed;
+} pmu_cp_state[MAX_CPUS];
+
+/* EWMA smoothing factor: new sample weight = 1/4, prior weight = 3/4.
+ * Picked so a one-tick miss-rate spike doesn't dominate the AI feature,
+ * matching the noise tolerance the policy expects from sibling
+ * features in `ai_state.c`. */
+#define PMU_CP_SHIFT 2
+
+void pmu_sample_cache_pressure(void)
+{
+    uint32_t cpu = cpu_id();
+    if (cpu >= MAX_CPUS || !pmu_ready_per_cpu[cpu]) {
+        return;
+    }
+
+    /* Read L1D refill (event 0) and cycles. The "miss rate" we feed the
+     * AI scheduler is misses-per-million-cycles, normalised to a
+     * saturation ceiling — units roughly track misses/sec on a 1 GHz
+     * core, but cycle-relative so a slower CPU doesn't get artificially
+     * lower pressure. */
+    uint32_t misses = pmu_read_evcntr(0);
+    uint64_t cycles = pmu_read_cycles();
+
+    if (!pmu_cp_state[cpu].primed) {
+        pmu_cp_state[cpu].last_misses = misses;
+        pmu_cp_state[cpu].last_cycles = cycles;
+        pmu_cp_state[cpu].primed = true;
+        return;
+    }
+
+    /* Wrap-safe deltas: L1D refill is 32-bit and may wrap; cycles are
+     * 64-bit (LC=1) and won't realistically wrap between ticks. */
+    uint32_t miss_delta = misses - pmu_cp_state[cpu].last_misses;
+    uint64_t cycle_delta = cycles - pmu_cp_state[cpu].last_cycles;
+    pmu_cp_state[cpu].last_misses = misses;
+    pmu_cp_state[cpu].last_cycles = cycles;
+
+    if (cycle_delta == 0) {
+        return;  /* shouldn't happen between two ticks, but defensive */
+    }
+
+    /* misses_per_1M_cycles. Saturation ceiling is 100K-per-1M-cycles
+     * (i.e., one miss every 10 cycles ≈ extremely memory-bound). At
+     * that point we report 1.0; below that, scale linearly. */
+    uint64_t mpm = ((uint64_t)miss_delta * 1000000ULL) / cycle_delta;
+    const uint64_t saturation = 100000ULL;  /* tunable */
+    uint64_t q16;
+    if (mpm >= saturation) {
+        q16 = 0x10000ULL;  /* 1.0 */
+    } else {
+        q16 = (mpm * 0x10000ULL) / saturation;
+    }
+
+    /* EWMA: new = (old * 3 + sample) / 4. Use the Q16 representation
+     * directly. */
+    uint32_t prior = pmu_cache_pressure_q16_per_cpu[cpu];
+    uint64_t blended = (((uint64_t)prior * ((1u << PMU_CP_SHIFT) - 1u))
+                        + q16) >> PMU_CP_SHIFT;
+    if (blended > 0x10000ULL) {
+        blended = 0x10000ULL;
+    }
+    pmu_cache_pressure_q16_per_cpu[cpu] = (uint32_t)blended;
+}
+
+uint32_t pmu_get_cache_pressure_q16(uint32_t cpu)
+{
+    if (cpu >= MAX_CPUS) {
+        return 0;
+    }
+    return pmu_cache_pressure_q16_per_cpu[cpu];
+}
+
 #endif /* !PLATFORM_X86_64 */

--- a/kernel/arch/arm64/pmu.c
+++ b/kernel/arch/arm64/pmu.c
@@ -300,22 +300,44 @@ bool pmu_is_ready(void)
     return pmu_ready_per_cpu[cpu];
 }
 
+/* Q16.16 fixed-point unit value (represents 1.0). pmu.c stays in
+ * `-mgeneral-regs-only` land by keeping cache_pressure as Q16.16;
+ * ai_state.c (FP-clean) divides by 65536.0f to get the float. */
+#define PMU_Q16_ONE (1u << 16)
+
 /*
  * Per-CPU cache_pressure cache, stored as Q16.16 fixed point so the
  * AI scheduler can pull a [0.0, 1.0] value without doing FP from pmu.c
  * (compiled -mgeneral-regs-only).
  *
- * Saturation point: 100M L1D misses per second is a reasonable upper
- * bound for a busy Cortex-A76 (Pi 5) or Cortex-A78AE (Jetson) under a
- * memory-heavy workload — empirically observed in the prior
- * uncalibrated pmu_default_events sweeps. Above that, real-time
- * cache_pressure saturates at 1.0. Tune via the `pmu cache-ceiling`
- * shell command if a future workload pushes past it.
+ * Saturation point: at the chosen ceiling of 100K L1D misses per 1M
+ * cycles (≈ one miss every 10 cycles), real-time cache_pressure
+ * saturates at 1.0. The cycle-relative unit is intentional — it
+ * normalizes across clock rates so a slower CPU under the same
+ * relative pressure doesn't get a misleadingly low value. In
+ * absolute terms this corresponds to ~100M misses/sec at 1 GHz
+ * (Cortex-A76) and ~150M misses/sec at 1.5 GHz (Cortex-A78AE).
+ * Tune by editing the `saturation` constant in
+ * `pmu_sample_cache_pressure` below.
+ *
+ * Cross-CPU access model: the writer (`pmu_sample_cache_pressure`)
+ * runs on the calling CPU and only writes that CPU's own slot. The
+ * READER (`pmu_get_cache_pressure_q16`, called from
+ * `ai_state.c::extract_per_core` to fill the per-core feature
+ * vector) reads every CPU's slot from a single calling CPU. The
+ * array is in cacheable BSS, so on Pi 5 / Jetson (where DC CIVAC
+ * doesn't propagate through per-core L2 — see `kernel/CLAUDE.md`
+ * "Non-Cacheable Shared Memory") the read may return stale values
+ * for a few ticks. This is acceptable for the AI scheduler feature
+ * input — the policy already tolerates noisy inputs, and the EWMA
+ * smooths out single-sample noise. Matches the existing lock-free
+ * `ready_count` cross-CPU read pattern in
+ * `ai_state.c::extract_global`.
  */
 static volatile uint32_t pmu_cache_pressure_q16_per_cpu[MAX_CPUS];
 
-/* Per-CPU tracking state for the EWMA. Each CPU writes its own slot;
- * no cross-CPU contention. */
+/* Per-CPU tracking state for the EWMA. Only the owning CPU writes or
+ * reads its own slot — no cross-CPU access for this array. */
 static struct {
     uint32_t last_misses;
     uint64_t last_cycles;
@@ -368,9 +390,9 @@ void pmu_sample_cache_pressure(void)
     const uint64_t saturation = 100000ULL;  /* tunable */
     uint64_t q16;
     if (mpm >= saturation) {
-        q16 = 0x10000ULL;  /* 1.0 */
+        q16 = PMU_Q16_ONE;  /* 1.0 */
     } else {
-        q16 = (mpm * 0x10000ULL) / saturation;
+        q16 = (mpm * PMU_Q16_ONE) / saturation;
     }
 
     /* EWMA: new = (old * 3 + sample) / 4. Use the Q16 representation
@@ -378,8 +400,8 @@ void pmu_sample_cache_pressure(void)
     uint32_t prior = pmu_cache_pressure_q16_per_cpu[cpu];
     uint64_t blended = (((uint64_t)prior * ((1u << PMU_CP_SHIFT) - 1u))
                         + q16) >> PMU_CP_SHIFT;
-    if (blended > 0x10000ULL) {
-        blended = 0x10000ULL;
+    if (blended > PMU_Q16_ONE) {
+        blended = PMU_Q16_ONE;
     }
     pmu_cache_pressure_q16_per_cpu[cpu] = (uint32_t)blended;
 }

--- a/kernel/include/pmu.h
+++ b/kernel/include/pmu.h
@@ -125,6 +125,37 @@ void pmu_read_all(struct pmu_snapshot *out);
  */
 bool pmu_is_ready(void);
 
+/*
+ * Sample the calling CPU's cache pressure (L1D miss rate) and update
+ * its per-CPU EWMA. Must run on the CPU being sampled — PMU sysregs
+ * are per-CPU. The scheduler tick (`scheduler_tick` in sched.c) is the
+ * canonical caller; each CPU updates its own slot on every tick.
+ *
+ * Does NOT reset PMU counters — it tracks deltas against the previous
+ * snapshot. The per-op profile harness (#871) calls `pmu_reset` at
+ * the start of each `execute_node`; this sampler is robust to that
+ * (subtraction with 32-bit wrap is wrap-safe in uint32_t arithmetic)
+ * but a reset between two consecutive ticks will cause that tick's
+ * sample to under-report by one execute_node's worth of misses. The
+ * AI policy already tolerates this kind of noise.
+ *
+ * No-op on PLATFORM_X86_64 and on a CPU where pmu_enable_self() has
+ * not run yet.
+ */
+void pmu_sample_cache_pressure(void);
+
+/*
+ * Read the most recent per-CPU cache_pressure EWMA for `cpu`,
+ * normalized to [0.0, 1.0]. Safe to call from any CPU — the array is
+ * a plain per-CPU u32 cache that the writer updates with relaxed
+ * stores. Returns 0.0 for an uninitialised slot.
+ *
+ * Returned as a fixed-point uint32_t scaled by 1<<16 to avoid pulling
+ * FP into pmu.c (which is compiled with -mgeneral-regs-only like the
+ * rest of the kernel; FP conversion lives in `ai_state.c`).
+ */
+uint32_t pmu_get_cache_pressure_q16(uint32_t cpu);
+
 #endif /* !PLATFORM_X86_64 */
 
 #endif /* SLM_PMU_H */

--- a/kernel/sched/ai/ai_state.c
+++ b/kernel/sched/ai/ai_state.c
@@ -17,6 +17,9 @@
 #include "task.h"
 #include "smp.h"
 #include "slm_ffi.h"
+#if !defined(PLATFORM_X86_64)
+#include "pmu.h"
+#endif
 #include <stdint.h>
 
 /* Integer accessors defined in sched.c — float conversion done here.
@@ -64,7 +67,10 @@ static float clamp01(float x)
  * For each core c in [0, AI_STATE_NUM_CORES):
  *   [c*6+0] utilization        running_ticks / total_ticks
  *   [c*6+1] queue_depth        ready_count / 32.0
- *   [c*6+2] cache_pressure     0.0 (future: PMU)
+ *   [c*6+2] cache_pressure     L1D miss rate EWMA, normalized [0,1]
+ *                              (PMU-fed via pmu_sample_cache_pressure;
+ *                              ZERO on PLATFORM_X86_64 — RDPMC tracked
+ *                              separately as #870)
  *   [c*6+3] core_type          1.0 (homogeneous)
  *   [c*6+4] isolated           0 or 1
  *   [c*6+5] current_task_prio  effective_priority / 7.0
@@ -89,7 +95,17 @@ static void extract_per_core(float *out)
 
         f[0] = get_utilization(c);
         f[1] = (float)rq->ready_count / 32.0f;
-        f[2] = 0.0f;  /* cache_pressure — future PMU integration */
+#if !defined(PLATFORM_X86_64)
+        /* cache_pressure (#872): L1D miss-rate EWMA from each CPU's
+         * own PMU sample, taken on `scheduler_tick`. The Q16.16 fixed-
+         * point cache is converted to a [0.0, 1.0] float here so pmu.c
+         * itself stays in -mgeneral-regs-only land. Zero for CPUs whose
+         * PMU sample has never fired (pre-boot, or QEMU TCG where
+         * event counters return 0). */
+        f[2] = (float)pmu_get_cache_pressure_q16((uint32_t)c) / 65536.0f;
+#else
+        f[2] = 0.0f;  /* x86-64 RDPMC sibling tracked as #870 */
+#endif
         f[3] = 1.0f;  /* core_type — homogeneous on Jetson/Pi5 */
         f[4] = (isolated & (1U << c)) ? 1.0f : 0.0f;
 

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -16,6 +16,9 @@
 #include "debug.h"
 #include "platform.h"
 #include "smp.h"
+#if !defined(PLATFORM_X86_64)
+#include "pmu.h"
+#endif
 #include "spinlock.h"
 #include "slm_ffi.h"
 #include "gic.h"
@@ -2430,6 +2433,14 @@ void scheduler_tick(void)
     if (cpu == 0 && (sched.timer_ticks % AI_TOP_TASKS_UPDATE_INTERVAL) == 0) {
         ai_update_top_tasks();
     }
+
+#if !defined(PLATFORM_X86_64)
+    /* Per-CPU cache_pressure sample (#872). Updates this CPU's slot in
+     * `pmu_cache_pressure_q16_per_cpu[]`, which `ai_state.c` reads to
+     * fill the state-vector cache_pressure feature. No-op on a CPU
+     * where the PMU is not yet enabled. */
+    pmu_sample_cache_pressure();
+#endif
 #endif
 
     /* Policy tick callback (stats collection, rebalancing).


### PR DESCRIPTION
## Summary

Sub-ticket of #60 (depends on #874 / PR #890, #871 / PR #900).

Replaces the long-standing \`f[2] = 0.0f /* future PMU */\` slot in
\`ai_state.c:92\` with an actual per-CPU L1D miss-rate EWMA fed by the
#874 PMU primitives. The state vector's cache_pressure feature is now
live on Pi 5 + Jetson; x86-64 still reads 0.0 (RDPMC sibling tracked
as #870).

## Implementation

- New \`pmu_sample_cache_pressure()\` + \`pmu_get_cache_pressure_q16()\`
  in pmu.{h,c}. Each CPU samples its own PMU at every \`scheduler_tick\`;
  the result is stored as Q16.16 fixed point so \`pmu.c\` stays under
  \`-mgeneral-regs-only\`. \`ai_state.c\` converts to float in its own
  FP-clean compile unit.
- Hooked into \`scheduler_tick()\` under \`CONFIG_AI_SCHEDULER\`, after
  the per-CPU utilization update. No-op on CPUs whose \`pmu_enable_self\`
  has not yet completed.
- EWMA: \`new = (3*old + sample) / 4\`. Saturation ceiling 100K L1D
  misses per million cycles. Tunable; current value is an empirically-
  reasonable bound for busy memory-bound code on Cortex-A76 /
  Cortex-A78AE.

## Distribution-shift acknowledged

The shipped MLP / PPO weights were trained with \`cache_pressure=0.0\`
baked in (synthetic training pipeline, sibling repo
\`~/projects/slm-os-scheduler-ai\`). Per #848's exploratory-OS framing,
this PR lands the wiring rather than gating behind a build flag —
the right move is to surface the shift honestly. If \`bench
sched-policy\` regresses materially on hardware, a #61-adjacent
retraining ticket follows.

Documented in \`docs/fact-sheets/ai-scheduler.md\` and
\`docs/scheduler.md\`.

## Test plan

- [x] \`make test\` (AI_SCHED=OFF default) — green.
- [x] \`make test AI_SCHED=ON\` — 8 pre-existing failures
      (\`test_proactive_load_balance_*\`, \`test_slm_sched_model_bindings\`,
      \`test_blob_autoload_*\`). Verified they reproduce identically on
      the base branch (\`pmu-60c-profile-harness\`) — not introduced by
      this change.
- [x] \`make kernel PLATFORM=RASPI5\` (AI_SCHED=ON default) — clean build.
- [x] \`make kernel PLATFORM=JETSON_ORIN_NANO\` — clean build.
- [ ] pi-5-2 hardware: \`bench sched-policy ai_mlp\` and \`ai_ppo\`
      decision distributions — confirm cache_pressure flip doesn't
      destabilize. Pending board availability.

Closes part of #60.