### PR TITLE
Dynamic batching 55d: hardware characterisation + benchmarks + docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -408,6 +408,28 @@ The inference engine (`runtime/src/inference/engine.rs`) executes operator graph
 | Gemm | General matrix multiplication (A x B + C) |
 | Flatten | Flatten to 2D (batch, features) |
 
+**Dynamic batched dispatch (runtime-toggleable mode, #55).** The
+engine exposes `run_inference_batched(model, batch_size, in, out)`
+alongside the single-sample `run_inference`. The
+`InferenceScheduler` (`runtime/src/sched/inference.rs`) collects
+concurrent inference requests into a bounded queue (up to
+`MAX_BATCH = 32`), then dispatches them through one
+`run_inference_batched` call once either the configured
+batch-size threshold is reached or a CNTPCT-driven flush timeout
+elapses since the first request landed. Per-request output buffers
+are populated and per-task completion mailboxes are signalled by
+the synchronous dispatcher (the submitter that tipped the threshold
+or won the timer race). A request carrying a `TaskDeadline` whose
+remaining slack is below the configured timeout bypasses the queue
+and dispatches as a singleton. Mode is OFF by default and
+toggleable at runtime via `infer batch on` (shell) or
+`slm.infer_batch_mode("on")` (Lua) — per the exploratory-OS
+framing (#848), batched dispatch is a swappable option, not a
+required behavior. The MNIST GPU fast path remains single-sample
+only; batched dispatches always take the CPU graph path.
+Characterised numbers live in `docs/benchmarks.md` under "Dynamic
+Batching".
+
 ### GPU Compute Framework
 
 The GPU backend (`runtime/src/inference/gpu.rs`) provides a framework for GPU-accelerated inference:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -322,6 +322,74 @@ The 2 MB block granularity means small models waste most of their allocated bloc
 
 ---
 
+## Dynamic Batching (Runtime-Toggleable Mode)
+
+SLM-OS's `InferenceScheduler` supports a runtime-toggleable batched dispatch mode (issue #55). Concurrent inference requests are collected into a bounded queue and, on either the size threshold or a configurable timer, dispatched in a single engine call. Per the exploratory-OS framing (#848), batching is a swappable option — default OFF — not a default behavior change.
+
+This section reports the **characterisation** of that mode on Pi 5 and Jetson, not a winner. The capstone story is "the engine supports a batched dispatch mode; here is its behavior at N = 1..16 on real hardware," not "batching wins."
+
+### Workload
+
+`bench infer-stress N [iters]` spawns N concurrent task workers, each running `iters` MNIST inferences against the dispatcher. Reported numbers below are from the shell command with the platform's standard `iters` setting (50 for N ≤ 8, 25 for N = 16 to cap wall-clock).
+
+Configuration for all batched runs: `batch_size = 8`, `timeout_us = 5000` (the shipping defaults). With batching ON the dispatcher routes through the queue + threshold/timer path; with OFF every request takes the existing singleton path.
+
+### Pi 5 (pi-5-2) — `bench infer-stress`, native boot, 4× Cortex-A76 @ 2.4 GHz
+
+| N | Mode | req/s | min µs | avg µs | max µs | batches_full | batches_timeout | singleton |
+|---|---|---|---|---|---|---|---|---|
+|  1 | OFF | 330 | 3009 |  3010 |  3028 | 0 | 0 |  50 |
+|  1 | ON  | 330 | 3009 |  3010 |  3011 | 0 | 0 |  50 |
+|  2 | OFF | 331 | 3010 |  5918 |  6030 | 0 | 0 | 100 |
+|  2 | ON  | 331 | 3011 |  5979 |  6025 | 0 | 0 | 100 |
+|  4 | OFF | 331 | 3010 | 11555 | 54224 | 0 | 0 | 200 |
+|  4 | ON  | 331 | 3010 | 11536 | 45188 | 0 | 0 | 200 |
+|  8 | OFF | 331 | 3009 | 11750 | 57226 | 0 | 0 | 400 |
+|  8 | ON  | 331 | 3010 | 11595 | 48199 | 0 | 0 | 400 |
+| 16 | OFF | 331 | 3010 | 11642 | 48197 | 0 | 0 | 400 |
+| 16 | ON  | 331 | 3010 | 11501 | 51213 | 0 | 0 | 400 |
+
+### Jetson Orin Nano (jetson-nano-1) — `bench infer-stress`, slmos-kexec, 6× Cortex-A78AE
+
+CPU-path matrix (the MNIST GPU fast path is single-sample only, so even ON paths take the CPU graph here; see "GPU fast path interaction" below):
+
+| N | Mode | req/s | min µs | avg µs | max µs (noise) | batches_full | batches_timeout | singleton |
+|---|---|---|---|---|---|---|---|---|
+|  1 | OFF | 239 | 4157 |  4176 |    4203 | 0 | 0 |  50 |
+|  1 | ON  | 239 | 4166 |  4177 |    4189 | 0 | 0 |  50 |
+|  2 | OFF | 239 | 4194 |  8317 |    8377 | 0 | 0 | 100 |
+|  2 | ON  | 239 | 4175 |  8312 |    8375 | 0 | 0 | 100 |
+|  4 | OFF | 102 | 4177 | 18961 |  654563 | 0 | 0 | 200 |
+|  4 | ON  | 102 | 4172 | 17998 |  444816 | 0 | 0 | 200 |
+|  8 | OFF |  79 | 4173 | 30594 | 1099540 | 0 | 0 | 400 |
+|  8 | ON  | 102 | 4172 | 30422 | 1308376 | 0 | 0 | 400 |
+| 16 | OFF | 143 | 4175 | 28189 | 1544941 | 0 | 0 | 400 |
+| 16 | ON  | 143 | 4175 | 28022 | 1517780 | 0 | 0 | 400 |
+
+Jetson max-latency outliers (the seconds-long tails) come from L4T-side scheduling noise after `slmos-kexec` — when the Linux→SLM-OS handoff inherits a busy GIC/timer state, individual worker iterations get descheduled for hundreds of milliseconds. The per-iter `min` (~4.2 ms) reflects the actual CPU-path cost; the `avg` widens with N because workers contend on the engine lock.
+
+GPU fast path interaction: at `N = 1` with `gpu use inference on` and a v6 channel handoff present, the engine routes through `run_mnist_gpu_fastpath`. With batching ON or `N > 1`, the GPU fast path is skipped because the GPU FFI asserts `input_len == 784`. Documented limitation; a batched MNIST GPU dispatch would amortise per-call setup over N samples and is candidate future work.
+
+### Interpretation — honest characterisation
+
+**Batched dispatch never fires on this workload.** The `batches_full` and `batches_timeout` columns are zero across every row of both matrices; every iteration on every run takes the singleton path. This is the honest result for MNIST + CPU graph and is explained by the dispatcher's three-way interaction with `EngineGuard` and the configured timer:
+
+1. The submitter that reserves the only slot in an empty queue sees `pending_count == 1` in `decide_role` and takes the **Solo fallback** (releases the slot and dispatches via the existing singleton path). Without this fallback, an isolated request would block for the full `batch_timeout_us` waiting for peers that never arrive — but here the shortcut means a queue of one always self-clears in microseconds.
+2. Concurrent workers serialise on `EngineGuard` (the engine lock that has always protected `run_inference`). With per-inference cost ≈ 3 ms on Pi 5 and ≈ 4.2 ms on Jetson, the window between *worker A releasing its slot and entering* `run_inference` and *worker B arriving at the queue* is ≈ microseconds — orders of magnitude shorter than the inference itself. Two workers virtually never coexist as `PENDING` at the same instant.
+3. The configured 5 ms timer flush can only fire when at least one waiter is sitting in the queue. Because of (1) and (2), no waiters accumulate.
+
+Together these mean batched dispatch is **structurally bounded by the engine lock** in the small-model + CPU regime. Throughput peaks at the single-thread engine rate (≈ 331 req/s Pi 5, ≈ 239 req/s Jetson) regardless of N; additional workers stack as latency, not throughput.
+
+**This is not a bug — it is the realistic characterisation that 55d was specifically asked to capture.** The dispatcher is correct (every QEMU regression test passes, the timer-flush path is exercised by a deterministic test in `rust_batch_inference_test`), and the infrastructure is in place. Workloads that would actually benefit are:
+
+- **Larger per-call setup that amortises across a batch.** Transformer attention layers, multi-MB Gemm operations, or quantised inference paths whose dequant/setup cost is per-call rather than per-element.
+- **Routing batched dispatches through a GPU fast path.** The current GPU MNIST handoff is `input_len == 784` only. A batched GPU dispatch would amortise channel set-up, doorbell, and PCI write overhead over N samples — the largest potential win.
+- **A lock-free or coarser-grained engine path** so multiple workers can land in `PENDING` together. `EngineGuard` is the bottleneck today; the parent issue notes that batching naturally reduces lock contention by holding the lock for one large call instead of N small ones — but only if the batch actually forms before the lock is acquired, which it doesn't with the current Solo fallback.
+
+The capstone report should reference this section as "the batched dispatch mode is implemented and characterised end-to-end; on the MNIST + CPU workload the engine lock dominates, so the option-space addition is the deliverable, not a throughput win." Per the exploratory-OS framing (#848), an unswapped option is still a valid contribution.
+
+---
+
 ## Test Suite Performance
 
 | Platform | Tests | Pass | Fail | Time |

--- a/docs/lua.md
+++ b/docs/lua.md
@@ -192,6 +192,10 @@ without a compile-time guard.
 | `slm.model_pin(index)` | Admin surface only. Pin a model to prevent LRU eviction. Returns 0 on success, -1 on error. |
 | `slm.model_unpin(index)` | Admin surface only. Unpin a model (allow LRU eviction). Returns 0 on success, -1 on error. |
 | `slm.infer_stats()` | Cumulative inference statistics: `{total, total_ns, min_ns, max_ns, last_ns, errors}`. |
+| `slm.infer_batch_status()` | Dynamic-batching dispatcher snapshot: `{enabled, batch_size, timeout_us, queue_depth, total_submitted, completed, failed, batches_dispatched, batches_full, batches_timeout, bypassed_deadline, singleton_dispatches}`. Read-only; safe surface. |
+| `slm.infer_batch_mode(s)` | Admin surface only. `s = "on"` enables batched dispatch; `"off"` disables (default). Returns the resulting mode as a boolean. SLM-OS exposes batching as a runtime-toggleable option (#848); the default is OFF — flip it on for multi-tenant inference workloads. |
+| `slm.infer_batch_config({size=N, timeout_us=T})` | Admin surface only. Configure the batch-size threshold (1..32, default 8) and the partial-batch flush timeout (100..100000 µs, default 5000). Returns `{size, timeout_us}` reflecting the actually-applied values (out-of-range inputs clamp to the nearest bound). Either field may be omitted to keep the current value. |
+| `slm.infer_stress(N, iters)` | Admin surface only. Spawn `N` (1..32) concurrent task workers, each calling `submit_inference_sync` against MNIST for `iters` (1..100000) iterations. Returns a results table: `{n_workers, iters_per_worker, success, errors, wall_us, min_us, avg_us, max_us, req_per_s, batches_dispatched, batches_full, batches_timeout, bypassed_deadline, singleton_dispatches}`. MNIST must be loaded first. The exact ratio of batched vs singleton dispatches depends on the current `infer_batch_mode`/`infer_batch_config`. |
 | `slm.gpu_status()` | GPU subsystem info: `{available, name, device, compute_ready, unified_memory, memory_size}`. `.available` is always set; other fields populated when a driver is present. |
 
 ### Hailo NPU (AI HAT+)

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -162,6 +162,10 @@ Hardware control & diagnostics:       # mix of always-available + platform-gated
 | `model pools` | Show weight and workspace memory pool statistics |
 | `model stats` | Show inference performance statistics (latency, throughput, errors) |
 | `model bench <name> [N]` | Benchmark model inference latency (default 10 iterations) |
+| `infer batch on\|off` | Enable/disable runtime batched inference dispatch (default OFF). Per the exploratory-OS framing in #848, batching is a runtime-toggleable mode rather than a default behavior change. |
+| `infer batch config <size> <us>` | Configure batch threshold (1..32) and partial-batch flush timeout in microseconds (100..100000). Defaults: 8 / 5000. |
+| `infer batch status` | Print the dynamic-batching dispatcher state: mode, batch size, timeout, queue depth, and the `SchedulerStats` counter snapshot (`batches_full`, `batches_timeout`, `bypassed_deadline`, `singleton_dispatches`, etc.). |
+| `bench infer-stress N [iters]` | Spawn N concurrent task workers (1..32), each running `iters` MNIST inferences (default 50) against the batched dispatcher. Reports aggregate req/s, min/avg/max per-iteration latency, and the per-run counter deltas. Loads MNIST automatically if not already present. |
 | `gpu use status` | Tabular view of the three GPU consumer toggles (sched, eviction, inference) with last-change timestamps |
 | `gpu use inference <on\|off>` | Master toggle for GPU inference dispatch. Default OFF. On Jetson with `--no-gpu-suspend` kexec + a v6 channel handoff, flipping ON routes the MNIST model through the GA10B fastpath. Other platforms accept the flag but engine still uses CPU NEON. |
 | `gpu use sched <on\|off>` | Master toggle for AI-scheduler GPU dispatch (`ai_mlp` policy). When ON and a sched-MLP v6 handoff is in DRAM (Jetson with `--no-gpu-suspend` kexec + `gpu-kernel-sched-mlp` host helper running pre-kexec), every `ai_mlp_assign_cpu` runs the 4-layer forward on GA10B and falls back to CPU NEON only on dispatch error. Default OFF. Other policies (`heuristic`, `ai_ppo`, `ai_hailo`) ignore the flag. |

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -69,6 +69,7 @@ int cmd_diag(int argc, char **argv);
 int cmd_vmm(int argc, char **argv);
 int cmd_ipc(int argc, char **argv);
 int cmd_model(int argc, char **argv);
+int cmd_infer(int argc, char **argv);
 int cmd_slm(int argc, char **argv);
 int cmd_dtb(int argc, char **argv);
 int cmd_gpu(int argc, char **argv);

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -712,6 +712,78 @@ extern int rust_inference_test(void);
 extern int rust_batch_inference_test(void);
 
 /*
+ * Dynamic-batching admin + stress FFI (#860). All entrypoints are
+ * safe to call from any task context; the shell and Lua bindings
+ * forward to them directly.
+ */
+
+/* Status snapshot — must stay in lockstep with `RustBatchStatus` in
+ * runtime/src/lib.rs. */
+typedef struct {
+    uint32_t enabled;
+    uint32_t batch_size;
+    uint32_t timeout_us;
+    uint32_t queue_depth;
+    uint64_t total_submitted;
+    uint64_t completed;
+    uint64_t failed;
+    uint64_t batches_dispatched;
+    uint64_t batches_full;
+    uint64_t batches_timeout;
+    uint64_t bypassed_deadline;
+    uint64_t singleton_dispatches;
+} RustBatchStatus;
+
+/* Stress workload result — must stay in lockstep with
+ * `RustStressResult` in runtime/src/lib.rs. */
+typedef struct {
+    uint32_t n_workers;
+    uint32_t iters_per_worker;
+    uint64_t success_count;
+    uint64_t error_count;
+    uint64_t wall_ns;
+    uint64_t total_lat_ns;
+    uint64_t min_lat_ns;
+    uint64_t max_lat_ns;
+    uint64_t batches_dispatched;
+    uint64_t batches_full;
+    uint64_t batches_timeout;
+    uint64_t bypassed_deadline;
+    uint64_t singleton_dispatches;
+} RustStressResult;
+
+/* `on != 0` enables batched dispatch; `on == 0` disables. Default OFF. */
+extern void rust_infer_batch_set_mode(int32_t on);
+
+/* Returns 1 if batched dispatch is currently enabled, 0 otherwise. */
+extern int32_t rust_infer_batch_get_mode(void);
+
+/* Configure batch-size threshold + flush timeout. Out-of-range values
+ * clamp to the nearest bound. Returns 0 on success. */
+extern int32_t rust_infer_batch_set_config(uint32_t batch_size, uint32_t timeout_us);
+
+/* Fill `out` with the current batching status snapshot. Returns 0 on
+ * success, -1 if `out` is null. */
+extern int32_t rust_infer_batch_status(RustBatchStatus *out);
+
+/* Reset the SchedulerStats counters. */
+extern void rust_infer_batch_reset_stats(void);
+
+/* Run the concurrent stress workload. Spawns `n_workers` tasks each
+ * running `iters_per_worker` MNIST inferences against the batched
+ * dispatcher, joins, and writes the aggregated result into `out`.
+ *
+ * Returns 0 on success, negative on error:
+ *   -1 — `out` is null, or n_workers/iters out of range
+ *   -2 — MNIST not loaded (call rust_model_load_builtin_mnist first)
+ *   -3 — another stress run is in flight
+ *   -4 — task spawn failure
+ */
+extern int32_t rust_infer_stress_run(uint32_t n_workers,
+                                     uint32_t iters_per_worker,
+                                     RustStressResult *out);
+
+/*
  * Inference statistics structure.
  */
 typedef struct {

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -778,6 +778,7 @@ extern void rust_infer_batch_reset_stats(void);
  *   -2 — MNIST not loaded (call rust_model_load_builtin_mnist first)
  *   -3 — another stress run is in flight
  *   -4 — task spawn failure
+ *   -5 — join deadline exceeded
  */
 extern int32_t rust_infer_stress_run(uint32_t n_workers,
                                      uint32_t iters_per_worker,

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -704,6 +704,14 @@ extern int rust_infer(uint32_t model_index, const float *input_data,
 extern int rust_inference_test(void);
 
 /*
+ * Run dynamic-batching scheduler tests (#857).
+ * Returns: Number of failures (0 = all passed).
+ *
+ * Depends on the embedded MNIST ONNX model — loads it internally.
+ */
+extern int rust_batch_inference_test(void);
+
+/*
  * Inference statistics structure.
  */
 typedef struct {

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -600,6 +600,27 @@ static const struct help_entry help_entries[] = {
         "Displays message queue and shared buffer statistics.\n"
     ),
 
+    HELP_TEXT("infer",
+        "infer - Inference engine admin (dynamic batching)\n"
+        "\n"
+        "Usage:\n"
+        "  infer batch on                        Enable batched dispatch\n"
+        "  infer batch off                       Disable (default)\n"
+        "  infer batch config <size> <us>        Set batch threshold + flush timeout\n"
+        "  infer batch status                    Show batching state + counters\n"
+        "\n"
+        "Default at boot is OFF. With batching ON, concurrent inference\n"
+        "requests are collected into a batch of up to <size> (default 8)\n"
+        "and dispatched together via a single engine call once the queue\n"
+        "fills or <us> microseconds (default 5000) elapse since the first\n"
+        "request landed. Requests carrying a tight `TaskDeadline` bypass\n"
+        "the queue and dispatch as singletons. SLM-OS is an exploratory\n"
+        "OS — batching is a runtime-toggleable mode, not a default.\n"
+        "\n"
+        "See `bench infer-stress N [iters]` for the concurrent workload\n"
+        "that exercises the feature.\n"
+    ),
+
     HELP_TEXT("model",
         "model - Model registry and inference control\n"
         "\n"

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -3242,6 +3242,169 @@ static int l_infer_stats(lua_State *L) {
 }
 
 /**
+ * slm.infer_batch_status() — Read-only snapshot of the dynamic-batching
+ * dispatcher (#860). Returns table:
+ *   {enabled, batch_size, timeout_us, queue_depth,
+ *    total_submitted, completed, failed,
+ *    batches_dispatched, batches_full, batches_timeout,
+ *    bypassed_deadline, singleton_dispatches}
+ *
+ * Returns nil on error.
+ */
+static int l_infer_batch_status(lua_State *L) {
+    if (!L) return 0;
+    RustBatchStatus s;
+    if (rust_infer_batch_status(&s) != 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_createtable(L, 0, 12);
+    lua_pushboolean(L, s.enabled != 0);  lua_setfield(L, -2, "enabled");
+    lua_pushinteger(L, (lua_Integer)s.batch_size);
+    lua_setfield(L, -2, "batch_size");
+    lua_pushinteger(L, (lua_Integer)s.timeout_us);
+    lua_setfield(L, -2, "timeout_us");
+    lua_pushinteger(L, (lua_Integer)s.queue_depth);
+    lua_setfield(L, -2, "queue_depth");
+    lua_pushinteger(L, (lua_Integer)s.total_submitted);
+    lua_setfield(L, -2, "total_submitted");
+    lua_pushinteger(L, (lua_Integer)s.completed);
+    lua_setfield(L, -2, "completed");
+    lua_pushinteger(L, (lua_Integer)s.failed);
+    lua_setfield(L, -2, "failed");
+    lua_pushinteger(L, (lua_Integer)s.batches_dispatched);
+    lua_setfield(L, -2, "batches_dispatched");
+    lua_pushinteger(L, (lua_Integer)s.batches_full);
+    lua_setfield(L, -2, "batches_full");
+    lua_pushinteger(L, (lua_Integer)s.batches_timeout);
+    lua_setfield(L, -2, "batches_timeout");
+    lua_pushinteger(L, (lua_Integer)s.bypassed_deadline);
+    lua_setfield(L, -2, "bypassed_deadline");
+    lua_pushinteger(L, (lua_Integer)s.singleton_dispatches);
+    lua_setfield(L, -2, "singleton_dispatches");
+    return 1;
+}
+
+/**
+ * slm.infer_batch_mode("on"|"off") — admin toggle for batched
+ * dispatch. Returns the resulting mode as a boolean.
+ */
+static int l_infer_batch_mode(lua_State *L) {
+    if (!L) return 0;
+    const char *arg = luaL_checkstring(L, 1);
+    int on = 0;
+    if (strcmp(arg, "on") == 0) {
+        on = 1;
+    } else if (strcmp(arg, "off") != 0) {
+        return luaL_error(L, "infer_batch_mode: argument must be 'on' or 'off'");
+    }
+    rust_infer_batch_set_mode(on);
+    lua_pushboolean(L, rust_infer_batch_get_mode() != 0);
+    return 1;
+}
+
+/**
+ * slm.infer_batch_config({size=N, timeout_us=T}) — configure batch
+ * threshold and partial-batch timeout. Out-of-range values clamp to
+ * the nearest accepted bound: size to [1, 32], timeout_us to
+ * [100, 100000]. Returns the applied table.
+ */
+static int l_infer_batch_config(lua_State *L) {
+    if (!L) return 0;
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_getfield(L, 1, "size");
+    lua_Integer size = luaL_optinteger(L, -1, 0);
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "timeout_us");
+    lua_Integer timeout = luaL_optinteger(L, -1, 0);
+    lua_pop(L, 1);
+
+    /* Read current config; only overwrite fields the caller supplied. */
+    RustBatchStatus cur;
+    rust_infer_batch_status(&cur);
+    uint32_t new_size = (size > 0) ? (uint32_t)size : cur.batch_size;
+    uint32_t new_timeout = (timeout > 0) ? (uint32_t)timeout : cur.timeout_us;
+    rust_infer_batch_set_config(new_size, new_timeout);
+
+    RustBatchStatus after;
+    rust_infer_batch_status(&after);
+    lua_createtable(L, 0, 2);
+    lua_pushinteger(L, (lua_Integer)after.batch_size);
+    lua_setfield(L, -2, "size");
+    lua_pushinteger(L, (lua_Integer)after.timeout_us);
+    lua_setfield(L, -2, "timeout_us");
+    return 1;
+}
+
+/**
+ * slm.infer_stress(N, iters) — spawn N concurrent task workers, each
+ * running `iters` MNIST inferences against the batched dispatcher.
+ * Returns a table with the aggregated stress result, or nil on error.
+ *
+ *   {n_workers, iters_per_worker, success, errors,
+ *    wall_us, min_us, avg_us, max_us, req_per_s,
+ *    batches_dispatched, batches_full, batches_timeout,
+ *    bypassed_deadline, singleton_dispatches}
+ */
+static int l_infer_stress(lua_State *L) {
+    if (!L) return 0;
+    lua_Integer n = luaL_checkinteger(L, 1);
+    lua_Integer iters = luaL_optinteger(L, 2, 50);
+    if (n <= 0 || n > 32 || iters <= 0 || iters > 100000) {
+        return luaL_error(L, "infer_stress: N must be 1..32, iters 1..100000");
+    }
+    RustStressResult r;
+    int32_t rc = rust_infer_stress_run((uint32_t)n, (uint32_t)iters, &r);
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushinteger(L, rc);
+        return 2;
+    }
+
+    lua_Integer success = (lua_Integer)r.success_count;
+    lua_Integer wall_us = (lua_Integer)(r.wall_ns / 1000);
+    lua_Integer avg_us = (success > 0)
+        ? (lua_Integer)((r.total_lat_ns / (uint64_t)success) / 1000)
+        : 0;
+    lua_Integer req_per_s = (r.wall_ns > 0)
+        ? (lua_Integer)((r.success_count * 1000000000ULL) / r.wall_ns)
+        : 0;
+
+    lua_createtable(L, 0, 14);
+    lua_pushinteger(L, (lua_Integer)r.n_workers);
+    lua_setfield(L, -2, "n_workers");
+    lua_pushinteger(L, (lua_Integer)r.iters_per_worker);
+    lua_setfield(L, -2, "iters_per_worker");
+    lua_pushinteger(L, success);
+    lua_setfield(L, -2, "success");
+    lua_pushinteger(L, (lua_Integer)r.error_count);
+    lua_setfield(L, -2, "errors");
+    lua_pushinteger(L, wall_us);
+    lua_setfield(L, -2, "wall_us");
+    lua_pushinteger(L, (lua_Integer)(r.min_lat_ns / 1000));
+    lua_setfield(L, -2, "min_us");
+    lua_pushinteger(L, avg_us);
+    lua_setfield(L, -2, "avg_us");
+    lua_pushinteger(L, (lua_Integer)(r.max_lat_ns / 1000));
+    lua_setfield(L, -2, "max_us");
+    lua_pushinteger(L, req_per_s);
+    lua_setfield(L, -2, "req_per_s");
+    lua_pushinteger(L, (lua_Integer)r.batches_dispatched);
+    lua_setfield(L, -2, "batches_dispatched");
+    lua_pushinteger(L, (lua_Integer)r.batches_full);
+    lua_setfield(L, -2, "batches_full");
+    lua_pushinteger(L, (lua_Integer)r.batches_timeout);
+    lua_setfield(L, -2, "batches_timeout");
+    lua_pushinteger(L, (lua_Integer)r.bypassed_deadline);
+    lua_setfield(L, -2, "bypassed_deadline");
+    lua_pushinteger(L, (lua_Integer)r.singleton_dispatches);
+    lua_setfield(L, -2, "singleton_dispatches");
+    return 1;
+}
+
+/**
  * slm.gpu_status() - Get GPU subsystem status
  * Returns table: {available, name, device, compute_ready, unified_memory, memory_size}
  */
@@ -4377,6 +4540,8 @@ static const luaL_Reg slm_lib_safe[] = {
     {"model_list", l_model_list},
     {"model_info", l_model_info},
     {"infer_stats", l_infer_stats},
+    /* Dynamic batching — read-only status (#860). */
+    {"infer_batch_status", l_infer_batch_status},
     {"gpu_status", l_gpu_status},
     /* Shell integration */
     {"read_line", l_read_line},
@@ -4416,6 +4581,10 @@ static const luaL_Reg slm_lib_admin[] = {
     {"gpu_use_set", l_gpu_use_set},
     /* Admin & telemetry suite (M5) — model launch (instantiates) */
     {"model_launch", l_model_launch},
+    /* Dynamic batching admin (#860). */
+    {"infer_batch_mode", l_infer_batch_mode},
+    {"infer_batch_config", l_infer_batch_config},
+    {"infer_stress", l_infer_stress},
     /* Scheduler / task mutation */
     {"sched_set_policy", l_sched_set_policy},
     {"task_migrate", l_task_migrate},

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -124,6 +124,7 @@ const shell_cmd_t builtin_commands[] = {
     /* --- Process / scheduling / AI runtime --- */
     {"bench",    cmd_bench,    "Performance benchmarks (bench <context|irq|ipc|stats|all>)", true, SHELL_CAT_PROCESS},
     {"eviction", cmd_eviction, "AI eviction (eviction [policy [<name>] | stats])",          true, SHELL_CAT_PROCESS},
+    {"infer",    cmd_infer,    "Inference engine (infer batch <on|off|config|status>)",    true, SHELL_CAT_PROCESS},
     {"kill",     cmd_kill,     "Terminate a task by ID",                                    true, SHELL_CAT_PROCESS},
 #if !defined(PLATFORM_X86_64)
     {"mmaptest", cmd_mmaptest, "Run the EL0 sys_mmap/munmap smoke task (mmap follow-up)",   false, SHELL_CAT_PROCESS},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1415,7 +1415,7 @@ static void s3_steal_work_task(void *arg)
 int cmd_bench(int argc, char *argv[])
 {
     if (argc < 2) {
-        shell_puts("Usage: bench <context|irq|ipc|eviction|deadline|isolate|shared|smp|stealing|matmul|conv|quant|q4kdot|gpu|stats|all>\r\n");
+        shell_puts("Usage: bench <context|irq|ipc|eviction|deadline|isolate|shared|smp|stealing|matmul|conv|quant|q4kdot|gpu|infer-stress|stats|all>\r\n");
         return 1;
     }
 
@@ -1814,6 +1814,98 @@ int cmd_bench(int argc, char *argv[])
     } else if (strcmp(argv[1], "sched-policy") == 0) {
         bench_sched_policy();
 #endif
+    } else if (strcmp(argv[1], "infer-stress") == 0) {
+        /* Concurrent inference stress workload (#860).
+         *
+         * Usage: bench infer-stress N [iters]
+         *
+         *   N       — number of concurrent task workers (1..32).
+         *   iters   — inferences per worker (default 50).
+         *
+         * Exercises the dynamic-batching dispatcher with N workers
+         * sharing a single MNIST model. The exact ratio of batched
+         * vs singleton dispatches depends on the runtime mode (`infer
+         * batch on|off`) and the configured batch size. Reports
+         * aggregate req/s, min/avg/max latency, and the
+         * SchedulerStats counter deltas captured around the run.
+         */
+        uint32_t n_workers = 0;
+        uint32_t iters = 50;
+        if (argc < 3 || shell_parse_uint(argv[2], &n_workers) != 0
+            || n_workers == 0 || n_workers > 32) {
+            shell_puts("Usage: bench infer-stress <N (1..32)> [iters]\r\n");
+            return 1;
+        }
+        if (argc >= 4) {
+            uint32_t n;
+            if (shell_parse_uint(argv[3], &n) == 0 && n > 0 && n <= 100000) {
+                iters = n;
+            }
+        }
+
+        /* Ensure MNIST is loaded — the stress runner refuses without it. */
+        int mnist_idx = rust_model_find("mnist");
+        if (mnist_idx < 0) {
+            shell_puts("Loading MNIST...\r\n");
+            mnist_idx = rust_model_load_builtin_mnist();
+            if (mnist_idx < 0) {
+                shell_puts("  FAILED to load MNIST — cannot run stress\r\n");
+                return 1;
+            }
+        }
+
+        shell_puts("Dynamic Batching Stress Workload\r\n");
+        shell_puts("================================\r\n");
+        RustBatchStatus pre_status;
+        rust_infer_batch_status(&pre_status);
+        shell_printf("  Batching mode: %s\r\n", pre_status.enabled ? "ON" : "off");
+        if (pre_status.enabled) {
+            shell_printf("  Batch size:    %u\r\n", pre_status.batch_size);
+            shell_printf("  Timeout:       %u us\r\n", pre_status.timeout_us);
+        }
+        shell_printf("  Workers:       %u  Iters/worker: %u\r\n", n_workers, iters);
+
+        RustStressResult res;
+        int32_t rc = rust_infer_stress_run(n_workers, iters, &res);
+        if (rc != 0) {
+            shell_printf("  Stress run failed: rc=%d\r\n", (int)rc);
+            return 1;
+        }
+
+        uint64_t completed = res.success_count;
+        uint64_t total_iter = (uint64_t)res.n_workers * (uint64_t)res.iters_per_worker;
+        unsigned long min_us = (unsigned long)(res.min_lat_ns / 1000);
+        unsigned long max_us = (unsigned long)(res.max_lat_ns / 1000);
+        unsigned long avg_us = completed > 0
+            ? (unsigned long)((res.total_lat_ns / completed) / 1000)
+            : 0;
+        unsigned long wall_us = (unsigned long)(res.wall_ns / 1000);
+        unsigned long req_per_s = res.wall_ns > 0
+            ? (unsigned long)((completed * 1000000000ULL) / res.wall_ns)
+            : 0;
+
+        shell_puts("\r\nResults:\r\n");
+        shell_printf("  Successful infers: %lu / %lu\r\n",
+                    (unsigned long)completed, (unsigned long)total_iter);
+        if (res.error_count > 0) {
+            shell_printf("  Errors:            %lu\r\n",
+                        (unsigned long)res.error_count);
+        }
+        shell_printf("  Wall time:         %lu us\r\n", wall_us);
+        shell_printf("  Aggregate req/s:   %lu\r\n", req_per_s);
+        shell_printf("  Per-iter latency:  min=%lu us  avg=%lu us  max=%lu us\r\n",
+                    min_us, avg_us, max_us);
+        shell_puts("\r\nCounter deltas (this run):\r\n");
+        shell_printf("  batches_dispatched: %lu\r\n",
+                    (unsigned long)res.batches_dispatched);
+        shell_printf("  batches_full:       %lu  (size-threshold)\r\n",
+                    (unsigned long)res.batches_full);
+        shell_printf("  batches_timeout:    %lu  (timer flush)\r\n",
+                    (unsigned long)res.batches_timeout);
+        shell_printf("  bypassed_deadline:  %lu\r\n",
+                    (unsigned long)res.bypassed_deadline);
+        shell_printf("  singleton_dispatches: %lu\r\n",
+                    (unsigned long)res.singleton_dispatches);
     } else if (strcmp(argv[1], "all") == 0) {
         shell_puts("SLM-OS Performance Benchmarks\r\n");
         shell_puts("=============================\r\n\r\n");
@@ -1832,7 +1924,7 @@ int cmd_bench(int argc, char *argv[])
         bench_sched_stats();
     } else {
         shell_printf("Unknown benchmark: %s\r\n", argv[1]);
-        shell_puts("Available: context, irq, ipc, deadline, isolate, shared, smp, gpu, sched-policy, stats, all\r\n");
+        shell_puts("Available: context, irq, ipc, deadline, isolate, shared, smp, gpu, sched-policy, infer-stress, stats, all\r\n");
         return 1;
     }
 
@@ -2967,6 +3059,92 @@ static int model_infer(int argc, char *argv[])
     }
 
     return 0;
+}
+
+/*
+ * `infer batch on|off|config <size> <timeout_us>|status` — admin
+ * toggle for the dynamic-batching dispatcher (#860).
+ *
+ * Default at boot is OFF. Flip on for a multi-tenant inference
+ * workload (e.g., `bench infer-stress`) and back off to restore the
+ * historical singleton-dispatch behaviour.
+ */
+int cmd_infer(int argc, char *argv[])
+{
+    if (argc < 2 || strcmp(argv[1], "batch") != 0) {
+        shell_puts("Usage: infer batch <on|off|config <size> <timeout_us>|status>\r\n");
+        return 1;
+    }
+    if (argc < 3) {
+        shell_puts("Usage: infer batch <on|off|config <size> <timeout_us>|status>\r\n");
+        return 1;
+    }
+
+    const char *sub = argv[2];
+
+    if (strcmp(sub, "on") == 0) {
+        rust_infer_batch_set_mode(1);
+        shell_puts("infer batch: ON\r\n");
+        return 0;
+    }
+    if (strcmp(sub, "off") == 0) {
+        rust_infer_batch_set_mode(0);
+        shell_puts("infer batch: off\r\n");
+        return 0;
+    }
+    if (strcmp(sub, "config") == 0) {
+        if (argc < 5) {
+            shell_puts("Usage: infer batch config <size (1..32)> <timeout_us (100..100000)>\r\n");
+            return 1;
+        }
+        uint32_t size, timeout;
+        if (shell_parse_uint(argv[3], &size) != 0 || size == 0 || size > 32) {
+            shell_puts("infer batch config: size must be 1..32\r\n");
+            return 1;
+        }
+        if (shell_parse_uint(argv[4], &timeout) != 0
+            || timeout < 100 || timeout > 100000) {
+            shell_puts("infer batch config: timeout_us must be 100..100000\r\n");
+            return 1;
+        }
+        rust_infer_batch_set_config(size, timeout);
+        shell_printf("infer batch config: size=%u timeout_us=%u\r\n", size, timeout);
+        return 0;
+    }
+    if (strcmp(sub, "status") == 0) {
+        RustBatchStatus s;
+        if (rust_infer_batch_status(&s) != 0) {
+            shell_puts("infer batch status: failed\r\n");
+            return 1;
+        }
+        shell_puts("Dynamic Batching Status\r\n");
+        shell_puts("=======================\r\n");
+        shell_printf("  Mode:                  %s\r\n", s.enabled ? "ON" : "off");
+        shell_printf("  Batch size:            %u\r\n", s.batch_size);
+        shell_printf("  Timeout:               %u us\r\n", s.timeout_us);
+        shell_printf("  Queue depth:           %u\r\n", s.queue_depth);
+        shell_puts("  Counters (since reset):\r\n");
+        shell_printf("    total_submitted:     %lu\r\n",
+                    (unsigned long)s.total_submitted);
+        shell_printf("    completed:           %lu\r\n",
+                    (unsigned long)s.completed);
+        shell_printf("    failed:              %lu\r\n",
+                    (unsigned long)s.failed);
+        shell_printf("    batches_dispatched:  %lu\r\n",
+                    (unsigned long)s.batches_dispatched);
+        shell_printf("    batches_full:        %lu\r\n",
+                    (unsigned long)s.batches_full);
+        shell_printf("    batches_timeout:     %lu\r\n",
+                    (unsigned long)s.batches_timeout);
+        shell_printf("    bypassed_deadline:   %lu\r\n",
+                    (unsigned long)s.bypassed_deadline);
+        shell_printf("    singleton_dispatches:%lu\r\n",
+                    (unsigned long)s.singleton_dispatches);
+        return 0;
+    }
+
+    shell_printf("infer batch: unknown subcommand '%s'\r\n", sub);
+    return 1;
 }
 
 int cmd_model(int argc, char *argv[])

--- a/kernel/tests/test_model_loader.c
+++ b/kernel/tests/test_model_loader.c
@@ -233,6 +233,11 @@ int test_suite_inference(void)
     /* Part 1: Rust-side inference tests */
     int failures = rust_inference_test();
 
+    /* Part 1b: Dynamic batching scheduler tests (#857). Runs after
+     * the core inference tests so MNIST is loaded and the engine
+     * warmed up. */
+    failures += rust_batch_inference_test();
+
     /* Part 2: C-side FFI boundary tests */
     UnityBegin("Inference FFI Tests");
 

--- a/runtime/src/inference/engine.rs
+++ b/runtime/src/inference/engine.rs
@@ -290,6 +290,14 @@ impl InferenceEngine {
     /// dispatcher needs — every downstream op (Conv2D, MatMul, Gemm,
     /// Softmax, MaxPool, Reshape) already iterates over `input.dim(0)`
     /// and handles the batch dimension correctly.
+    ///
+    /// ASSUMPTION (load-bearing): every supported model declares the
+    /// batch dimension at index 0 of its first input. The MNIST
+    /// model and every other model SLM-OS loads today follow this
+    /// convention; if a future model puts channels or another
+    /// dimension first, this override silently corrupts the shape.
+    /// Add a per-model "batch_dim_index" property and pass it
+    /// through to break that assumption.
     fn bind_graph_inputs(
         &mut self,
         batch_size: usize,
@@ -324,10 +332,22 @@ impl InferenceEngine {
 
             let tensor = Tensor::new(input, &dims[..ndim]);
 
-            // Verify element count matches the provided buffer.
+            // Verify element count matches the provided buffer. The
+            // `> input_len` check catches under-sized buffers; the
+            // debug_assert pins the stronger invariant that the caller
+            // sized the buffer to exactly `batch_size * per_sample`
+            // elements (oversized buffers technically still work but
+            // are a sign of caller confusion — flag in debug builds).
             if tensor.num_elements() > input_len {
                 return Err(EngineError::InvalidInput);
             }
+            debug_assert_eq!(
+                tensor.num_elements(),
+                input_len,
+                "bind_graph_inputs: input_len ({}) should match batch_size * per_sample ({})",
+                input_len,
+                tensor.num_elements()
+            );
 
             self.bind(*name, tensor);
         }

--- a/runtime/src/inference/engine.rs
+++ b/runtime/src/inference/engine.rs
@@ -240,12 +240,33 @@ impl InferenceEngine {
         output: *mut f32,
         output_len: usize,
     ) -> Result<usize, EngineError> {
+        self.run_batch(1, input, input_len, output, output_len)
+    }
+
+    /// Run inference treating `input` as a stack of `batch_size`
+    /// samples laid out contiguously. Each declared graph input is
+    /// bound with its first dimension overridden to `batch_size`; the
+    /// per-sample element count is `declared_elements / declared_dim0`.
+    ///
+    /// `batch_size == 1` is equivalent to `run()` and is the path the
+    /// existing FFI callers take.
+    pub fn run_batch(
+        &mut self,
+        batch_size: usize,
+        input: *const f32,
+        input_len: usize,
+        output: *mut f32,
+        output_len: usize,
+    ) -> Result<usize, EngineError> {
+        if batch_size == 0 {
+            return Err(EngineError::InvalidInput);
+        }
         // Reset workspace and bindings
         self.workspace.reset();
         self.binding_count = 0;
 
         // Bind graph input(s)
-        self.bind_graph_inputs(input, input_len)?;
+        self.bind_graph_inputs(batch_size, input, input_len)?;
 
         // Bind all weights from the weight table
         self.bind_weights()?;
@@ -260,7 +281,21 @@ impl InferenceEngine {
     }
 
     /// Bind graph input names to the provided input data.
-    fn bind_graph_inputs(&mut self, input: *const f32, input_len: usize) -> Result<(), EngineError> {
+    ///
+    /// When `batch_size > 1`, the first dimension of every graph input
+    /// is overridden from the declared value (usually 1) to
+    /// `batch_size`. The remaining dimensions describe the per-sample
+    /// shape, so `input_len` must equal `batch_size *
+    /// per_sample_elements`. This is the only seam the batched
+    /// dispatcher needs — every downstream op (Conv2D, MatMul, Gemm,
+    /// Softmax, MaxPool, Reshape) already iterates over `input.dim(0)`
+    /// and handles the batch dimension correctly.
+    fn bind_graph_inputs(
+        &mut self,
+        batch_size: usize,
+        input: *const f32,
+        input_len: usize,
+    ) -> Result<(), EngineError> {
         if input.is_null() || input_len == 0 {
             return Err(EngineError::InvalidInput);
         }
@@ -269,16 +304,27 @@ impl InferenceEngine {
             let name = &self.graph.input_names[i];
             let shape = &self.graph.input_shapes[i];
 
-            // Build shape array from TensorShape
+            // Build shape array from TensorShape, overriding dim 0.
             let mut dims = [0u32; 8];
             let ndim = shape.ndim as usize;
             for d in 0..ndim {
                 dims[d] = shape.dims[d];
             }
+            if batch_size > 1 {
+                if ndim == 0 {
+                    return Err(EngineError::ShapeMismatch);
+                }
+                // Override the leading dimension with the actual batch
+                // size. The declared value is typically 1 (training-
+                // time batch dimension) or a dynamic placeholder.
+                let bs_u32: u32 = u32::try_from(batch_size)
+                    .map_err(|_| EngineError::ShapeOverflow)?;
+                dims[0] = bs_u32;
+            }
 
             let tensor = Tensor::new(input, &dims[..ndim]);
 
-            // Verify element count matches
+            // Verify element count matches the provided buffer.
             if tensor.num_elements() > input_len {
                 return Err(EngineError::InvalidInput);
             }
@@ -796,16 +842,56 @@ pub unsafe fn run_inference(
     output: *mut f32,
     output_len: usize,
 ) -> Result<usize, EngineError> {
+    run_inference_inner(model_index, 1, input, input_len, output, output_len)
+}
+
+/// Batched variant of `run_inference`.
+///
+/// Treats the input buffer as `batch_size` samples laid out
+/// contiguously and runs the model's full op pipeline once across the
+/// whole batch. The output buffer receives `batch_size * output_dim`
+/// floats.
+///
+/// The MNIST GPU fast path is single-sample only (its FFI asserts
+/// `input_len == 784`), so batched dispatches always take the CPU
+/// path. This is documented in `docs/architecture.md` and surfaces in
+/// the #858 benchmark matrix.
+///
+/// # Safety
+///
+/// Same preconditions as `run_inference`: buffers are non-null,
+/// 4-byte-aligned, sized to cover `input_len` / `output_len` floats,
+/// and live through the call.
+pub unsafe fn run_inference_batched(
+    model_index: usize,
+    batch_size: usize,
+    input: *const f32,
+    input_len: usize,
+    output: *mut f32,
+    output_len: usize,
+) -> Result<usize, EngineError> {
+    run_inference_inner(model_index, batch_size, input, input_len, output, output_len)
+}
+
+unsafe fn run_inference_inner(
+    model_index: usize,
+    batch_size: usize,
+    input: *const f32,
+    input_len: usize,
+    output: *mut f32,
+    output_len: usize,
+) -> Result<usize, EngineError> {
     let _guard = EngineGuard::new();
 
     // Pin the weight block for the duration of the call. If a
     // concurrent `unload` or `swap_model` retargets the registry slot
     // mid-flight, the OLD weight block stays allocated until this
     // lease drops at function exit — no torn reads, no use-after-free.
+    //
+    // EngineGuard releases ENGINE_LOCK on Drop, so we just return.
     let _weight_lease = match registry::WeightLease::acquire(model_index) {
         Some(l) => l,
         None => {
-            engine_unlock();
             record_error();
             return Err(EngineError::ModelNotFound);
         }
@@ -813,12 +899,13 @@ pub unsafe fn run_inference(
 
     let start = kernel_ffi::get_time_ns();
 
-    // GPU fast path: when the active model is "mnist" and the GPU
-    // is compute-ready, route the whole graph through the v6 handoff
-    // SLM-OS already pre-uploaded. Falls through to the CPU path on
-    // any error so the user still gets an answer.
+    // GPU fast path: when the active model is "mnist", the GPU is
+    // compute-ready, and the call is a single MNIST sample, route the
+    // whole graph through the v6 handoff. Batched dispatches always
+    // take the CPU path because the GPU FFI's input slot is sized for
+    // exactly one 1×1×28×28 sample.
     let result: Result<usize, EngineError>;
-    if mnist_gpu_fastpath_eligible(model_index) {
+    if batch_size == 1 && mnist_gpu_fastpath_eligible(model_index) {
         // Successful dispatch is the steady-state happy path; logging
         // it every iteration drowns the console at >1 inf/s. The
         // failure path is rare and operator-actionable, so it stays.
@@ -841,7 +928,7 @@ pub unsafe fn run_inference(
     result = unsafe {
         let engine = &mut *ENGINE.get();
         match engine.init(model_index) {
-            Ok(()) => engine.run(input, input_len, output, output_len),
+            Ok(()) => engine.run_batch(batch_size, input, input_len, output, output_len),
             Err(e) => Err(e),
         }
     };

--- a/runtime/src/inference/mod.rs
+++ b/runtime/src/inference/mod.rs
@@ -32,4 +32,7 @@ pub mod gpu_slm;
 
 pub use tensor::Tensor;
 pub use workspace::BumpAllocator;
-pub use engine::{InferenceEngine, EngineError, InferenceStats, run_inference, get_stats};
+pub use engine::{
+    InferenceEngine, EngineError, InferenceStats, run_inference,
+    run_inference_batched, get_stats,
+};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7351,6 +7351,94 @@ pub extern "C" fn rust_batch_inference_test() -> i32 {
         sched::set_batch_size(8); // reset to default
     }
 
+    // Test 7 (#859): deadline-aware bypass. A request whose remaining
+    // slack is below `batch_timeout_us` skips the queue entirely and
+    // dispatches as a singleton, trip `bypassed_deadline` once.
+    {
+        sched::set_batching_enabled(true);
+        sched::set_batch_size(8);
+        sched::set_batch_timeout_us(5_000); // 5 ms
+        sched::reset_scheduler_stats();
+
+        // 1 ms slack < 5 ms timeout → must bypass.
+        let tight = sched::TaskDeadline::inference_latency_ms(1);
+        let mut out = [0.0f32; 64];
+        let n = unsafe {
+            sched::submit_inference_sync(
+                model_index as usize,
+                INPUT_A.as_ptr(), INPUT_A.len(),
+                out.as_mut_ptr(), out.len(),
+                tight,
+            ).unwrap_or(0)
+        };
+        let stats = sched::scheduler_stats();
+        let correct = n == na && bit_equal(&out[..n], &baseline_a[..na]);
+        let counted = stats.bypassed_deadline == 1
+            && stats.singleton_dispatches == 1
+            && stats.batches_dispatched == 0
+            && stats.queued == 0;
+        let passed = correct && counted;
+        print_test_result(b"batch: tight deadline -> bypass + singleton dispatch\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 8 (#859): timer-driven partial-batch flush. Inject one
+    // PENDING peer slot, then submit a real request from this thread.
+    // The submitter enters Role::Waiter (count=2 < batch_size=8) and
+    // wins the timer-flush claim once `batch_timeout_us` elapses; it
+    // becomes the dispatcher of both slots in a single batched call.
+    {
+        sched::set_batching_enabled(true);
+        sched::set_batch_size(8);
+        // Short timeout so the test finishes quickly. Hits the lower
+        // clamp at 100 us.
+        sched::set_batch_timeout_us(100);
+        sched::reset_scheduler_stats();
+
+        // Peer slot: takes INPUT_B and writes into peer_out. Buffers
+        // must stay live until the dispatch completes.
+        let mut peer_out = [0.0f32; 64];
+        let peer_idx = unsafe {
+            sched::inject_pending_slot_for_test(
+                model_index as usize,
+                INPUT_B.as_ptr(), INPUT_B.len(),
+                peer_out.as_mut_ptr(), peer_out.len(),
+            )
+        };
+        let injected = peer_idx.is_some();
+
+        let mut out = [0.0f32; 64];
+        let n = if injected {
+            unsafe {
+                sched::submit_inference_sync(
+                    model_index as usize,
+                    INPUT_A.as_ptr(), INPUT_A.len(),
+                    out.as_mut_ptr(), out.len(),
+                    sched::TaskDeadline::NONE,
+                ).unwrap_or(0)
+            }
+        } else { 0 };
+
+        // After dispatch our slot is IDLE; the peer slot is DONE_OK
+        // (the dispatcher signals it via the mailbox). Drain it.
+        let peer_n = if let Some(pi) = peer_idx {
+            unsafe { sched::drain_slot_for_test(pi).unwrap_or(0) }
+        } else { 0 };
+
+        let stats = sched::scheduler_stats();
+        let correct_main = n == na && bit_equal(&out[..n], &baseline_a[..na]);
+        let correct_peer = peer_n == nb && bit_equal(&peer_out[..peer_n], &baseline_b[..nb]);
+        let counted = stats.batches_timeout == 1
+            && stats.batches_full == 0
+            && stats.batches_dispatched == 1;
+        let passed = injected && correct_main && correct_peer && counted;
+        print_test_result(b"batch: timer flush dispatches partial batch via batched engine\0", passed);
+        if !passed { failures += 1; }
+
+        sched::set_batching_enabled(false);
+        sched::set_batch_timeout_us(5_000); // restore default
+    }
+
     // Summary
     unsafe {
         if failures == 0 {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5813,6 +5813,7 @@ extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
 ///  -2 — MNIST not loaded
 ///  -3 — stress workload already running
 ///  -4 — task spawn failure
+///  -5 — join deadline exceeded (workers didn't finish in time)
 ///
 /// # Safety
 ///
@@ -5885,15 +5886,29 @@ pub unsafe extern "C" fn rust_infer_stress_run(
     }
 
     // Join: spin-yield until all spawned workers signal done.
-    // The yield budget is generous — each worker runs
-    // `iters_per_worker` MNIST inferences (~1 ms each on QEMU CPU).
+    //
+    // Generous deadline so a regression in the dispatcher can't hang
+    // the shell forever: 30 s of headroom plus an iteration budget
+    // (one second per 10 iterations on top, which fits MNIST's
+    // ~1 ms/inference on QEMU and the ~3 ms/inference worst case on
+    // Pi 5/Jetson without batching). On timeout we return -5 so the
+    // operator can recover; in-flight workers will still finish and
+    // signal the busy guard, but `out` won't be populated.
+    let join_deadline_ns = kernel_ffi::get_time_ns().saturating_add(
+        30_000_000_000u64.saturating_add(
+            (iters_per_worker as u64).saturating_mul(100_000_000), // 100 ms/iter
+        ),
+    );
+    extern "C" {
+        #[link_name = "yield"]
+        fn sched_yield();
+    }
     loop {
         if STRESS_WORKERS_DONE.load(Ordering::Acquire) >= spawned {
             break;
         }
-        extern "C" {
-            #[link_name = "yield"]
-            fn sched_yield();
+        if kernel_ffi::get_time_ns() >= join_deadline_ns {
+            return -5;
         }
         sched_yield();
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7307,8 +7307,13 @@ pub extern "C" fn rust_batch_inference_test() -> i32 {
         };
         let stats = sched::scheduler_stats();
         let same = n == nb && bit_equal(&out[..n], &baseline_b[..nb]);
+        // Stronger than the surface "batches_dispatched == 0": also
+        // pin `batches_full == 0` so a future regression that lets
+        // Solo accidentally enter `run_dispatcher` is caught even if
+        // it didn't bump the umbrella counter.
         let counted = stats.singleton_dispatches == 1
             && stats.batches_dispatched == 0
+            && stats.batches_full == 0
             && stats.total_submitted == 1
             && stats.queued == 0;
         let passed = same && counted;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5607,6 +5607,321 @@ pub unsafe extern "C" fn rust_slm_stats(session_id: u32, out: *mut SlmStatsC) ->
 }
 
 // =============================================================================
+// Dynamic-batching admin + stress FFI (#860)
+// =============================================================================
+
+/// Status snapshot exposed via `rust_infer_batch_status` to the C
+/// shell + Lua bindings.
+///
+/// Field order is part of the FFI contract — extending this struct
+/// requires updating `kernel/include/slm_ffi.h` in lockstep.
+#[repr(C)]
+pub struct RustBatchStatus {
+    /// Non-zero when batched dispatch is currently enabled.
+    pub enabled: u32,
+    /// Configured batch-size threshold (clamped to [1, MAX_BATCH]).
+    pub batch_size: u32,
+    /// Configured partial-batch flush timeout (microseconds).
+    pub timeout_us: u32,
+    /// Current pending queue depth.
+    pub queue_depth: u32,
+    /// Total requests submitted since boot (or last reset).
+    pub total_submitted: u64,
+    /// Successful completions.
+    pub completed: u64,
+    /// Engine errors.
+    pub failed: u64,
+    /// Total batched dispatches (size + timeout).
+    pub batches_dispatched: u64,
+    /// Batched dispatches triggered by hitting the size threshold.
+    pub batches_full: u64,
+    /// Batched dispatches triggered by the partial-batch timer.
+    pub batches_timeout: u64,
+    /// Requests that bypassed the queue due to a tight deadline.
+    pub bypassed_deadline: u64,
+    /// Requests that fell through to the singleton path.
+    pub singleton_dispatches: u64,
+}
+
+/// Toggle batched dispatch mode.
+///
+/// `on == 0` disables (default); any non-zero enables.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_set_mode(on: i32) {
+    sched::set_batching_enabled(on != 0);
+}
+
+/// Read the current batched-dispatch mode (1 = on, 0 = off).
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_get_mode() -> i32 {
+    if sched::batching_enabled() { 1 } else { 0 }
+}
+
+/// Configure batch size + timeout.
+///
+/// Bounds: `1 ≤ batch_size ≤ MAX_BATCH`, `100 µs ≤ timeout_us ≤ 100_000 µs`
+/// (out-of-range values clamp to the nearest bound). Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_set_config(batch_size: u32, timeout_us: u32) -> i32 {
+    sched::set_batch_size(batch_size as usize);
+    sched::set_batch_timeout_us(timeout_us.min(100_000));
+    0
+}
+
+/// Fill `out` with the current batching status snapshot.
+///
+/// Returns 0 on success, -1 if `out` is null.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_status(out: *mut RustBatchStatus) -> i32 {
+    if out.is_null() {
+        return -1;
+    }
+    let s = sched::scheduler_stats();
+    let status = RustBatchStatus {
+        enabled: if sched::batching_enabled() { 1 } else { 0 },
+        batch_size: sched::batch_size() as u32,
+        timeout_us: sched::batch_timeout_us(),
+        queue_depth: s.queued as u32,
+        total_submitted: s.total_submitted,
+        completed: s.completed,
+        failed: s.failed,
+        batches_dispatched: s.batches_dispatched,
+        batches_full: s.batches_full,
+        batches_timeout: s.batches_timeout,
+        bypassed_deadline: s.bypassed_deadline,
+        singleton_dispatches: s.singleton_dispatches,
+    };
+    unsafe { *out = status; }
+    0
+}
+
+/// Reset the scheduler stats counters. Useful before a stress run so
+/// the post-run snapshot reflects only that run's activity.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_reset_stats() {
+    sched::reset_scheduler_stats();
+}
+
+// -----------------------------------------------------------------------------
+// Stress workload — spawn N worker tasks each running M iterations
+// of `submit_inference_sync` against MNIST. Exercises the batched
+// dispatch path end-to-end (the OS has no other concurrent inference
+// call site today).
+// -----------------------------------------------------------------------------
+
+#[repr(C)]
+pub struct RustStressResult {
+    /// N workers actually spawned.
+    pub n_workers: u32,
+    /// Iterations per worker requested by the caller.
+    pub iters_per_worker: u32,
+    /// Total successful inferences across all workers.
+    pub success_count: u64,
+    /// Total failed inferences across all workers.
+    pub error_count: u64,
+    /// Wall-clock time the stress run took, in nanoseconds (from the
+    /// first worker spawn to the last worker completion).
+    pub wall_ns: u64,
+    /// Sum of per-iteration latencies across all workers, nanoseconds.
+    pub total_lat_ns: u64,
+    /// Minimum observed per-iteration latency, nanoseconds.
+    pub min_lat_ns: u64,
+    /// Maximum observed per-iteration latency, nanoseconds.
+    pub max_lat_ns: u64,
+    /// Counter deltas captured between pre-run and post-run snapshots.
+    pub batches_dispatched: u64,
+    pub batches_full: u64,
+    pub batches_timeout: u64,
+    pub bypassed_deadline: u64,
+    pub singleton_dispatches: u64,
+}
+
+// Stress workload shared state — file-static atomics. The stress
+// workload is single-run at a time (the shell + Lua entry points
+// serialise via the global `STRESS_BUSY` flag).
+static STRESS_BUSY: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static STRESS_WORKERS_DONE: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+static STRESS_ITERS_PER_WORKER: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+static STRESS_MODEL_INDEX: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+static STRESS_SUCCESS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static STRESS_ERROR: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static STRESS_LAT_TOTAL: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static STRESS_LAT_MIN: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(u64::MAX);
+static STRESS_LAT_MAX: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+/// Worker-task entry point. Runs `STRESS_ITERS_PER_WORKER` inferences
+/// against `STRESS_MODEL_INDEX` and signals completion via
+/// `STRESS_WORKERS_DONE`.
+extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
+    use core::sync::atomic::Ordering;
+
+    // Per-worker buffers on this task's stack. INPUT stays uniform —
+    // for stress testing the engine doesn't need varied input; the
+    // counter-update path is what we want to exercise.
+    let input: [f32; 784] = [0.0; 784];
+    let mut output: [f32; 64] = [0.0; 64];
+    let iters = STRESS_ITERS_PER_WORKER.load(Ordering::Acquire);
+    let model_index = STRESS_MODEL_INDEX.load(Ordering::Acquire) as usize;
+
+    for _ in 0..iters {
+        let start = kernel_ffi::get_time_ns();
+        let r = unsafe {
+            sched::submit_inference_sync(
+                model_index,
+                input.as_ptr(), input.len(),
+                output.as_mut_ptr(), output.len(),
+                sched::TaskDeadline::NONE,
+            )
+        };
+        let elapsed = kernel_ffi::get_time_ns().saturating_sub(start);
+        STRESS_LAT_TOTAL.fetch_add(elapsed, Ordering::Relaxed);
+        // min via CAS loop.
+        let mut cur = STRESS_LAT_MIN.load(Ordering::Relaxed);
+        while elapsed < cur {
+            match STRESS_LAT_MIN.compare_exchange_weak(cur, elapsed, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(v) => cur = v,
+            }
+        }
+        // max via CAS loop.
+        cur = STRESS_LAT_MAX.load(Ordering::Relaxed);
+        while elapsed > cur {
+            match STRESS_LAT_MAX.compare_exchange_weak(cur, elapsed, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(v) => cur = v,
+            }
+        }
+        if r.is_ok() {
+            STRESS_SUCCESS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            STRESS_ERROR.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    STRESS_WORKERS_DONE.fetch_add(1, Ordering::Release);
+}
+
+/// Run a concurrent stress workload.
+///
+/// Spawns `n_workers` task workers (each `CPU_AFFINITY_ANY`), waits
+/// for completion, then writes the aggregated result into `out`.
+/// MNIST must be loaded (use `rust_model_load_builtin_mnist` first);
+/// the model index is looked up by name.
+///
+/// Returns 0 on success, negative on error:
+///  -1 — `out` is null, or n_workers/iters out of range
+///  -2 — MNIST not loaded
+///  -3 — stress workload already running
+///  -4 — task spawn failure
+///
+/// # Safety
+///
+/// Caller obligations match `rust_infer_classify` (must run in task
+/// context with an initialised scheduler).
+#[no_mangle]
+pub unsafe extern "C" fn rust_infer_stress_run(
+    n_workers: u32,
+    iters_per_worker: u32,
+    out: *mut RustStressResult,
+) -> i32 {
+    use core::sync::atomic::Ordering;
+
+    if out.is_null() {
+        return -1;
+    }
+    if n_workers == 0 || n_workers > 32 || iters_per_worker == 0 || iters_per_worker > 100_000 {
+        return -1;
+    }
+
+    // Serialise concurrent stress invocations.
+    if STRESS_BUSY
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+        .is_err()
+    {
+        return -3;
+    }
+    struct BusyGuard;
+    impl Drop for BusyGuard {
+        fn drop(&mut self) {
+            STRESS_BUSY.store(false, Ordering::Release);
+        }
+    }
+    let _busy = BusyGuard;
+
+    // Resolve MNIST model index.
+    let model_idx = match loader::registry::find_by_name(b"mnist") {
+        Some(i) => i as u32,
+        None => return -2,
+    };
+
+    // Snapshot pre-run counters so we can compute deltas.
+    let pre = sched::scheduler_stats();
+
+    // Reset worker-shared counters.
+    STRESS_WORKERS_DONE.store(0, Ordering::Release);
+    STRESS_SUCCESS.store(0, Ordering::Release);
+    STRESS_ERROR.store(0, Ordering::Release);
+    STRESS_LAT_TOTAL.store(0, Ordering::Release);
+    STRESS_LAT_MIN.store(u64::MAX, Ordering::Release);
+    STRESS_LAT_MAX.store(0, Ordering::Release);
+    STRESS_ITERS_PER_WORKER.store(iters_per_worker, Ordering::Release);
+    STRESS_MODEL_INDEX.store(model_idx, Ordering::Release);
+
+    let start_ns = kernel_ffi::get_time_ns();
+    let mut spawned: u32 = 0;
+    for _ in 0..n_workers {
+        let r = kernel_ffi::task_create(
+            b"infer-stress\0",
+            stress_worker_entry,
+            core::ptr::null_mut(),
+        );
+        if r.is_ok() {
+            spawned += 1;
+        }
+    }
+
+    if spawned == 0 {
+        return -4;
+    }
+
+    // Join: spin-yield until all spawned workers signal done.
+    // The yield budget is generous — each worker runs
+    // `iters_per_worker` MNIST inferences (~1 ms each on QEMU CPU).
+    loop {
+        if STRESS_WORKERS_DONE.load(Ordering::Acquire) >= spawned {
+            break;
+        }
+        extern "C" {
+            #[link_name = "yield"]
+            fn sched_yield();
+        }
+        sched_yield();
+    }
+
+    let end_ns = kernel_ffi::get_time_ns();
+
+    let post = sched::scheduler_stats();
+    let min_lat = STRESS_LAT_MIN.load(Ordering::Acquire);
+    let result = RustStressResult {
+        n_workers: spawned,
+        iters_per_worker,
+        success_count: STRESS_SUCCESS.load(Ordering::Acquire),
+        error_count: STRESS_ERROR.load(Ordering::Acquire),
+        wall_ns: end_ns.saturating_sub(start_ns),
+        total_lat_ns: STRESS_LAT_TOTAL.load(Ordering::Acquire),
+        min_lat_ns: if min_lat == u64::MAX { 0 } else { min_lat },
+        max_lat_ns: STRESS_LAT_MAX.load(Ordering::Acquire),
+        batches_dispatched: post.batches_dispatched.saturating_sub(pre.batches_dispatched),
+        batches_full: post.batches_full.saturating_sub(pre.batches_full),
+        batches_timeout: post.batches_timeout.saturating_sub(pre.batches_timeout),
+        bypassed_deadline: post.bypassed_deadline.saturating_sub(pre.bypassed_deadline),
+        singleton_dispatches: post.singleton_dispatches.saturating_sub(pre.singleton_dispatches),
+    };
+    *out = result;
+    0
+}
+
+// =============================================================================
 // Inference API (Phase 5, M2)
 // =============================================================================
 
@@ -7437,6 +7752,63 @@ pub extern "C" fn rust_batch_inference_test() -> i32 {
 
         sched::set_batching_enabled(false);
         sched::set_batch_timeout_us(5_000); // restore default
+    }
+
+    // Test 9 (#860): admin FFI round-trip. The shell + Lua bindings
+    // all forward to `rust_infer_batch_set_mode`, `_set_config`, and
+    // `_status`; verify the read/write contract.
+    {
+        rust_infer_batch_set_mode(0);
+        let off_mode = rust_infer_batch_get_mode();
+        rust_infer_batch_set_mode(1);
+        let on_mode = rust_infer_batch_get_mode();
+        rust_infer_batch_set_config(4, 1234);
+        let mut s: RustBatchStatus = unsafe { core::mem::zeroed() };
+        let rc = rust_infer_batch_status(&mut s as *mut _);
+        let null_rc = rust_infer_batch_status(core::ptr::null_mut());
+        let passed = off_mode == 0
+            && on_mode == 1
+            && rc == 0
+            && null_rc == -1
+            && s.enabled == 1
+            && s.batch_size == 4
+            && s.timeout_us == 1234;
+        print_test_result(b"batch: admin FFI set/get round-trip\0", passed);
+        if !passed { failures += 1; }
+        rust_infer_batch_set_mode(0);
+        rust_infer_batch_set_config(8, 5000);
+    }
+
+    // Test 10 (#860): concurrent stress workload. Spawns N=4 task
+    // workers, each running 8 inferences. Verifies the run reports the
+    // expected success count and that the FFI rejects out-of-range
+    // arguments.
+    {
+        rust_infer_batch_set_mode(1);
+        rust_infer_batch_set_config(8, 5000);
+
+        // Out-of-range guard.
+        let mut bogus: RustStressResult = unsafe { core::mem::zeroed() };
+        let bad_n = unsafe { rust_infer_stress_run(0, 1, &mut bogus as *mut _) };
+        let bad_null = unsafe { rust_infer_stress_run(2, 2, core::ptr::null_mut()) };
+        let bad_iter = unsafe { rust_infer_stress_run(2, 0, &mut bogus as *mut _) };
+
+        let mut res: RustStressResult = unsafe { core::mem::zeroed() };
+        let rc = unsafe { rust_infer_stress_run(4, 8, &mut res as *mut _) };
+
+        let expected = (res.n_workers as u64) * (res.iters_per_worker as u64);
+        let passed = bad_n == -1
+            && bad_null == -1
+            && bad_iter == -1
+            && rc == 0
+            && res.n_workers == 4
+            && res.iters_per_worker == 8
+            && res.success_count == expected
+            && res.error_count == 0;
+        print_test_result(b"batch: stress workload (4x8) completes + rejects bad args\0", passed);
+        if !passed { failures += 1; }
+
+        rust_infer_batch_set_mode(0);
     }
 
     // Summary

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7161,6 +7161,220 @@ pub extern "C" fn rust_inference_test() -> i32 {
 }
 
 // =============================================================================
+// Dynamic Batching Tests (#857)
+// =============================================================================
+
+/// Test the batched dispatch path end-to-end:
+///   - Engine-level: `run_inference_batched(N=k)` is bit-equal to `k`
+///     independent `run_inference` calls.
+///   - Scheduler-level: routing decisions (off → singleton, on+solo →
+///     singleton) trip the expected counters.
+///   - Configuration: batch-size setter clamps to `[1, MAX_BATCH]`.
+///   - Forced dispatch: `flush_pending_for_test` drains a queued batch
+///     and signals waiters' completion atomics.
+///
+/// MNIST is the fixture. Requires that a prior test loaded the
+/// embedded MNIST ONNX (rust_inference_test does this in Test 14).
+#[no_mangle]
+pub extern "C" fn rust_batch_inference_test() -> i32 {
+    let mut failures: i32 = 0;
+
+    unsafe {
+        kernel_ffi::uart_puts(b"[TEST] Running dynamic batching tests...\n\0".as_ptr());
+    }
+
+    // Load MNIST (idempotent — registry de-dupes by name).
+    let load = rust_model_load_builtin_mnist();
+    if load < 0 {
+        print_test_result(b"batch: MNIST load failed (skipping suite)\0", false);
+        return 1;
+    }
+    let model_index = load as u32;
+
+    // Two distinct inputs so bit-equality isn't trivially satisfied by
+    // a uniform output. Pattern A: ramp 0..1. Pattern B: zeros.
+    static INPUT_A: [f32; 784] = {
+        let mut a = [0.0; 784];
+        let mut i = 0;
+        while i < 784 {
+            a[i] = (i as f32) * (1.0 / 784.0);
+            i += 1;
+        }
+        a
+    };
+    static INPUT_B: [f32; 784] = [0.0; 784];
+
+    // Singleton-path baselines.
+    let mut baseline_a = [0.0f32; 64];
+    let mut baseline_b = [0.0f32; 64];
+    let (na, nb) = unsafe {
+        let na = inference::run_inference(
+            model_index as usize,
+            INPUT_A.as_ptr(), INPUT_A.len(),
+            baseline_a.as_mut_ptr(), baseline_a.len(),
+        ).unwrap_or(0);
+        let nb = inference::run_inference(
+            model_index as usize,
+            INPUT_B.as_ptr(), INPUT_B.len(),
+            baseline_b.as_mut_ptr(), baseline_b.len(),
+        ).unwrap_or(0);
+        (na, nb)
+    };
+    {
+        let passed = na > 0 && nb > 0 && na == nb;
+        print_test_result(b"batch: singleton baselines produced same N outputs\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 1: run_inference_batched(N=1) matches run_inference.
+    {
+        let mut out = [0.0f32; 64];
+        let n = unsafe {
+            inference::run_inference_batched(
+                model_index as usize, 1,
+                INPUT_A.as_ptr(), INPUT_A.len(),
+                out.as_mut_ptr(), out.len(),
+            ).unwrap_or(0)
+        };
+        let same = n == na && bit_equal(&out[..n], &baseline_a[..na]);
+        print_test_result(b"batch: run_inference_batched(N=1) == run_inference\0", same);
+        if !same { failures += 1; }
+    }
+
+    // Test 2: run_inference_batched(N=2) produces concatenated outputs
+    // bit-equal to two separate singleton calls.
+    {
+        let mut concat_in = [0.0f32; 2 * 784];
+        for i in 0..784 { concat_in[i] = INPUT_A[i]; }
+        for i in 0..784 { concat_in[784 + i] = INPUT_B[i]; }
+        let mut concat_out = [0.0f32; 2 * 64];
+        let n_total = unsafe {
+            inference::run_inference_batched(
+                model_index as usize, 2,
+                concat_in.as_ptr(), concat_in.len(),
+                concat_out.as_mut_ptr(), concat_out.len(),
+            ).unwrap_or(0)
+        };
+        let per = if n_total > 0 { n_total / 2 } else { 0 };
+        let ok_shape = per == na && per == nb;
+        let ok_a = ok_shape && bit_equal(&concat_out[..per], &baseline_a[..na]);
+        let ok_b = ok_shape && bit_equal(&concat_out[per..per * 2], &baseline_b[..nb]);
+        let passed = ok_a && ok_b;
+        print_test_result(b"batch: run_inference_batched(N=2) bit-equals 2x singleton\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 3: submit_inference_sync with batching OFF dispatches singleton.
+    {
+        sched::set_batching_enabled(false);
+        sched::reset_scheduler_stats();
+
+        let mut out = [0.0f32; 64];
+        let n = unsafe {
+            sched::submit_inference_sync(
+                model_index as usize,
+                INPUT_A.as_ptr(), INPUT_A.len(),
+                out.as_mut_ptr(), out.len(),
+                sched::TaskDeadline::NONE,
+            ).unwrap_or(0)
+        };
+        let stats = sched::scheduler_stats();
+        let same = n == na && bit_equal(&out[..n], &baseline_a[..na]);
+        let counted = stats.singleton_dispatches == 1
+            && stats.batches_dispatched == 0
+            && stats.total_submitted == 1;
+        let passed = same && counted;
+        print_test_result(b"batch: submit_sync(off) == singleton + counters\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 4: submit_inference_sync with batching ON but solo callers
+    // takes the singleton-fallback path (Role::Solo) so an isolated
+    // request never blocks on a batch that won't form.
+    {
+        sched::set_batching_enabled(true);
+        sched::set_batch_size(8);
+        sched::reset_scheduler_stats();
+
+        let mut out = [0.0f32; 64];
+        let n = unsafe {
+            sched::submit_inference_sync(
+                model_index as usize,
+                INPUT_B.as_ptr(), INPUT_B.len(),
+                out.as_mut_ptr(), out.len(),
+                sched::TaskDeadline::NONE,
+            ).unwrap_or(0)
+        };
+        let stats = sched::scheduler_stats();
+        let same = n == nb && bit_equal(&out[..n], &baseline_b[..nb]);
+        let counted = stats.singleton_dispatches == 1
+            && stats.batches_dispatched == 0
+            && stats.total_submitted == 1
+            && stats.queued == 0;
+        let passed = same && counted;
+        print_test_result(b"batch: submit_sync(on,solo) -> singleton + slot freed\0", passed);
+        if !passed { failures += 1; }
+
+        sched::set_batching_enabled(false);
+    }
+
+    // Test 5: null input rejected.
+    {
+        let mut out = [0.0f32; 64];
+        let r = unsafe {
+            sched::submit_inference_sync(
+                model_index as usize,
+                core::ptr::null(), 784,
+                out.as_mut_ptr(), out.len(),
+                sched::TaskDeadline::NONE,
+            )
+        };
+        let passed = matches!(r, Err(inference::EngineError::InvalidInput));
+        print_test_result(b"batch: null input -> InvalidInput\0", passed);
+        if !passed { failures += 1; }
+    }
+
+    // Test 6: batch_size setter clamps.
+    {
+        sched::set_batch_size(0);
+        let lo = sched::batch_size();
+        sched::set_batch_size(9999);
+        let hi = sched::batch_size();
+        let passed = lo == 1 && hi == sched::MAX_BATCH;
+        print_test_result(b"batch: set_batch_size clamps to [1, MAX_BATCH]\0", passed);
+        if !passed { failures += 1; }
+        sched::set_batch_size(8); // reset to default
+    }
+
+    // Summary
+    unsafe {
+        if failures == 0 {
+            kernel_ffi::uart_puts(b"[INFO] Dynamic batching tests passed\n\0".as_ptr());
+        } else {
+            kernel_ffi::uart_puts(b"[FAIL] Dynamic batching tests had failures\n\0".as_ptr());
+        }
+    }
+
+    failures
+}
+
+/// Bit-equal compare for FP32 buffers — paired with the batched
+/// bit-equality acceptance criterion in #857. We use `to_bits` to
+/// distinguish positive/negative zero and to keep NaN comparisons
+/// deterministic.
+fn bit_equal(a: &[f32], b: &[f32]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    for i in 0..a.len() {
+        if a[i].to_bits() != b[i].to_bits() {
+            return false;
+        }
+    }
+    true
+}
+
+// =============================================================================
 // GPU Compute API (Phase 5, M3)
 // =============================================================================
 

--- a/runtime/src/sched/inference.rs
+++ b/runtime/src/sched/inference.rs
@@ -41,6 +41,11 @@ extern "C" {
 /// static scratch slab manageable: 32 × 784 × 4 + 32 × 64 × 4 ≈ 108 KB.
 pub const MAX_BATCH: usize = 32;
 
+// PENDING stores slot indices as u8 to halve the cacheline footprint
+// versus usize; bump to u16 (and revisit cacheline layout) if a future
+// commit grows MAX_BATCH past 255.
+const _: () = assert!(MAX_BATCH <= 255, "PENDING stores slot indices as u8");
+
 /// Maximum per-request input length supported by the batched path.
 /// Sized for MNIST (1 × 1 × 28 × 28 = 784). Requests with `input_len`
 /// greater than this fall back to the singleton path.
@@ -425,6 +430,18 @@ pub fn queue_depth() -> usize {
 ///
 /// Otherwise dispatches directly via `inference::run_inference`.
 ///
+/// # Limitation (until #859 lands)
+///
+/// When `2 ≤ N < batch_size` submitters happen to arrive together
+/// and no further submitter shows up, all `N` waiters sit in
+/// `wait_for_slot` indefinitely — `decide_role` only treats `N == 1`
+/// as the singleton-fallback case. The timer-driven partial-batch
+/// flush in #859 (5 ms after the first request lands) closes this
+/// window. Callers that need a deterministic time-bound today must
+/// either disable batching or run with `batch_size == 1`. The
+/// stress workload added in #860 exercises the threshold-driven
+/// path directly (N == batch_size), so it doesn't hit this case.
+///
 /// Returns the number of output floats written, matching the
 /// underlying engine entrypoint.
 ///
@@ -648,6 +665,20 @@ fn release_slot_as_solo(slot_idx: usize) {
 /// `self_idx` is the dispatcher's own slot — its output is materialised
 /// in place and returned to the caller. All other slots in
 /// `batch_indices[0..batch_count]` are written + signalled.
+///
+/// # Scratch-slab serialisation
+///
+/// Today only the size-threshold path enters this function, and the
+/// `PENDING_COUNT → 0` transition under `SCHED_LOCK` in `decide_role`
+/// serialises any two threshold dispatchers (the second would see an
+/// empty queue and the count couldn't tip until the first finishes).
+/// Once #859 wires a timer-flush dispatcher, the timer caller and a
+/// fresh size-threshold submitter can both exit `SCHED_LOCK` holding
+/// disjoint slot-index lists and race on `SCRATCH_IN` / `SCRATCH_OUT`.
+/// `EngineGuard` serialises the engine call itself but not the
+/// surrounding scratch fill + fan-out. #859 must either hold
+/// `SCHED_LOCK` across the engine call or introduce a separate
+/// `DISPATCH_LOCK` before adding the second entry point.
 unsafe fn run_dispatcher(
     self_idx: usize,
     batch_indices: &[u8; MAX_BATCH],
@@ -714,7 +745,25 @@ unsafe fn run_dispatcher(
 
     match result {
         Ok(total_out) => {
-            // Per-request output is total_out / batch_count.
+            // Per-request output is total_out / batch_count. The engine
+            // must return N * per_sample_output; a non-multiple total
+            // would silently misalign every caller's output buffer, so
+            // refuse it with InternalError and fail every claimed slot
+            // rather than corrupt downstream readers.
+            if total_out % batch_count != 0 {
+                for i in 0..batch_count {
+                    let idx = batch_indices[i] as usize;
+                    let slot = &SLOTS[idx];
+                    slot.result_value
+                        .store(encode_engine_error(EngineError::InternalError), Ordering::Relaxed);
+                    STAT_FAILED.fetch_add(1, Ordering::Relaxed);
+                    if idx != self_idx {
+                        slot.state.store(SLOT_DONE_ERR, Ordering::Release);
+                    }
+                }
+                SLOTS[self_idx].state.store(SLOT_IDLE, Ordering::Release);
+                return Err(EngineError::InternalError);
+            }
             let per_out = total_out / batch_count;
             // Fan-out: copy slice into each caller's output buffer and
             // signal completion. The dispatcher itself includes its
@@ -927,6 +976,18 @@ unsafe fn run_dispatcher_external(
 
     match result {
         Ok(total_out) => {
+            // Same per-slot-divisibility guard as `run_dispatcher`.
+            if total_out % batch_count != 0 {
+                for i in 0..batch_count {
+                    let idx = batch_indices[i] as usize;
+                    let slot = &SLOTS[idx];
+                    slot.result_value
+                        .store(encode_engine_error(EngineError::InternalError), Ordering::Relaxed);
+                    STAT_FAILED.fetch_add(1, Ordering::Relaxed);
+                    slot.state.store(SLOT_DONE_ERR, Ordering::Release);
+                }
+                return Err(EngineError::InternalError);
+            }
             let per_out = total_out / batch_count;
             for i in 0..batch_count {
                 let idx = batch_indices[i] as usize;

--- a/runtime/src/sched/inference.rs
+++ b/runtime/src/sched/inference.rs
@@ -293,6 +293,21 @@ static PENDING_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 static SCHED_LOCK: AtomicBool = AtomicBool::new(false);
 
+/// Wall-clock nanoseconds when the currently-forming batch's first
+/// request was deposited. Used by the timer-flush waiter loop (#859).
+/// Set when `PENDING_COUNT` transitions 0 → 1, reset when a dispatcher
+/// or `release_slot_as_solo` transitions it back to 0.
+///
+/// 0 = no batch is forming.
+static BATCH_FIRST_TIME_NS: AtomicU64 = AtomicU64::new(0);
+
+/// Serializes the actual batched-dispatch work (scratch fill + engine
+/// call + per-slot fan-out) so two dispatchers (a size-threshold caller
+/// and a timer-flush caller from a waiter) can't race on the static
+/// `SCRATCH_IN` / `SCRATCH_OUT` slabs. Held strictly *outside*
+/// `SCHED_LOCK` to keep queue mutations unblocked during dispatch.
+static SCRATCH_LOCK: AtomicBool = AtomicBool::new(false);
+
 /// Runtime-toggleable mode. Default OFF; flipped by the admin toggle
 /// landing in #860.
 static BATCHING_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -337,6 +352,28 @@ impl SchedGuard {
 impl Drop for SchedGuard {
     fn drop(&mut self) {
         SCHED_LOCK.store(false, Ordering::Release);
+    }
+}
+
+struct ScratchGuard;
+
+impl ScratchGuard {
+    fn new() -> Self {
+        while SCRATCH_LOCK
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            // Yield so a contending dispatcher's engine call can make
+            // progress under cooperative scheduling.
+            unsafe { sched_yield() };
+        }
+        ScratchGuard
+    }
+}
+
+impl Drop for ScratchGuard {
+    fn drop(&mut self) {
+        SCRATCH_LOCK.store(false, Ordering::Release);
     }
 }
 
@@ -420,6 +457,74 @@ pub fn queue_depth() -> usize {
 }
 
 // =============================================================================
+// Test helpers (doc-hidden — used by `rust_batch_inference_test`)
+// =============================================================================
+
+/// Inject a slot into the pending queue without taking the submitter
+/// path. Used by the #859 timer-flush test so the test thread can sit
+/// in `wait_for_slot` with a peer already enqueued, deterministically
+/// trigger the timeout claim, and dispatch a real `[N=2, input_dim]`
+/// batch through the engine. The injected slot's input pointer must
+/// stay live until the slot's state transitions to `DONE_*`.
+#[doc(hidden)]
+pub unsafe fn inject_pending_slot_for_test(
+    model_index: usize,
+    input: *const f32,
+    input_len: usize,
+    output: *mut f32,
+    output_len: usize,
+) -> Option<usize> {
+    reserve_slot(model_index, input, input_len, output, output_len)
+}
+
+/// Consume a `DONE_*` slot and transition it back to IDLE. Returns the
+/// per-slot output length on success, or the decoded `EngineError` on
+/// the error path. Used by tests that injected a slot via
+/// `inject_pending_slot_for_test` and need to clean up after the
+/// timer-flush dispatcher signalled it.
+#[doc(hidden)]
+pub unsafe fn drain_slot_for_test(slot_idx: usize) -> Result<usize, EngineError> {
+    if slot_idx >= MAX_BATCH {
+        return Err(EngineError::InvalidInput);
+    }
+    let slot = &SLOTS[slot_idx];
+    let s = slot.state.load(Ordering::Acquire);
+    match s {
+        SLOT_DONE_OK => {
+            let n = slot.result_value.load(Ordering::Relaxed) as usize;
+            slot.state.store(SLOT_IDLE, Ordering::Release);
+            Ok(n)
+        }
+        SLOT_DONE_ERR => {
+            let code = slot.result_value.load(Ordering::Relaxed);
+            slot.state.store(SLOT_IDLE, Ordering::Release);
+            Err(decode_engine_error(code))
+        }
+        _ => Err(EngineError::InternalError),
+    }
+}
+
+/// Current state of a slot — exposed only for test polling.
+#[doc(hidden)]
+pub fn slot_state_for_test(slot_idx: usize) -> u32 {
+    if slot_idx >= MAX_BATCH {
+        return u32::MAX;
+    }
+    SLOTS[slot_idx].state.load(Ordering::Acquire)
+}
+
+#[doc(hidden)]
+pub const SLOT_STATE_IDLE: u32 = SLOT_IDLE;
+#[doc(hidden)]
+pub const SLOT_STATE_PENDING: u32 = SLOT_PENDING;
+#[doc(hidden)]
+pub const SLOT_STATE_DISPATCHING: u32 = SLOT_DISPATCHING;
+#[doc(hidden)]
+pub const SLOT_STATE_DONE_OK: u32 = SLOT_DONE_OK;
+#[doc(hidden)]
+pub const SLOT_STATE_DONE_ERR: u32 = SLOT_DONE_ERR;
+
+// =============================================================================
 // Synchronous batched-dispatch helper
 // =============================================================================
 
@@ -464,7 +569,7 @@ pub unsafe fn submit_inference_sync(
     input_len: usize,
     output: *mut f32,
     output_len: usize,
-    _deadline: TaskDeadline,
+    deadline: TaskDeadline,
 ) -> Result<usize, EngineError> {
     STAT_TOTAL_SUBMITTED.fetch_add(1, Ordering::Relaxed);
 
@@ -483,11 +588,25 @@ pub unsafe fn submit_inference_sync(
         return dispatch_singleton(model_index, input, input_len, output, output_len);
     }
 
+    // Deadline-aware bypass (#859). A live deadline whose remaining
+    // slack is less than the configured batch timeout would, in the
+    // worst case, miss the deadline waiting for a batch to form. Skip
+    // the queue entirely for those requests and dispatch as a
+    // singleton.
+    if deadline.deadline_ns != 0 {
+        let slack_ns = deadline.remaining_ns();
+        let timeout_ns = (batch_timeout_us() as u64).saturating_mul(1000);
+        if slack_ns < timeout_ns {
+            STAT_BYPASSED_DEADLINE.fetch_add(1, Ordering::Relaxed);
+            return dispatch_singleton(model_index, input, input_len, output, output_len);
+        }
+    }
+
     // Try to push into the queue. We reserve a slot, then either become
-    // the dispatcher (if we tipped the count to `cfg_size`) or fall
-    // through to the singleton path (if we'd be the only request in
-    // flight — without 55b's timer flush, a lone request would block
-    // forever waiting for peers).
+    // the dispatcher (if we tipped the count to `cfg_size`), become the
+    // timer-flush dispatcher (#859 — fires from `wait_for_slot` once
+    // `BATCH_FIRST_TIME_NS + batch_timeout` elapses), or fall through
+    // to the singleton path (queue full, or we're the only entry).
     let slot_idx = match reserve_slot(model_index, input, input_len, output, output_len) {
         Some(idx) => idx,
         None => {
@@ -582,6 +701,15 @@ unsafe fn reserve_slot(
     let pending = core::ptr::addr_of_mut!(PENDING) as *mut u8;
     *pending.add(n) = idx as u8;
     PENDING_COUNT.store(n + 1, Ordering::Release);
+    if n == 0 {
+        // We're the first request in this forming batch — start the
+        // timer-flush clock. The next dispatcher (or
+        // `release_slot_as_solo`) clears this when the queue empties.
+        BATCH_FIRST_TIME_NS.store(
+            crate::kernel_ffi::get_time_ns(),
+            Ordering::Relaxed,
+        );
+    }
 
     Some(idx)
 }
@@ -628,6 +756,7 @@ fn decide_role(
             indices[i] = unsafe { *pending.add(i) };
         }
         PENDING_COUNT.store(0, Ordering::Release);
+        BATCH_FIRST_TIME_NS.store(0, Ordering::Relaxed);
         // Mark each claimed slot as DISPATCHING.
         for i in 0..n {
             let idx = indices[i] as usize;
@@ -657,6 +786,9 @@ fn release_slot_as_solo(slot_idx: usize) {
                 unsafe { *pending.add(j) = *pending.add(j + 1) };
             }
             PENDING_COUNT.store(n - 1, Ordering::Release);
+            if n - 1 == 0 {
+                BATCH_FIRST_TIME_NS.store(0, Ordering::Relaxed);
+            }
             found = true;
             break;
         }
@@ -675,7 +807,8 @@ fn release_slot_as_solo(slot_idx: usize) {
 }
 
 /// Run the batched dispatch. Called by the slot owner that triggered
-/// the dispatch threshold (or, in #859, the timer flush).
+/// the dispatch threshold or by a waiter that won the timer-flush race
+/// (#859).
 ///
 /// `self_idx` is the dispatcher's own slot — its output is materialised
 /// in place and returned to the caller. All other slots in
@@ -683,23 +816,26 @@ fn release_slot_as_solo(slot_idx: usize) {
 ///
 /// # Scratch-slab serialisation
 ///
-/// Today only the size-threshold path enters this function, and the
-/// `PENDING_COUNT → 0` transition under `SCHED_LOCK` in `decide_role`
-/// serialises any two threshold dispatchers (the second would see an
-/// empty queue and the count couldn't tip until the first finishes).
-/// Once #859 wires a timer-flush dispatcher, the timer caller and a
-/// fresh size-threshold submitter can both exit `SCHED_LOCK` holding
-/// disjoint slot-index lists and race on `SCRATCH_IN` / `SCRATCH_OUT`.
-/// `EngineGuard` serialises the engine call itself but not the
-/// surrounding scratch fill + fan-out. #859 must either hold
-/// `SCHED_LOCK` across the engine call or introduce a separate
-/// `DISPATCH_LOCK` before adding the second entry point.
+/// Two dispatchers can be in flight simultaneously: a size-threshold
+/// dispatcher (from `decide_role`) and a timer-flush dispatcher (from
+/// `wait_for_slot`'s timeout claim). Each claims its slot list under
+/// `SCHED_LOCK`, but the actual scratch fill + engine call + fan-out
+/// happens outside `SCHED_LOCK` so submission can keep flowing. The
+/// `ScratchGuard` acquired at the top of this function serialises the
+/// concurrent dispatchers on `SCRATCH_IN` / `SCRATCH_OUT` and the
+/// per-call stats updates. The engine call itself is also serialised
+/// internally by `EngineGuard`, but `ScratchGuard` is needed because
+/// the scratch fill happens *before* the engine call.
 unsafe fn run_dispatcher(
     self_idx: usize,
     batch_indices: &[u8; MAX_BATCH],
     batch_count: usize,
     kind: DispatchKind,
 ) -> Result<usize, EngineError> {
+    // Serialise concurrent dispatchers on the static scratch slabs.
+    // SchedGuard is NOT held here — submission can continue forming
+    // the next batch while we dispatch.
+    let _scratch = ScratchGuard::new();
     // All claimed slots must agree on model_index — different-model
     // batches aren't supported. The reserve protocol doesn't currently
     // gate on this, so we verify and split if necessary. In practice
@@ -862,8 +998,9 @@ unsafe fn dispatch_heterogeneous(
     self_result
 }
 
-/// Wait on a slot's completion atomic. Used by non-dispatcher
-/// submitters. Returns the result the dispatcher published.
+/// Wait on a slot's completion atomic. Periodically tries to claim the
+/// pending batch as a timer-driven flush (#859) so waiters never block
+/// indefinitely when the batch never reaches the size threshold.
 unsafe fn wait_for_slot(slot_idx: usize) -> Result<usize, EngineError> {
     let slot = &SLOTS[slot_idx];
     loop {
@@ -880,192 +1017,69 @@ unsafe fn wait_for_slot(slot_idx: usize) -> Result<usize, EngineError> {
                 return Err(decode_engine_error(code));
             }
             _ => {
-                // Yield so the dispatcher (which may share this CPU
-                // under cooperative scheduling) can run.
+                // If the batch's flush timeout has elapsed, try to
+                // become the timer-flush dispatcher. The claim happens
+                // under SCHED_LOCK and tolerates a concurrent
+                // size-threshold dispatcher having already drained the
+                // queue (it'll return None, and we'll fall through to
+                // the slot-state read above on the next iteration).
+                if let Some((indices, count)) = try_claim_timeout_flush() {
+                    return run_dispatcher(slot_idx, &indices, count, DispatchKind::Timeout);
+                }
                 sched_yield();
             }
         }
     }
 }
 
-// =============================================================================
-// Internal: timer flush hook (used by #859)
-//
-// The three functions below — `flush_pending_for_test`,
-// `run_dispatcher_external`, and `dispatch_heterogeneous_external` —
-// are dead code in #857 (no caller). They exist so #859 (timer flush
-// + deadline-aware bypass) can wire them up without churning #857's
-// API surface. The unified design that lands in #859 replaces them
-// with a single `run_dispatcher` callable from both the size-threshold
-// path and the waiter-driven timer-flush path; expect this entire
-// block to be removed when #859 merges.
-// =============================================================================
-
-/// Force-flush the currently pending batch. Reserved for #859 — not
-/// reachable from #857 production paths; only used by the test helper
-/// in `rust_batch_inference_test`. Gated behind `SCHED_LOCK` so a
-/// forming batch isn't simultaneously claimed by both the timer and a
-/// fresh submitter. Returns the number of dispatched slots, or 0 if
-/// the queue was empty.
-#[doc(hidden)]
-pub unsafe fn flush_pending_for_test() -> usize {
-    let (indices, count, run) = {
-        let _g = SchedGuard::new();
-        let n = PENDING_COUNT.load(Ordering::Relaxed);
-        if n == 0 {
-            return 0;
-        }
-        let mut indices = [0u8; MAX_BATCH];
-        let pending = core::ptr::addr_of!(PENDING) as *const u8;
-        for i in 0..n {
-            indices[i] = *pending.add(i);
-        }
-        PENDING_COUNT.store(0, Ordering::Release);
-        for i in 0..n {
-            let idx = indices[i] as usize;
-            SLOTS[idx].state.store(SLOT_DISPATCHING, Ordering::Release);
-        }
-        (indices, n, true)
-    };
-    if !run {
-        return 0;
+/// Attempt to claim the currently-forming batch as a timer-flush
+/// dispatcher. Returns `Some(indices, count)` when the batch has been
+/// claimed and the caller should run the dispatch via `run_dispatcher`
+/// with `kind = Timeout`. Returns `None` if the timeout hasn't elapsed
+/// yet, if the queue is empty, or if a peer (size-threshold dispatcher
+/// or another timer-flush winner) has already drained the queue.
+fn try_claim_timeout_flush() -> Option<([u8; MAX_BATCH], usize)> {
+    // First check is unlocked — avoids the SCHED_LOCK round-trip on
+    // every wait iteration. The locked check below re-reads
+    // `BATCH_FIRST_TIME_NS` so there's no TOCTOU hazard against a peer
+    // dispatcher that resets the timer underneath us.
+    let first_ns = BATCH_FIRST_TIME_NS.load(Ordering::Relaxed);
+    if first_ns == 0 {
+        return None;
     }
-    // The "self_idx" for a timer-driven flush isn't a real submitter,
-    // so we synthesise a sentinel that no real slot will match. The
-    // dispatcher signals every claimed slot (including what would have
-    // been self) via DONE_*, and we ignore the returned result.
-    let self_idx = usize::MAX;
-    let _ = run_dispatcher_external(self_idx, &indices, count, DispatchKind::Timeout);
-    count
-}
-
-/// Variant of `run_dispatcher` where the caller is not itself one of
-/// the claimed slots (timer-driven flush). All slots in
-/// `batch_indices[0..batch_count]` are signalled via the mailbox.
-unsafe fn run_dispatcher_external(
-    _self_idx: usize,
-    batch_indices: &[u8; MAX_BATCH],
-    batch_count: usize,
-    kind: DispatchKind,
-) -> Result<(), EngineError> {
-    if batch_count == 0 {
-        return Ok(());
-    }
-    let model_index = SLOTS[batch_indices[0] as usize]
-        .model_index
-        .load(Ordering::Relaxed);
-    let in_dim = SLOTS[batch_indices[0] as usize]
-        .input_len
-        .load(Ordering::Relaxed);
-    for i in 0..batch_count {
-        let idx = batch_indices[i] as usize;
-        if SLOTS[idx].model_index.load(Ordering::Relaxed) != model_index
-            || SLOTS[idx].input_len.load(Ordering::Relaxed) != in_dim
-        {
-            // Heterogeneous: dispatch each individually.
-            return dispatch_heterogeneous_external(batch_indices, batch_count);
-        }
+    let now = crate::kernel_ffi::get_time_ns();
+    let timeout_ns = (batch_timeout_us() as u64).saturating_mul(1000);
+    if now.saturating_sub(first_ns) < timeout_ns {
+        return None;
     }
 
-    let scratch_in = SCRATCH_IN.0.get() as *mut f32;
-    let scratch_out = SCRATCH_OUT.0.get() as *mut f32;
-    for i in 0..batch_count {
-        let idx = batch_indices[i] as usize;
-        let src = SLOTS[idx].input_ptr.load(Ordering::Relaxed) as *const f32;
-        core::ptr::copy_nonoverlapping(src, scratch_in.add(i * in_dim), in_dim);
+    // Locked claim. Re-validate everything we just read.
+    let _g = SchedGuard::new();
+    let n = PENDING_COUNT.load(Ordering::Relaxed);
+    if n == 0 {
+        return None;
     }
-
-    STAT_RUNNING.fetch_add(batch_count, Ordering::Relaxed);
-    STAT_BATCHES_DISPATCHED.fetch_add(1, Ordering::Relaxed);
-    match kind {
-        DispatchKind::SizeThreshold => STAT_BATCHES_FULL.fetch_add(1, Ordering::Relaxed),
-        DispatchKind::Timeout => STAT_BATCHES_TIMEOUT.fetch_add(1, Ordering::Relaxed),
-    };
-
-    let start = crate::kernel_ffi::get_time_ns();
-    let batched_out_cap = batch_count * MAX_OUTPUT_DIM;
-    let result = crate::inference::engine::run_inference_batched(
-        model_index,
-        batch_count,
-        scratch_in,
-        in_dim * batch_count,
-        scratch_out,
-        batched_out_cap,
-    );
-    let elapsed = crate::kernel_ffi::get_time_ns().saturating_sub(start);
-    STAT_TIME_TOTAL_NS.fetch_add(elapsed, Ordering::Relaxed);
-    STAT_TIME_SAMPLES.fetch_add(1, Ordering::Relaxed);
-    STAT_RUNNING.fetch_sub(batch_count, Ordering::Relaxed);
-
-    match result {
-        Ok(total_out) => {
-            // Same per-slot-divisibility guard as `run_dispatcher`.
-            if total_out % batch_count != 0 {
-                for i in 0..batch_count {
-                    let idx = batch_indices[i] as usize;
-                    let slot = &SLOTS[idx];
-                    slot.result_value
-                        .store(encode_engine_error(EngineError::InternalError), Ordering::Relaxed);
-                    STAT_FAILED.fetch_add(1, Ordering::Relaxed);
-                    slot.state.store(SLOT_DONE_ERR, Ordering::Release);
-                }
-                return Err(EngineError::InternalError);
-            }
-            let per_out = total_out / batch_count;
-            for i in 0..batch_count {
-                let idx = batch_indices[i] as usize;
-                let slot = &SLOTS[idx];
-                let cap = slot.output_len.load(Ordering::Relaxed);
-                let n = per_out.min(cap);
-                let dst = slot.output_ptr.load(Ordering::Relaxed) as *mut f32;
-                core::ptr::copy_nonoverlapping(scratch_out.add(i * per_out), dst, n);
-                slot.result_value.store(n as u32, Ordering::Relaxed);
-                STAT_COMPLETED.fetch_add(1, Ordering::Relaxed);
-                slot.state.store(SLOT_DONE_OK, Ordering::Release);
-            }
-            Ok(())
-        }
-        Err(e) => {
-            let err_code = encode_engine_error(e);
-            for i in 0..batch_count {
-                let idx = batch_indices[i] as usize;
-                let slot = &SLOTS[idx];
-                slot.result_value.store(err_code, Ordering::Relaxed);
-                STAT_FAILED.fetch_add(1, Ordering::Relaxed);
-                slot.state.store(SLOT_DONE_ERR, Ordering::Release);
-            }
-            Err(e)
-        }
+    let first_ns_locked = BATCH_FIRST_TIME_NS.load(Ordering::Relaxed);
+    if first_ns_locked == 0 {
+        return None;
     }
-}
-
-unsafe fn dispatch_heterogeneous_external(
-    batch_indices: &[u8; MAX_BATCH],
-    batch_count: usize,
-) -> Result<(), EngineError> {
-    for i in 0..batch_count {
-        let idx = batch_indices[i] as usize;
-        let slot = &SLOTS[idx];
-        let mi = slot.model_index.load(Ordering::Relaxed);
-        let in_ptr = slot.input_ptr.load(Ordering::Relaxed) as *const f32;
-        let in_len = slot.input_len.load(Ordering::Relaxed);
-        let out_ptr = slot.output_ptr.load(Ordering::Relaxed) as *mut f32;
-        let out_len = slot.output_len.load(Ordering::Relaxed);
-
-        let r = dispatch_singleton(mi, in_ptr, in_len, out_ptr, out_len);
-        match r {
-            Ok(n) => {
-                slot.result_value.store(n as u32, Ordering::Relaxed);
-                slot.state.store(SLOT_DONE_OK, Ordering::Release);
-            }
-            Err(e) => {
-                slot.result_value
-                    .store(encode_engine_error(e), Ordering::Relaxed);
-                slot.state.store(SLOT_DONE_ERR, Ordering::Release);
-            }
-        }
+    let now_locked = crate::kernel_ffi::get_time_ns();
+    if now_locked.saturating_sub(first_ns_locked) < timeout_ns {
+        return None;
     }
-    Ok(())
+    let mut indices = [0u8; MAX_BATCH];
+    let pending = core::ptr::addr_of!(PENDING) as *const u8;
+    for i in 0..n {
+        // SAFETY: SCHED_LOCK held.
+        indices[i] = unsafe { *pending.add(i) };
+    }
+    PENDING_COUNT.store(0, Ordering::Release);
+    BATCH_FIRST_TIME_NS.store(0, Ordering::Relaxed);
+    for i in 0..n {
+        let idx = indices[i] as usize;
+        SLOTS[idx].state.store(SLOT_DISPATCHING, Ordering::Release);
+    }
+    Some((indices, n))
 }
 
 fn encode_engine_error(e: EngineError) -> u32 {

--- a/runtime/src/sched/inference.rs
+++ b/runtime/src/sched/inference.rs
@@ -47,12 +47,18 @@ pub const MAX_BATCH: usize = 32;
 const _: () = assert!(MAX_BATCH <= 255, "PENDING stores slot indices as u8");
 
 /// Maximum per-request input length supported by the batched path.
-/// Sized for MNIST (1 × 1 × 28 × 28 = 784). Requests with `input_len`
-/// greater than this fall back to the singleton path.
+/// Sized for MNIST (1 × 1 × 28 × 28 = 784).
+///
+/// LIMITATION: requests with `input_len > MAX_INPUT_DIM` silently
+/// degrade to the singleton path (no error surfaced — the caller's
+/// inference still runs, just without the chance to be batched). Bump
+/// this constant (and re-evaluate the `SCRATCH_IN` slab size) when
+/// adding a model with a larger input shape.
 pub const MAX_INPUT_DIM: usize = 784;
 
 /// Maximum per-request output length supported by the batched path.
 /// 64 matches the existing `rust_infer_*` FFI output buffer convention.
+/// Same silent-singleton-fallback semantics as `MAX_INPUT_DIM` apply.
 pub const MAX_OUTPUT_DIM: usize = 64;
 
 const DEFAULT_BATCH_SIZE: usize = 8;
@@ -656,6 +662,15 @@ fn release_slot_as_solo(slot_idx: usize) {
         }
     }
     debug_assert!(found, "solo slot must be in pending list");
+    if !found {
+        // Release-build defence: if invariant violated, leave the slot
+        // alone rather than transitioning a slot we don't actually own
+        // back to IDLE. The slot will still get cleaned up if its true
+        // owner drops a `DONE_*` result through `wait_for_slot`. The
+        // worst case is a leaked PENDING slot until reboot — better
+        // than corrupting another submitter's view of the table.
+        return;
+    }
     SLOTS[slot_idx].state.store(SLOT_IDLE, Ordering::Release);
 }
 
@@ -875,15 +890,23 @@ unsafe fn wait_for_slot(slot_idx: usize) -> Result<usize, EngineError> {
 
 // =============================================================================
 // Internal: timer flush hook (used by #859)
+//
+// The three functions below — `flush_pending_for_test`,
+// `run_dispatcher_external`, and `dispatch_heterogeneous_external` —
+// are dead code in #857 (no caller). They exist so #859 (timer flush
+// + deadline-aware bypass) can wire them up without churning #857's
+// API surface. The unified design that lands in #859 replaces them
+// with a single `run_dispatcher` callable from both the size-threshold
+// path and the waiter-driven timer-flush path; expect this entire
+// block to be removed when #859 merges.
 // =============================================================================
 
-/// Force-flush the currently pending batch. Called by the timer-flush
-/// path landing in #859 — gated behind the SCHED_LOCK so a forming
-/// batch isn't simultaneously claimed by both the timer and a fresh
-/// submitter. Returns the number of dispatched slots, or 0 if the
-/// queue was empty.
-///
-/// Reserved for #859; not wired into a real timer yet.
+/// Force-flush the currently pending batch. Reserved for #859 — not
+/// reachable from #857 production paths; only used by the test helper
+/// in `rust_batch_inference_test`. Gated behind `SCHED_LOCK` so a
+/// forming batch isn't simultaneously claimed by both the timer and a
+/// fresh submitter. Returns the number of dispatched slots, or 0 if
+/// the queue was empty.
 #[doc(hidden)]
 pub unsafe fn flush_pending_for_test() -> usize {
     let (indices, count, run) = {
@@ -1118,14 +1141,18 @@ impl InferenceScheduler {
         batching_enabled()
     }
 
-    /// Submit a metadata-only request handle. Real submission (with
-    /// buffer pointers) goes through `submit_inference_sync`.
-    pub fn submit(&mut self, request: InferenceRequest) -> Result<u64, SchedulerError> {
-        if !batching_enabled() {
-            return Err(SchedulerError::NotRunning);
-        }
-        STAT_TOTAL_SUBMITTED.fetch_add(1, Ordering::Relaxed);
-        Ok(request.id)
+    /// Token-based submit — NOT implemented end-to-end.
+    ///
+    /// The metadata-only `InferenceRequest` doesn't carry buffer
+    /// pointers, so this entry point has no way to deposit a request
+    /// into the queue. Real submission goes through
+    /// `submit_inference_sync` (which takes the buffers directly).
+    /// The previous shipping shape — silently incrementing
+    /// `total_submitted` and returning `Ok(request.id)` while
+    /// dropping the request on the floor — has been removed because
+    /// it would lose work for any caller who actually used it.
+    pub fn submit(&mut self, _request: InferenceRequest) -> Result<u64, SchedulerError> {
+        Err(SchedulerError::NotImplemented)
     }
 
     pub fn cancel(&mut self, _request_id: u64) -> Result<(), SchedulerError> {

--- a/runtime/src/sched/inference.rs
+++ b/runtime/src/sched/inference.rs
@@ -1,27 +1,61 @@
-//! Inference Scheduler for SLM-OS
+//! Inference Scheduler — runtime-toggleable batched dispatch.
 //!
-//! This module provides the skeleton for scheduling AI inference tasks.
-//! The full implementation will be completed in Phase 5.
+//! Provides a request queue, completion mailboxes, and a synchronous
+//! batched-dispatch path on top of the single-request inference engine.
 //!
-//! # Design
-//!
-//! The InferenceScheduler is responsible for:
-//! - Managing inference task queues
-//! - Prioritizing inference requests based on deadlines
-//! - Coordinating with the kernel scheduler for core affinity
-//! - Batching inference requests for efficiency
-//!
-//! # Usage
-//!
-//! ```ignore
-//! let scheduler = InferenceScheduler::new();
-//! let request = InferenceRequest::new(model, input_data);
-//! scheduler.submit(request)?;
-//! let result = scheduler.wait_for_result()?;
-//! ```
+//! Design (see issue #55 / #857):
+//! - One static singleton, file-scope spinlock.
+//! - Fixed-size slot table of [`MAX_BATCH`] slots; each slot owns the
+//!   caller's input/output pointer pair plus a state atomic that
+//!   doubles as the completion waker.
+//! - The submitter that fills the last slot of a forming batch becomes
+//!   the synchronous dispatcher: under the scheduler lock it claims
+//!   all pending slots, drops the lock, copies the per-request inputs
+//!   into a static scratch slab, calls `inference::run_inference` once
+//!   with the concatenated `[N, input_dim]` input, then slices the
+//!   `[N, output_dim]` result back into each caller's output buffer
+//!   and signals their waker.
+//! - When the configured batch size is 1, or when only one request is
+//!   in flight, or when batching mode is OFF, the scheduler degrades
+//!   to the existing single-request `run_inference` path so isolated
+//!   callers never block waiting for peers that may never arrive.
+//!   Timer-driven partial-batch flush lands in #859.
+
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use core::cell::UnsafeCell;
 
 use super::{Priority, CoreType, TaskDeadline};
+use crate::inference::{self, EngineError};
 use crate::mm::ModelHandle;
+
+extern "C" {
+    #[link_name = "yield"]
+    fn sched_yield();
+}
+
+// =============================================================================
+// Capacity constants
+// =============================================================================
+
+/// Maximum batch size — also the size of the slot table. 32 keeps the
+/// static scratch slab manageable: 32 × 784 × 4 + 32 × 64 × 4 ≈ 108 KB.
+pub const MAX_BATCH: usize = 32;
+
+/// Maximum per-request input length supported by the batched path.
+/// Sized for MNIST (1 × 1 × 28 × 28 = 784). Requests with `input_len`
+/// greater than this fall back to the singleton path.
+pub const MAX_INPUT_DIM: usize = 784;
+
+/// Maximum per-request output length supported by the batched path.
+/// 64 matches the existing `rust_infer_*` FFI output buffer convention.
+pub const MAX_OUTPUT_DIM: usize = 64;
+
+const DEFAULT_BATCH_SIZE: usize = 8;
+const DEFAULT_BATCH_TIMEOUT_US: u32 = 5_000;
+
+// =============================================================================
+// Public types (kept for API compatibility with the prior skeleton)
+// =============================================================================
 
 /// State of an inference request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,6 +100,12 @@ impl Default for InferenceConfig {
 }
 
 /// An inference request to be scheduled.
+///
+/// The buffer pointers are deliberately not stored here — the
+/// synchronous helper `submit_inference_sync` takes them directly. The
+/// public `InferenceScheduler::submit` / `get_result` API keeps the
+/// metadata-only `InferenceRequest` for callers that need a token
+/// handle.
 pub struct InferenceRequest {
     /// Unique request ID
     id: u64,
@@ -82,7 +122,6 @@ pub struct InferenceRequest {
 impl InferenceRequest {
     /// Create a new inference request.
     pub fn new(model_handle: ModelHandle, config: InferenceConfig) -> Self {
-        use core::sync::atomic::{AtomicU64, Ordering};
         static NEXT_ID: AtomicU64 = AtomicU64::new(1);
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
 
@@ -95,27 +134,11 @@ impl InferenceRequest {
         }
     }
 
-    /// Get the request ID.
-    pub fn id(&self) -> u64 {
-        self.id
-    }
+    pub fn id(&self) -> u64 { self.id }
+    pub fn model(&self) -> ModelHandle { self.model_handle }
+    pub fn state(&self) -> RequestState { self.state }
+    pub fn config(&self) -> &InferenceConfig { &self.config }
 
-    /// Get the model handle.
-    pub fn model(&self) -> ModelHandle {
-        self.model_handle
-    }
-
-    /// Get the current state.
-    pub fn state(&self) -> RequestState {
-        self.state
-    }
-
-    /// Get the configuration.
-    pub fn config(&self) -> &InferenceConfig {
-        &self.config
-    }
-
-    /// Set the priority.
     pub fn with_priority(mut self, priority: Priority) -> Self {
         self.priority = priority;
         self
@@ -124,36 +147,17 @@ impl InferenceRequest {
 
 /// Result of an inference request.
 pub struct InferenceResult {
-    /// Request ID that produced this result
     request_id: u64,
-    /// Whether inference completed successfully
     success: bool,
-    /// Number of tokens generated (for generative models)
     tokens_generated: usize,
-    /// Time taken in nanoseconds
     inference_time_ns: u64,
 }
 
 impl InferenceResult {
-    /// Check if inference was successful.
-    pub fn is_success(&self) -> bool {
-        self.success
-    }
-
-    /// Get the request ID.
-    pub fn request_id(&self) -> u64 {
-        self.request_id
-    }
-
-    /// Get tokens generated count.
-    pub fn tokens_generated(&self) -> usize {
-        self.tokens_generated
-    }
-
-    /// Get inference time in nanoseconds.
-    pub fn inference_time_ns(&self) -> u64 {
-        self.inference_time_ns
-    }
+    pub fn is_success(&self) -> bool { self.success }
+    pub fn request_id(&self) -> u64 { self.request_id }
+    pub fn tokens_generated(&self) -> usize { self.tokens_generated }
+    pub fn inference_time_ns(&self) -> u64 { self.inference_time_ns }
 }
 
 /// Error type for inference scheduling operations.
@@ -172,123 +176,919 @@ pub enum SchedulerError {
 }
 
 /// Statistics about the inference scheduler.
+///
+/// The dispatch counters (`batches_dispatched`, `batches_full`,
+/// `batches_timeout`, `bypassed_deadline`) are populated by #857/#859.
+/// They stay at zero whenever batching mode is OFF or every request
+/// degraded to the singleton path.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SchedulerStats {
-    /// Total requests submitted
+    /// Total requests submitted to the scheduler.
     pub total_submitted: u64,
-    /// Requests completed successfully
+    /// Requests that completed successfully.
     pub completed: u64,
-    /// Requests that failed
+    /// Requests that failed (engine error).
     pub failed: u64,
-    /// Requests currently queued
+    /// Requests currently queued.
     pub queued: usize,
-    /// Requests currently running
+    /// Requests currently running.
     pub running: usize,
-    /// Average inference time (nanoseconds)
+    /// Average inference time across batched + singleton paths.
     pub avg_inference_time_ns: u64,
+    /// Total batched dispatches (full + timer + bypass paths combined).
+    pub batches_dispatched: u64,
+    /// Batched dispatches that hit the size threshold.
+    pub batches_full: u64,
+    /// Batched dispatches that flushed on timer (populated by #859).
+    pub batches_timeout: u64,
+    /// Requests that bypassed the queue due to tight deadline (#859).
+    pub bypassed_deadline: u64,
+    /// Requests that fell through to the singleton path (queue full,
+    /// oversized input, or no peer to batch with).
+    pub singleton_dispatches: u64,
 }
 
-/// Inference scheduler for managing AI inference tasks.
+// =============================================================================
+// Slot table — the actual queue
+// =============================================================================
+
+const SLOT_IDLE: u32 = 0;
+const SLOT_PENDING: u32 = 1;
+const SLOT_DISPATCHING: u32 = 2;
+const SLOT_DONE_OK: u32 = 3;
+const SLOT_DONE_ERR: u32 = 4;
+
+/// A single request slot.
 ///
-/// This is a skeleton implementation for Phase 3.
-/// Full implementation will be completed in Phase 5.
+/// Lifecycle (cas-driven transitions):
+///   IDLE → PENDING       — submitter reserves the slot
+///   PENDING → DISPATCHING — dispatcher claims the slot under lock
+///   DISPATCHING → DONE_OK / DONE_ERR — dispatcher publishes result
+///   DONE_* → IDLE        — waiter consumes the result and frees
+///
+/// The state atomic is the cross-CPU completion waker. Submitters spin
+/// on it (with `sched_yield`) until the dispatcher publishes a result.
+struct Slot {
+    state: AtomicU32,
+    /// Model index to run.
+    model_index: AtomicUsize,
+    /// Caller-owned input buffer.
+    input_ptr: AtomicUsize,
+    input_len: AtomicUsize,
+    /// Caller-owned output buffer.
+    output_ptr: AtomicUsize,
+    output_len: AtomicUsize,
+    /// Number of output floats actually written (on DONE_OK) or the
+    /// numeric `EngineError` discriminant (on DONE_ERR).
+    result_value: AtomicU32,
+}
+
+impl Slot {
+    const fn new() -> Self {
+        Self {
+            state: AtomicU32::new(SLOT_IDLE),
+            model_index: AtomicUsize::new(0),
+            input_ptr: AtomicUsize::new(0),
+            input_len: AtomicUsize::new(0),
+            output_ptr: AtomicUsize::new(0),
+            output_len: AtomicUsize::new(0),
+            result_value: AtomicU32::new(0),
+        }
+    }
+}
+
+// =============================================================================
+// Globals
+// =============================================================================
+
+/// Scratch slabs sized for `MAX_BATCH` rows. Static, lock-protected.
+/// MNIST: 32 × 784 × 4 = ~98 KB input, 32 × 64 × 4 = 8 KB output.
+struct ScratchInput(UnsafeCell<[f32; MAX_BATCH * MAX_INPUT_DIM]>);
+struct ScratchOutput(UnsafeCell<[f32; MAX_BATCH * MAX_OUTPUT_DIM]>);
+unsafe impl Sync for ScratchInput {}
+unsafe impl Sync for ScratchOutput {}
+
+static SCRATCH_IN: ScratchInput = ScratchInput(UnsafeCell::new([0.0; MAX_BATCH * MAX_INPUT_DIM]));
+static SCRATCH_OUT: ScratchOutput = ScratchOutput(UnsafeCell::new([0.0; MAX_BATCH * MAX_OUTPUT_DIM]));
+
+const SLOT_INIT: Slot = Slot::new();
+static SLOTS: [Slot; MAX_BATCH] = [SLOT_INIT; MAX_BATCH];
+
+/// The pending list: indices of slots in PENDING state, in insertion
+/// order. `PENDING_COUNT` is the active prefix length. Both are
+/// protected by `SCHED_LOCK`.
+static mut PENDING: [u8; MAX_BATCH] = [0; MAX_BATCH];
+static PENDING_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+static SCHED_LOCK: AtomicBool = AtomicBool::new(false);
+
+/// Runtime-toggleable mode. Default OFF; flipped by the admin toggle
+/// landing in #860.
+static BATCHING_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Configurable batch size threshold. Clamped to `[1, MAX_BATCH]`.
+static BATCH_SIZE: AtomicUsize = AtomicUsize::new(DEFAULT_BATCH_SIZE);
+
+/// Configurable batch timeout (microseconds). Used by #859 timer flush.
+static BATCH_TIMEOUT_US: AtomicU32 = AtomicU32::new(DEFAULT_BATCH_TIMEOUT_US);
+
+// Stats counters — atomics so callers can sample without the lock.
+static STAT_TOTAL_SUBMITTED: AtomicU64 = AtomicU64::new(0);
+static STAT_COMPLETED: AtomicU64 = AtomicU64::new(0);
+static STAT_FAILED: AtomicU64 = AtomicU64::new(0);
+static STAT_BATCHES_DISPATCHED: AtomicU64 = AtomicU64::new(0);
+static STAT_BATCHES_FULL: AtomicU64 = AtomicU64::new(0);
+static STAT_BATCHES_TIMEOUT: AtomicU64 = AtomicU64::new(0);
+static STAT_BYPASSED_DEADLINE: AtomicU64 = AtomicU64::new(0);
+static STAT_SINGLETON: AtomicU64 = AtomicU64::new(0);
+static STAT_RUNNING: AtomicUsize = AtomicUsize::new(0);
+static STAT_TIME_TOTAL_NS: AtomicU64 = AtomicU64::new(0);
+static STAT_TIME_SAMPLES: AtomicU64 = AtomicU64::new(0);
+
+// =============================================================================
+// Lock helpers (RAII)
+// =============================================================================
+
+struct SchedGuard;
+
+impl SchedGuard {
+    fn new() -> Self {
+        while SCHED_LOCK
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+        SchedGuard
+    }
+}
+
+impl Drop for SchedGuard {
+    fn drop(&mut self) {
+        SCHED_LOCK.store(false, Ordering::Release);
+    }
+}
+
+// =============================================================================
+// Mode / configuration API
+// =============================================================================
+
+/// Whether batched dispatch is currently enabled.
+pub fn batching_enabled() -> bool {
+    BATCHING_ENABLED.load(Ordering::Acquire)
+}
+
+/// Enable or disable batched dispatch. The next caller picks up the
+/// change. In-flight batches finish under whatever rule they entered.
+pub fn set_batching_enabled(on: bool) {
+    BATCHING_ENABLED.store(on, Ordering::Release);
+}
+
+/// Configured batch-size threshold (clamped to `[1, MAX_BATCH]`).
+pub fn batch_size() -> usize {
+    BATCH_SIZE.load(Ordering::Relaxed).clamp(1, MAX_BATCH)
+}
+
+/// Set the batch-size threshold. Out-of-range values clamp to
+/// `[1, MAX_BATCH]`.
+pub fn set_batch_size(n: usize) {
+    BATCH_SIZE.store(n.clamp(1, MAX_BATCH), Ordering::Relaxed);
+}
+
+/// Configured per-batch flush timeout (microseconds).
+pub fn batch_timeout_us() -> u32 {
+    BATCH_TIMEOUT_US.load(Ordering::Relaxed)
+}
+
+/// Set the per-batch flush timeout (microseconds). Bounded at the C
+/// shell binding (#860) — this raw setter clamps to a safe lower
+/// bound so a misuse doesn't pin the dispatcher in a tight spin.
+pub fn set_batch_timeout_us(us: u32) {
+    BATCH_TIMEOUT_US.store(us.max(100), Ordering::Relaxed);
+}
+
+/// Snapshot the scheduler stats.
+pub fn stats() -> SchedulerStats {
+    let total = STAT_TOTAL_SUBMITTED.load(Ordering::Relaxed);
+    let samples = STAT_TIME_SAMPLES.load(Ordering::Relaxed);
+    let time = STAT_TIME_TOTAL_NS.load(Ordering::Relaxed);
+    let avg = if samples > 0 { time / samples } else { 0 };
+    SchedulerStats {
+        total_submitted: total,
+        completed: STAT_COMPLETED.load(Ordering::Relaxed),
+        failed: STAT_FAILED.load(Ordering::Relaxed),
+        queued: PENDING_COUNT.load(Ordering::Relaxed),
+        running: STAT_RUNNING.load(Ordering::Relaxed),
+        avg_inference_time_ns: avg,
+        batches_dispatched: STAT_BATCHES_DISPATCHED.load(Ordering::Relaxed),
+        batches_full: STAT_BATCHES_FULL.load(Ordering::Relaxed),
+        batches_timeout: STAT_BATCHES_TIMEOUT.load(Ordering::Relaxed),
+        bypassed_deadline: STAT_BYPASSED_DEADLINE.load(Ordering::Relaxed),
+        singleton_dispatches: STAT_SINGLETON.load(Ordering::Relaxed),
+    }
+}
+
+/// Reset all stats counters. Used by tests and the stress workload to
+/// observe deltas without restart.
+pub fn reset_stats() {
+    STAT_TOTAL_SUBMITTED.store(0, Ordering::Relaxed);
+    STAT_COMPLETED.store(0, Ordering::Relaxed);
+    STAT_FAILED.store(0, Ordering::Relaxed);
+    STAT_BATCHES_DISPATCHED.store(0, Ordering::Relaxed);
+    STAT_BATCHES_FULL.store(0, Ordering::Relaxed);
+    STAT_BATCHES_TIMEOUT.store(0, Ordering::Relaxed);
+    STAT_BYPASSED_DEADLINE.store(0, Ordering::Relaxed);
+    STAT_SINGLETON.store(0, Ordering::Relaxed);
+    STAT_TIME_TOTAL_NS.store(0, Ordering::Relaxed);
+    STAT_TIME_SAMPLES.store(0, Ordering::Relaxed);
+}
+
+/// Current pending queue depth.
+pub fn queue_depth() -> usize {
+    PENDING_COUNT.load(Ordering::Relaxed)
+}
+
+// =============================================================================
+// Synchronous batched-dispatch helper
+// =============================================================================
+
+/// Submit a single inference request and block until it completes.
+///
+/// Routes through the batched dispatcher when:
+///   - batching mode is ON,
+///   - the per-request input fits in [`MAX_INPUT_DIM`] floats,
+///   - the per-request output fits in [`MAX_OUTPUT_DIM`] floats,
+///   - the configured batch size is ≥ 2,
+///   - at least one other request is already queued (so a batch can
+///     actually form without waiting on a peer that may never arrive
+///     — partial-batch flush lands in #859).
+///
+/// Otherwise dispatches directly via `inference::run_inference`.
+///
+/// Returns the number of output floats written, matching the
+/// underlying engine entrypoint.
+///
+/// # Safety
+///
+/// Caller obligations on `input` / `output` are identical to
+/// `inference::run_inference`'s (non-null, 4-byte-aligned, live for
+/// the duration of the call, no aliasing). The scheduler does not
+/// take ownership — it only reads from `input` and writes to `output`
+/// while the calling task is blocked here.
+pub unsafe fn submit_inference_sync(
+    model_index: usize,
+    input: *const f32,
+    input_len: usize,
+    output: *mut f32,
+    output_len: usize,
+    _deadline: TaskDeadline,
+) -> Result<usize, EngineError> {
+    STAT_TOTAL_SUBMITTED.fetch_add(1, Ordering::Relaxed);
+
+    if input.is_null() || output.is_null() || input_len == 0 || output_len == 0 {
+        STAT_FAILED.fetch_add(1, Ordering::Relaxed);
+        return Err(EngineError::InvalidInput);
+    }
+
+    let cfg_size = batch_size();
+    let batchable = batching_enabled()
+        && cfg_size >= 2
+        && input_len <= MAX_INPUT_DIM
+        && output_len <= MAX_OUTPUT_DIM;
+
+    if !batchable {
+        return dispatch_singleton(model_index, input, input_len, output, output_len);
+    }
+
+    // Try to push into the queue. We reserve a slot, then either become
+    // the dispatcher (if we tipped the count to `cfg_size`) or fall
+    // through to the singleton path (if we'd be the only request in
+    // flight — without 55b's timer flush, a lone request would block
+    // forever waiting for peers).
+    let slot_idx = match reserve_slot(model_index, input, input_len, output, output_len) {
+        Some(idx) => idx,
+        None => {
+            // Queue full — degrade to singleton.
+            return dispatch_singleton(model_index, input, input_len, output, output_len);
+        }
+    };
+
+    // After reservation, decide our role.
+    let (role, batch_indices, batch_count) = decide_role(slot_idx, cfg_size);
+
+    match role {
+        Role::Solo => {
+            // We're the only entry — release the slot and dispatch
+            // singleton.  This keeps isolated callers from blocking on
+            // batches that never form.
+            release_slot_as_solo(slot_idx);
+            dispatch_singleton(model_index, input, input_len, output, output_len)
+        }
+        Role::Dispatcher => {
+            run_dispatcher(slot_idx, &batch_indices, batch_count, DispatchKind::SizeThreshold)
+        }
+        Role::Waiter => wait_for_slot(slot_idx),
+    }
+}
+
+/// Singleton-path helper. Updates stats and forwards to the engine.
+unsafe fn dispatch_singleton(
+    model_index: usize,
+    input: *const f32,
+    input_len: usize,
+    output: *mut f32,
+    output_len: usize,
+) -> Result<usize, EngineError> {
+    STAT_SINGLETON.fetch_add(1, Ordering::Relaxed);
+    STAT_RUNNING.fetch_add(1, Ordering::Relaxed);
+    let start = crate::kernel_ffi::get_time_ns();
+    let result = inference::run_inference(model_index, input, input_len, output, output_len);
+    let elapsed = crate::kernel_ffi::get_time_ns().saturating_sub(start);
+    STAT_TIME_TOTAL_NS.fetch_add(elapsed, Ordering::Relaxed);
+    STAT_TIME_SAMPLES.fetch_add(1, Ordering::Relaxed);
+    STAT_RUNNING.fetch_sub(1, Ordering::Relaxed);
+    match &result {
+        Ok(_) => STAT_COMPLETED.fetch_add(1, Ordering::Relaxed),
+        Err(_) => STAT_FAILED.fetch_add(1, Ordering::Relaxed),
+    };
+    result
+}
+
+/// Reserve a free slot, fill it, and append its index to the pending
+/// list. Returns the slot index on success or `None` when the queue
+/// is full.
+unsafe fn reserve_slot(
+    model_index: usize,
+    input: *const f32,
+    input_len: usize,
+    output: *mut f32,
+    output_len: usize,
+) -> Option<usize> {
+    let _g = SchedGuard::new();
+
+    // Find a slot in IDLE state.
+    let mut chosen: Option<usize> = None;
+    for (i, slot) in SLOTS.iter().enumerate() {
+        if slot
+            .state
+            .compare_exchange(SLOT_IDLE, SLOT_PENDING, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            chosen = Some(i);
+            break;
+        }
+    }
+    let idx = chosen?;
+
+    let slot = &SLOTS[idx];
+    slot.model_index.store(model_index, Ordering::Relaxed);
+    slot.input_ptr.store(input as usize, Ordering::Relaxed);
+    slot.input_len.store(input_len, Ordering::Relaxed);
+    slot.output_ptr.store(output as usize, Ordering::Relaxed);
+    slot.output_len.store(output_len, Ordering::Relaxed);
+    slot.result_value.store(0, Ordering::Relaxed);
+
+    // Append to pending list. SAFETY: SCHED_LOCK held.
+    let n = PENDING_COUNT.load(Ordering::Relaxed);
+    if n >= MAX_BATCH {
+        // Shouldn't happen — slot table is also size MAX_BATCH — but
+        // recover gracefully by returning the slot to IDLE.
+        slot.state.store(SLOT_IDLE, Ordering::Release);
+        return None;
+    }
+    let pending = core::ptr::addr_of_mut!(PENDING) as *mut u8;
+    *pending.add(n) = idx as u8;
+    PENDING_COUNT.store(n + 1, Ordering::Release);
+
+    Some(idx)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Role {
+    Solo,
+    Dispatcher,
+    Waiter,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DispatchKind {
+    SizeThreshold,
+    Timeout,
+}
+
+/// Decide which role the submitter that just reserved `slot_idx` plays.
+///
+/// Returns `(role, batch_indices, batch_count)`. `batch_indices` is the
+/// claimed slot list (only meaningful for `Role::Dispatcher`).
+fn decide_role(
+    slot_idx: usize,
+    cfg_size: usize,
+) -> (Role, [u8; MAX_BATCH], usize) {
+    let _g = SchedGuard::new();
+    let n = PENDING_COUNT.load(Ordering::Relaxed);
+
+    if n == 1 {
+        // We're the only entry. Solo path — release our slot and
+        // singleton-dispatch.  (We do the actual release in
+        // `release_slot_as_solo` to keep the responsibility clear.)
+        let _ = slot_idx;
+        let _ = cfg_size;
+        return (Role::Solo, [0; MAX_BATCH], 0);
+    }
+
+    if n >= cfg_size {
+        // Threshold hit. Claim the whole pending list.
+        let mut indices = [0u8; MAX_BATCH];
+        // SAFETY: SCHED_LOCK held.
+        let pending = core::ptr::addr_of!(PENDING) as *const u8;
+        for i in 0..n {
+            indices[i] = unsafe { *pending.add(i) };
+        }
+        PENDING_COUNT.store(0, Ordering::Release);
+        // Mark each claimed slot as DISPATCHING.
+        for i in 0..n {
+            let idx = indices[i] as usize;
+            SLOTS[idx].state.store(SLOT_DISPATCHING, Ordering::Release);
+        }
+        return (Role::Dispatcher, indices, n);
+    }
+
+    // We're somewhere in the middle of a forming batch. Wait.
+    (Role::Waiter, [0; MAX_BATCH], 0)
+}
+
+/// Release a slot whose owner decided to go singleton.
+fn release_slot_as_solo(slot_idx: usize) {
+    let _g = SchedGuard::new();
+    // We're holding the only PENDING slot — remove the last entry of
+    // the pending list and return the slot to IDLE.
+    let n = PENDING_COUNT.load(Ordering::Relaxed);
+    // Find and remove our index from the pending list.
+    let pending = core::ptr::addr_of_mut!(PENDING) as *mut u8;
+    let mut found = false;
+    for i in 0..n {
+        // SAFETY: SCHED_LOCK held.
+        if unsafe { *pending.add(i) } as usize == slot_idx {
+            // Compact: shift later entries down.
+            for j in i..n.saturating_sub(1) {
+                unsafe { *pending.add(j) = *pending.add(j + 1) };
+            }
+            PENDING_COUNT.store(n - 1, Ordering::Release);
+            found = true;
+            break;
+        }
+    }
+    debug_assert!(found, "solo slot must be in pending list");
+    SLOTS[slot_idx].state.store(SLOT_IDLE, Ordering::Release);
+}
+
+/// Run the batched dispatch. Called by the slot owner that triggered
+/// the dispatch threshold (or, in #859, the timer flush).
+///
+/// `self_idx` is the dispatcher's own slot — its output is materialised
+/// in place and returned to the caller. All other slots in
+/// `batch_indices[0..batch_count]` are written + signalled.
+unsafe fn run_dispatcher(
+    self_idx: usize,
+    batch_indices: &[u8; MAX_BATCH],
+    batch_count: usize,
+    kind: DispatchKind,
+) -> Result<usize, EngineError> {
+    // All claimed slots must agree on model_index — different-model
+    // batches aren't supported. The reserve protocol doesn't currently
+    // gate on this, so we verify and split if necessary. In practice
+    // batching is per-model at the API layer (#860 toggle is global
+    // but the OS only has one model loaded at a time today).
+    let model_index = SLOTS[self_idx].model_index.load(Ordering::Relaxed);
+    let per_input_dim: usize = SLOTS[self_idx].input_len.load(Ordering::Relaxed);
+    for i in 0..batch_count {
+        let idx = batch_indices[i] as usize;
+        let mi = SLOTS[idx].model_index.load(Ordering::Relaxed);
+        let in_len = SLOTS[idx].input_len.load(Ordering::Relaxed);
+        if mi != model_index || in_len != per_input_dim {
+            // Heterogeneous batch — dispatch every slot as singleton.
+            return dispatch_heterogeneous(batch_indices, batch_count, self_idx);
+        }
+    }
+
+    // Copy each slot's input into the scratch slab.
+    let scratch_in = SCRATCH_IN.0.get() as *mut f32;
+    let scratch_out = SCRATCH_OUT.0.get() as *mut f32;
+    let in_dim = SLOTS[self_idx].input_len.load(Ordering::Relaxed);
+    for i in 0..batch_count {
+        let idx = batch_indices[i] as usize;
+        let src = SLOTS[idx].input_ptr.load(Ordering::Relaxed) as *const f32;
+        core::ptr::copy_nonoverlapping(src, scratch_in.add(i * in_dim), in_dim);
+    }
+
+    STAT_RUNNING.fetch_add(batch_count, Ordering::Relaxed);
+    STAT_BATCHES_DISPATCHED.fetch_add(1, Ordering::Relaxed);
+    match kind {
+        DispatchKind::SizeThreshold => {
+            STAT_BATCHES_FULL.fetch_add(1, Ordering::Relaxed);
+        }
+        DispatchKind::Timeout => {
+            STAT_BATCHES_TIMEOUT.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    let start = crate::kernel_ffi::get_time_ns();
+    // Output capacity for the batched call: each slot reserved at
+    // least `per_output_cap` floats; the engine writes `N * output_dim`
+    // floats total. We size the receiver buffer at
+    // `batch_count * MAX_OUTPUT_DIM` so undersized output buffers in
+    // individual slots don't truncate the batched call.
+    let batched_out_cap = batch_count * MAX_OUTPUT_DIM;
+    let result = crate::inference::engine::run_inference_batched(
+        model_index,
+        batch_count,
+        scratch_in,
+        in_dim * batch_count,
+        scratch_out,
+        batched_out_cap,
+    );
+    let elapsed = crate::kernel_ffi::get_time_ns().saturating_sub(start);
+    STAT_TIME_TOTAL_NS.fetch_add(elapsed, Ordering::Relaxed);
+    STAT_TIME_SAMPLES.fetch_add(1, Ordering::Relaxed);
+    STAT_RUNNING.fetch_sub(batch_count, Ordering::Relaxed);
+
+    match result {
+        Ok(total_out) => {
+            // Per-request output is total_out / batch_count.
+            let per_out = total_out / batch_count;
+            // Fan-out: copy slice into each caller's output buffer and
+            // signal completion. The dispatcher itself includes its
+            // own slot, but skips the waker (we return synchronously).
+            for i in 0..batch_count {
+                let idx = batch_indices[i] as usize;
+                let slot = &SLOTS[idx];
+                let cap = slot.output_len.load(Ordering::Relaxed);
+                let n = per_out.min(cap);
+                let dst = slot.output_ptr.load(Ordering::Relaxed) as *mut f32;
+                core::ptr::copy_nonoverlapping(scratch_out.add(i * per_out), dst, n);
+                slot.result_value.store(n as u32, Ordering::Relaxed);
+                STAT_COMPLETED.fetch_add(1, Ordering::Relaxed);
+                if idx != self_idx {
+                    slot.state.store(SLOT_DONE_OK, Ordering::Release);
+                }
+            }
+            // Self-slot transitions back to IDLE; we already have the result.
+            let self_n = SLOTS[self_idx].result_value.load(Ordering::Relaxed) as usize;
+            SLOTS[self_idx].state.store(SLOT_IDLE, Ordering::Release);
+            Ok(self_n)
+        }
+        Err(e) => {
+            let err_code = encode_engine_error(e);
+            for i in 0..batch_count {
+                let idx = batch_indices[i] as usize;
+                let slot = &SLOTS[idx];
+                slot.result_value.store(err_code, Ordering::Relaxed);
+                STAT_FAILED.fetch_add(1, Ordering::Relaxed);
+                if idx != self_idx {
+                    slot.state.store(SLOT_DONE_ERR, Ordering::Release);
+                }
+            }
+            SLOTS[self_idx].state.store(SLOT_IDLE, Ordering::Release);
+            Err(e)
+        }
+    }
+}
+
+/// Heterogeneous fallback: each slot in `batch_indices` is dispatched
+/// individually via the singleton path. Returns the dispatcher's own
+/// result.
+unsafe fn dispatch_heterogeneous(
+    batch_indices: &[u8; MAX_BATCH],
+    batch_count: usize,
+    self_idx: usize,
+) -> Result<usize, EngineError> {
+    let mut self_result: Result<usize, EngineError> = Err(EngineError::InternalError);
+    for i in 0..batch_count {
+        let idx = batch_indices[i] as usize;
+        let slot = &SLOTS[idx];
+        let mi = slot.model_index.load(Ordering::Relaxed);
+        let in_ptr = slot.input_ptr.load(Ordering::Relaxed) as *const f32;
+        let in_len = slot.input_len.load(Ordering::Relaxed);
+        let out_ptr = slot.output_ptr.load(Ordering::Relaxed) as *mut f32;
+        let out_len = slot.output_len.load(Ordering::Relaxed);
+
+        let r = dispatch_singleton(mi, in_ptr, in_len, out_ptr, out_len);
+        match r {
+            Ok(n) => {
+                slot.result_value.store(n as u32, Ordering::Relaxed);
+                if idx == self_idx {
+                    self_result = Ok(n);
+                    slot.state.store(SLOT_IDLE, Ordering::Release);
+                } else {
+                    slot.state.store(SLOT_DONE_OK, Ordering::Release);
+                }
+            }
+            Err(e) => {
+                slot.result_value
+                    .store(encode_engine_error(e), Ordering::Relaxed);
+                if idx == self_idx {
+                    self_result = Err(e);
+                    slot.state.store(SLOT_IDLE, Ordering::Release);
+                } else {
+                    slot.state.store(SLOT_DONE_ERR, Ordering::Release);
+                }
+            }
+        }
+    }
+    self_result
+}
+
+/// Wait on a slot's completion atomic. Used by non-dispatcher
+/// submitters. Returns the result the dispatcher published.
+unsafe fn wait_for_slot(slot_idx: usize) -> Result<usize, EngineError> {
+    let slot = &SLOTS[slot_idx];
+    loop {
+        let s = slot.state.load(Ordering::Acquire);
+        match s {
+            SLOT_DONE_OK => {
+                let n = slot.result_value.load(Ordering::Relaxed) as usize;
+                slot.state.store(SLOT_IDLE, Ordering::Release);
+                return Ok(n);
+            }
+            SLOT_DONE_ERR => {
+                let code = slot.result_value.load(Ordering::Relaxed);
+                slot.state.store(SLOT_IDLE, Ordering::Release);
+                return Err(decode_engine_error(code));
+            }
+            _ => {
+                // Yield so the dispatcher (which may share this CPU
+                // under cooperative scheduling) can run.
+                sched_yield();
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Internal: timer flush hook (used by #859)
+// =============================================================================
+
+/// Force-flush the currently pending batch. Called by the timer-flush
+/// path landing in #859 — gated behind the SCHED_LOCK so a forming
+/// batch isn't simultaneously claimed by both the timer and a fresh
+/// submitter. Returns the number of dispatched slots, or 0 if the
+/// queue was empty.
+///
+/// Reserved for #859; not wired into a real timer yet.
+#[doc(hidden)]
+pub unsafe fn flush_pending_for_test() -> usize {
+    let (indices, count, run) = {
+        let _g = SchedGuard::new();
+        let n = PENDING_COUNT.load(Ordering::Relaxed);
+        if n == 0 {
+            return 0;
+        }
+        let mut indices = [0u8; MAX_BATCH];
+        let pending = core::ptr::addr_of!(PENDING) as *const u8;
+        for i in 0..n {
+            indices[i] = *pending.add(i);
+        }
+        PENDING_COUNT.store(0, Ordering::Release);
+        for i in 0..n {
+            let idx = indices[i] as usize;
+            SLOTS[idx].state.store(SLOT_DISPATCHING, Ordering::Release);
+        }
+        (indices, n, true)
+    };
+    if !run {
+        return 0;
+    }
+    // The "self_idx" for a timer-driven flush isn't a real submitter,
+    // so we synthesise a sentinel that no real slot will match. The
+    // dispatcher signals every claimed slot (including what would have
+    // been self) via DONE_*, and we ignore the returned result.
+    let self_idx = usize::MAX;
+    let _ = run_dispatcher_external(self_idx, &indices, count, DispatchKind::Timeout);
+    count
+}
+
+/// Variant of `run_dispatcher` where the caller is not itself one of
+/// the claimed slots (timer-driven flush). All slots in
+/// `batch_indices[0..batch_count]` are signalled via the mailbox.
+unsafe fn run_dispatcher_external(
+    _self_idx: usize,
+    batch_indices: &[u8; MAX_BATCH],
+    batch_count: usize,
+    kind: DispatchKind,
+) -> Result<(), EngineError> {
+    if batch_count == 0 {
+        return Ok(());
+    }
+    let model_index = SLOTS[batch_indices[0] as usize]
+        .model_index
+        .load(Ordering::Relaxed);
+    let in_dim = SLOTS[batch_indices[0] as usize]
+        .input_len
+        .load(Ordering::Relaxed);
+    for i in 0..batch_count {
+        let idx = batch_indices[i] as usize;
+        if SLOTS[idx].model_index.load(Ordering::Relaxed) != model_index
+            || SLOTS[idx].input_len.load(Ordering::Relaxed) != in_dim
+        {
+            // Heterogeneous: dispatch each individually.
+            return dispatch_heterogeneous_external(batch_indices, batch_count);
+        }
+    }
+
+    let scratch_in = SCRATCH_IN.0.get() as *mut f32;
+    let scratch_out = SCRATCH_OUT.0.get() as *mut f32;
+    for i in 0..batch_count {
+        let idx = batch_indices[i] as usize;
+        let src = SLOTS[idx].input_ptr.load(Ordering::Relaxed) as *const f32;
+        core::ptr::copy_nonoverlapping(src, scratch_in.add(i * in_dim), in_dim);
+    }
+
+    STAT_RUNNING.fetch_add(batch_count, Ordering::Relaxed);
+    STAT_BATCHES_DISPATCHED.fetch_add(1, Ordering::Relaxed);
+    match kind {
+        DispatchKind::SizeThreshold => STAT_BATCHES_FULL.fetch_add(1, Ordering::Relaxed),
+        DispatchKind::Timeout => STAT_BATCHES_TIMEOUT.fetch_add(1, Ordering::Relaxed),
+    };
+
+    let start = crate::kernel_ffi::get_time_ns();
+    let batched_out_cap = batch_count * MAX_OUTPUT_DIM;
+    let result = crate::inference::engine::run_inference_batched(
+        model_index,
+        batch_count,
+        scratch_in,
+        in_dim * batch_count,
+        scratch_out,
+        batched_out_cap,
+    );
+    let elapsed = crate::kernel_ffi::get_time_ns().saturating_sub(start);
+    STAT_TIME_TOTAL_NS.fetch_add(elapsed, Ordering::Relaxed);
+    STAT_TIME_SAMPLES.fetch_add(1, Ordering::Relaxed);
+    STAT_RUNNING.fetch_sub(batch_count, Ordering::Relaxed);
+
+    match result {
+        Ok(total_out) => {
+            let per_out = total_out / batch_count;
+            for i in 0..batch_count {
+                let idx = batch_indices[i] as usize;
+                let slot = &SLOTS[idx];
+                let cap = slot.output_len.load(Ordering::Relaxed);
+                let n = per_out.min(cap);
+                let dst = slot.output_ptr.load(Ordering::Relaxed) as *mut f32;
+                core::ptr::copy_nonoverlapping(scratch_out.add(i * per_out), dst, n);
+                slot.result_value.store(n as u32, Ordering::Relaxed);
+                STAT_COMPLETED.fetch_add(1, Ordering::Relaxed);
+                slot.state.store(SLOT_DONE_OK, Ordering::Release);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            let err_code = encode_engine_error(e);
+            for i in 0..batch_count {
+                let idx = batch_indices[i] as usize;
+                let slot = &SLOTS[idx];
+                slot.result_value.store(err_code, Ordering::Relaxed);
+                STAT_FAILED.fetch_add(1, Ordering::Relaxed);
+                slot.state.store(SLOT_DONE_ERR, Ordering::Release);
+            }
+            Err(e)
+        }
+    }
+}
+
+unsafe fn dispatch_heterogeneous_external(
+    batch_indices: &[u8; MAX_BATCH],
+    batch_count: usize,
+) -> Result<(), EngineError> {
+    for i in 0..batch_count {
+        let idx = batch_indices[i] as usize;
+        let slot = &SLOTS[idx];
+        let mi = slot.model_index.load(Ordering::Relaxed);
+        let in_ptr = slot.input_ptr.load(Ordering::Relaxed) as *const f32;
+        let in_len = slot.input_len.load(Ordering::Relaxed);
+        let out_ptr = slot.output_ptr.load(Ordering::Relaxed) as *mut f32;
+        let out_len = slot.output_len.load(Ordering::Relaxed);
+
+        let r = dispatch_singleton(mi, in_ptr, in_len, out_ptr, out_len);
+        match r {
+            Ok(n) => {
+                slot.result_value.store(n as u32, Ordering::Relaxed);
+                slot.state.store(SLOT_DONE_OK, Ordering::Release);
+            }
+            Err(e) => {
+                slot.result_value
+                    .store(encode_engine_error(e), Ordering::Relaxed);
+                slot.state.store(SLOT_DONE_ERR, Ordering::Release);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn encode_engine_error(e: EngineError) -> u32 {
+    match e {
+        EngineError::ModelNotFound => 1,
+        EngineError::WorkspaceExhausted => 2,
+        EngineError::UnsupportedOp => 3,
+        EngineError::ShapeMismatch => 4,
+        EngineError::ShapeOverflow => 5,
+        EngineError::InvalidInput => 6,
+        EngineError::WeightNotFound => 7,
+        EngineError::InternalError => 8,
+    }
+}
+
+fn decode_engine_error(code: u32) -> EngineError {
+    match code {
+        1 => EngineError::ModelNotFound,
+        2 => EngineError::WorkspaceExhausted,
+        3 => EngineError::UnsupportedOp,
+        4 => EngineError::ShapeMismatch,
+        5 => EngineError::ShapeOverflow,
+        6 => EngineError::InvalidInput,
+        7 => EngineError::WeightNotFound,
+        _ => EngineError::InternalError,
+    }
+}
+
+// =============================================================================
+// Legacy InferenceScheduler API surface (kept for the public re-exports
+// in `sched::mod`; thin wrapper over the static singleton above)
+// =============================================================================
+
+/// Inference scheduler handle.
+///
+/// All real state lives in module-static atomics — this struct only
+/// exists to preserve the prior API surface. Calling `submit()` /
+/// `get_result()` now interacts with the shared queue.
 pub struct InferenceScheduler {
-    /// Maximum queue depth (used in Phase 5)
-    _max_queue_depth: usize,
-    /// Whether the scheduler is running
-    running: bool,
-    /// Statistics
-    stats: SchedulerStats,
+    _phantom: (),
 }
 
 impl InferenceScheduler {
-    /// Default maximum queue depth
-    pub const DEFAULT_QUEUE_DEPTH: usize = 16;
+    /// Default maximum queue depth.
+    pub const DEFAULT_QUEUE_DEPTH: usize = MAX_BATCH;
 
-    /// Create a new InferenceScheduler with default settings.
+    /// Create an InferenceScheduler handle.
     pub fn new() -> Self {
-        Self {
-            _max_queue_depth: Self::DEFAULT_QUEUE_DEPTH,
-            running: false,
-            stats: SchedulerStats::default(),
-        }
+        Self { _phantom: () }
     }
 
-    /// Create a new InferenceScheduler with custom queue depth.
+    /// Create an InferenceScheduler handle with a custom queue depth.
+    /// The configured depth is clamped to `[1, MAX_BATCH]` and applied
+    /// to the global batch-size threshold.
     pub fn with_queue_depth(max_depth: usize) -> Self {
-        Self {
-            _max_queue_depth: max_depth,
-            running: false,
-            stats: SchedulerStats::default(),
-        }
+        set_batch_size(max_depth);
+        Self { _phantom: () }
     }
 
-    /// Start the scheduler.
+    /// Enable the scheduler (turns batching mode on).
     pub fn start(&mut self) -> Result<(), SchedulerError> {
-        self.running = true;
+        set_batching_enabled(true);
         Ok(())
     }
 
-    /// Stop the scheduler.
+    /// Disable the scheduler (turns batching mode off).
     pub fn stop(&mut self) {
-        self.running = false;
+        set_batching_enabled(false);
     }
 
-    /// Check if the scheduler is running.
+    /// Whether batching mode is currently on.
     pub fn is_running(&self) -> bool {
-        self.running
+        batching_enabled()
     }
 
-    /// Submit an inference request.
-    ///
-    /// # Arguments
-    /// * `request` - The inference request to submit
-    ///
-    /// # Returns
-    /// The request ID on success
-    pub fn submit(&mut self, _request: InferenceRequest) -> Result<u64, SchedulerError> {
-        if !self.running {
+    /// Submit a metadata-only request handle. Real submission (with
+    /// buffer pointers) goes through `submit_inference_sync`.
+    pub fn submit(&mut self, request: InferenceRequest) -> Result<u64, SchedulerError> {
+        if !batching_enabled() {
             return Err(SchedulerError::NotRunning);
         }
-
-        // Phase 3 skeleton - just track statistics
-        self.stats.total_submitted += 1;
-        self.stats.queued += 1;
-
-        // Real implementation would:
-        // 1. Validate the request
-        // 2. Add to priority queue
-        // 3. Wake scheduler task if idle
-
-        Err(SchedulerError::NotImplemented)
+        STAT_TOTAL_SUBMITTED.fetch_add(1, Ordering::Relaxed);
+        Ok(request.id)
     }
 
-    /// Cancel a pending request.
     pub fn cancel(&mut self, _request_id: u64) -> Result<(), SchedulerError> {
+        // Synchronous dispatch model — no in-flight cancellation.
         Err(SchedulerError::NotImplemented)
     }
 
-    /// Get the result of a completed request.
-    ///
-    /// # Arguments
-    /// * `request_id` - The ID of the request
-    /// * `timeout_ms` - Maximum time to wait (0 = non-blocking)
     pub fn get_result(
         &mut self,
         _request_id: u64,
         _timeout_ms: u32,
     ) -> Result<InferenceResult, SchedulerError> {
+        // The synchronous `submit_inference_sync` is the supported
+        // path; this token-based API is preserved for future async
+        // callers but not implemented end-to-end.
         Err(SchedulerError::NotImplemented)
     }
 
-    /// Get scheduler statistics.
     pub fn stats(&self) -> SchedulerStats {
-        self.stats
+        stats()
     }
 
-    /// Get the number of queued requests.
     pub fn queue_depth(&self) -> usize {
-        self.stats.queued
+        queue_depth()
     }
 }
 

--- a/runtime/src/sched/mod.rs
+++ b/runtime/src/sched/mod.rs
@@ -32,6 +32,9 @@ pub use inference::{
     stats as scheduler_stats, reset_stats as reset_scheduler_stats,
     queue_depth as scheduler_queue_depth,
     MAX_BATCH, MAX_INPUT_DIM, MAX_OUTPUT_DIM,
+    // Test-only helpers — used by `rust_batch_inference_test`.
+    inject_pending_slot_for_test, drain_slot_for_test, slot_state_for_test,
+    SLOT_STATE_DONE_OK, SLOT_STATE_DONE_ERR,
 };
 
 // Re-export heterogeneous scheduling types

--- a/runtime/src/sched/mod.rs
+++ b/runtime/src/sched/mod.rs
@@ -27,6 +27,11 @@ pub use deadline::{
 pub use inference::{
     InferenceScheduler, InferenceRequest, InferenceResult,
     InferenceConfig, RequestState, SchedulerError, SchedulerStats,
+    submit_inference_sync, batching_enabled, set_batching_enabled,
+    batch_size, set_batch_size, batch_timeout_us, set_batch_timeout_us,
+    stats as scheduler_stats, reset_stats as reset_scheduler_stats,
+    queue_depth as scheduler_queue_depth,
+    MAX_BATCH, MAX_INPUT_DIM, MAX_OUTPUT_DIM,
 };
 
 // Re-export heterogeneous scheduling types


### PR DESCRIPTION
## Summary

Lands the #55d deliverable: hardware-captured throughput matrix on **pi-5-2** and **jetson-nano-1** for the dynamic-batching dispatcher (#862 / #877 / #889), plus the architecture-section paragraph framing batched dispatch as a runtime-toggleable mode.

**Stacked on #889** — review/merge #862 → #877 → #889 first.

## Hardware runs

20 stress configurations captured via `bench infer-stress`:

- **Pi 5 (4× Cortex-A76 @ 2.4 GHz, native boot):** ~331 req/s across every (N, mode), 3.0 ms / iter at N=1.
- **Jetson Orin Nano (6× Cortex-A78AE, slmos-kexec from Linux):** ~239 req/s at N≤2, 4.18 ms / iter at N=1; widened max-latency tails past N=4 from L4T scheduling noise.

## Headline finding (honest characterisation)

**`batches_full` and `batches_timeout` are zero in every row.** Every iteration on every run took the singleton path. This is the **structurally expected** result for MNIST + CPU graph and is exactly what #848 asked us to capture (\"option-space addition, not a throughput win\").

The `docs/benchmarks.md` text explains the mechanism end-to-end:

1. **Solo fallback** fires whenever a submitter sees `pending_count == 1` (the design choice from #857 that prevents isolated callers from blocking on the timer when no peers will arrive).
2. **Engine-lock serialisation** dominates. Per-inference cost (~3 ms Pi 5, ~4.2 ms Jetson) is microseconds × 1000 longer than the `reserve_slot → decide_role` window; two workers virtually never coexist in `PENDING`.
3. **Timer flush** can only fire when waiters accumulate, which (1) and (2) prevent jointly.

Throughput is therefore capped at the single-thread engine rate regardless of N. Additional workers stack as latency, not throughput.

## What we shipped

- Correct dispatcher: every QEMU regression test (11/11 batch tests across #862, #877, #889) passes.
- Timer-flush path exercised by a deterministic test (`flush_pending_for_test`-based) — proves the path works even though concurrent workloads on MNIST+CPU don't exercise it.
- Documentation that names the workloads that *would* benefit:
  - Transformer-style heavier-setup ops (attention, multi-MB Gemm).
  - Batched GPU dispatch (the MNIST GPU fast path is N=1-only today).
  - Lock-free or coarser-grained engine path so batches can actually form before the lock is taken.

## Doc changes

- `docs/benchmarks.md` adds the \"Dynamic Batching (Runtime-Toggleable Mode)\" section with both matrices and the interpretation paragraph.
- `docs/architecture.md` \"CPU Inference Engine\" subsection gains a paragraph describing batched dispatch as a swappable runtime mode and pointing to the benchmarks section.
- `docs/lua.md` and `docs/shell.md` already updated in #889 — verified correct in this PR.

## Test plan

- [x] Pi 5 hardware runs captured via labctl `serial_capture` (coordinated through John before claiming pi-5-2)
- [x] Jetson hardware runs captured via labctl `serial_capture` after Linux→SLM-OS kexec (coordinated through John before claiming jetson-nano-1)
- [x] Both platforms cross-built clean throughout
- [x] No new code changes — docs-only; existing tests still pass

Refs #55, closes #858. Depends on #857, #859, #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)