### PR TITLE
sshd 199c: SSH channel → shell_session + autostart (#891) — DEMO MOMENT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,15 @@ if(ENABLE_NETWORKING AND NET_SSHD AND NET_SSHD_AUTOSTART)
     add_compile_definitions(NET_SSHD_AUTOSTART=1)
 endif()
 
+# #199c demo: wolfSSH user-auth callback that accepts every login. The
+# kernel logs a WARNING on every autostart while this is wired. #199d
+# (#896) lands real scrypt-against-/etc/passwd auth and flips this OFF
+# in a one-line CMake diff — no source change needed in sshd.c.
+option(NET_SSHD_DEMO_ALLOW_ALL "wolfSSH allow-all user-auth stub (#199c demo)" ON)
+if(ENABLE_NETWORKING AND NET_SSHD AND NET_SSHD_DEMO_ALLOW_ALL)
+    add_compile_definitions(NET_SSHD_DEMO_ALLOW_ALL=1)
+endif()
+
 # Linker script - platform-specific
 if(PLATFORM STREQUAL "X86_64")
     # Three x86-64 layouts — KEXEC_BUILD and BZIMAGE_BUILD are mutually

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1918,12 +1918,15 @@ if(ENABLE_NETWORKING AND NET_SSHD AND NOT PLATFORM STREQUAL "X86_64")
     target_link_libraries(wolfssh PRIVATE wolfcrypt)
 
     # SLM-OS-side glue: time, RNG seed, lwIP IO callbacks, listener,
-    # accept loop, host-key persistence, shell verb.
+    # accept loop, host-key persistence, shell-session binding,
+    # autostart, shell verb.
     target_sources(slmos.elf PRIVATE
         kernel/net/ssh/wolf_os.c
         kernel/net/ssh/sshd.c
         kernel/net/ssh/sshd_shell.c
         kernel/net/ssh/host_key.c
+        kernel/net/ssh/shell_io_ssh.c
+        kernel/net/ssh/sshd_autostart.c
     )
     target_include_directories(slmos.elf PRIVATE
         ${CMAKE_SOURCE_DIR}/kernel/net/ssh)

--- a/kernel/net/ssh/shell_io_ssh.c
+++ b/kernel/net/ssh/shell_io_ssh.c
@@ -25,7 +25,6 @@
 #include "kbuf.h"
 #include "rng.h"
 #include "shell_session.h"
-#include "spinlock.h"
 #include "string.h"
 #include "task.h"
 #include "timer.h"
@@ -40,11 +39,17 @@
 
 struct ssh_io_ctx {
     WOLFSSH         *ssh;        /* borrowed — owner is sshd_conn */
-    spinlock_t       lock;       /* serialises stream_send writes */
     volatile bool    closed;     /* set by close() or peer disconnect */
     bool             binary_mode;
     char             read_holdover;
     bool             have_holdover;
+};
+
+/* Allocation wrapper: one kbuf_alloc covers both the shell_io vtable
+ * and the per-session ctx, halving the per-session allocator hops. */
+struct ssh_io_alloc {
+    struct shell_io     io;
+    struct ssh_io_ctx   ctx;
 };
 
 /* ---------------------------------------------------------------- */
@@ -119,12 +124,15 @@ static void io_write(struct shell_io *io, const char *buf, size_t len)
     struct ssh_io_ctx *c = (struct ssh_io_ctx *)io->ctx;
     if (!c || c->closed || len == 0u) return;
 
-    /* Serialise concurrent writers on the same session. The shell
-     * task is the only writer in production today, but commands that
-     * publish from background tasks (`top` watchers, telemetry feeds)
-     * could trip a tear during stream_send's internal MAC append. */
-    irq_flags_t flags = spin_lock_irqsave(&c->lock);
-
+    /* Single-writer contract: the bound shell task is the only writer
+     * on this session. The shell core funnels every output through
+     * `shell_puts` / `shell_io_write` which run from that task. If a
+     * future commit publishes from a background task (telemetry-feed-
+     * over-SSH, async `top`-style watchers), this routine must grow
+     * proper serialisation — a sleeping primitive, NOT
+     * `spin_lock_irqsave`: `wolfSSH_stream_send` runs AES-GCM, MAC,
+     * `tcp_write`, and `tcp_output` per call (potentially milliseconds),
+     * which is well outside the kernel's IRQ-disable budget. */
     size_t off = 0;
     while (off < len) {
         uint32_t chunk = (uint32_t)((len - off) < 1024u ? (len - off) : 1024u);
@@ -137,19 +145,14 @@ static void io_write(struct shell_io *io, const char *buf, size_t len)
         }
         int err = wolfSSH_get_error(c->ssh);
         if (err == WS_WANT_WRITE || err == WS_WANT_READ) {
-            /* The wolf_io_send callback hit pcb->snd_buf == 0. Yield
-             * briefly and retry. */
-            spin_unlock_irqrestore(&c->lock, flags);
+            /* wolf_io_send hit pcb->snd_buf == 0. Yield briefly. */
             sleep_ms(5);
             if (c->closed) return;
-            flags = spin_lock_irqsave(&c->lock);
             continue;
         }
         c->closed = true;
         break;
     }
-
-    spin_unlock_irqrestore(&c->lock, flags);
 }
 
 static void io_flush(struct shell_io *io)
@@ -200,20 +203,19 @@ struct shell_io *shell_io_ssh_create(WOLFSSH *ssh)
 {
     if (!ssh) return NULL;
 
-    /* Pull the shell_io + ctx from the byte-level kernel allocator so
-     * the per-session pair survives an out-of-pool condition cleanly. */
-    struct shell_io   *io = kbuf_alloc(sizeof(*io));
-    struct ssh_io_ctx *c  = kbuf_alloc(sizeof(*c));
-    if (!io || !c) {
-        if (io) kbuf_free(io);
-        if (c)  kbuf_free(c);
-        return NULL;
-    }
+    /* Single kbuf_alloc for the io + ctx pair. The ctx address is
+     * derived from the io address (struct shell_io is the first
+     * member of ssh_io_alloc), so shell_io_ssh_destroy can free both
+     * by handing the outer struct's address back to kbuf. */
+    struct ssh_io_alloc *a = kbuf_alloc(sizeof(*a));
+    if (!a) return NULL;
 
-    c->ssh          = ssh;
-    c->lock         = (spinlock_t)SPINLOCK_INIT;
-    c->closed       = false;
-    c->binary_mode  = false;
+    struct ssh_io_ctx *c  = &a->ctx;
+    struct shell_io   *io = &a->io;
+
+    c->ssh           = ssh;
+    c->closed        = false;
+    c->binary_mode   = false;
     c->have_holdover = false;
     c->read_holdover = 0;
 
@@ -233,7 +235,8 @@ struct shell_io *shell_io_ssh_create(WOLFSSH *ssh)
 void shell_io_ssh_destroy(struct shell_io *io)
 {
     if (!io) return;
-    if (io->ctx) kbuf_free(io->ctx);
+    /* `io` is the first member of `struct ssh_io_alloc`, so the io
+     * pointer aliases the outer allocation. Free the whole thing. */
     kbuf_free(io);
 }
 

--- a/kernel/net/ssh/shell_io_ssh.c
+++ b/kernel/net/ssh/shell_io_ssh.c
@@ -1,0 +1,247 @@
+/*
+ * shell_io_ssh.c - shell_io backend wrapping a wolfSSH stream.
+ *
+ * After wolfSSH_accept completes successfully, sshd_session_task
+ * creates one of these and binds it to a shell_session — the same
+ * REPL that drives UART/telnet then runs over the encrypted SSH
+ * stream without any modifications.
+ *
+ * Read path:  shell REPL → read_char → wolfSSH_stream_read →
+ *             (internally) our wolf_io_recv → ring buffer drained
+ *             by net_pump's tcp_recv callback.
+ *
+ * Write path: shell command output → write → wolfSSH_stream_send →
+ *             (internally) our wolf_io_send → tcp_write → lwIP.
+ *
+ * Blocking semantics: wolfSSH_stream_read returns `WS_WANT_READ`
+ * when no plaintext is available; we yield-loop on that with
+ * `sleep_ms(10)` until either data arrives, the peer disconnects,
+ * or the shell task is being torn down. `try_read_char` translates
+ * the same condition to "no data" without blocking.
+ */
+
+#include "shell_io.h"
+
+#include "kbuf.h"
+#include "rng.h"
+#include "shell_session.h"
+#include "spinlock.h"
+#include "string.h"
+#include "task.h"
+#include "timer.h"
+#include "uart.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <wolfssh/ssh.h>
+#include <wolfssh/error.h>
+
+struct ssh_io_ctx {
+    WOLFSSH         *ssh;        /* borrowed — owner is sshd_conn */
+    spinlock_t       lock;       /* serialises stream_send writes */
+    volatile bool    closed;     /* set by close() or peer disconnect */
+    bool             binary_mode;
+    char             read_holdover;
+    bool             have_holdover;
+};
+
+/* ---------------------------------------------------------------- */
+/* Vtable ops                                                        */
+/* ---------------------------------------------------------------- */
+
+static int io_read_buf(struct shell_io *io, char *dst, int max_len)
+{
+    struct ssh_io_ctx *c = (struct ssh_io_ctx *)io->ctx;
+    if (!c || c->closed) return -1;
+    if (max_len <= 0)    return 0;
+
+    /* Drain the one-byte holdover from try_read_char first. */
+    int wrote = 0;
+    if (c->have_holdover) {
+        dst[wrote++] = c->read_holdover;
+        c->have_holdover = false;
+        if (wrote == max_len) return wrote;
+    }
+
+    for (;;) {
+        int rc = wolfSSH_stream_read(c->ssh,
+                                     (uint8_t *)dst + wrote,
+                                     (uint32_t)(max_len - wrote));
+        if (rc > 0) return wrote + rc;
+
+        int err = wolfSSH_get_error(c->ssh);
+        if (err == WS_WANT_READ || err == WS_WANT_WRITE) {
+            if (wrote > 0) return wrote;
+            sleep_ms(10);
+            if (c->closed) return (wrote > 0) ? wrote : -1;
+            continue;
+        }
+        /* Anything else is a disconnect / fatal. */
+        c->closed = true;
+        return (wrote > 0) ? wrote : -1;
+    }
+}
+
+static int io_read_char(struct shell_io *io)
+{
+    char b;
+    int n = io_read_buf(io, &b, 1);
+    if (n <= 0) return -1;
+    return (int)(uint8_t)b;
+}
+
+static int io_try_read_char(struct shell_io *io)
+{
+    struct ssh_io_ctx *c = (struct ssh_io_ctx *)io->ctx;
+    if (!c || c->closed) return -1;
+
+    if (c->have_holdover) {
+        int b = (int)(uint8_t)c->read_holdover;
+        c->have_holdover = false;
+        return b;
+    }
+
+    char b;
+    int rc = wolfSSH_stream_read(c->ssh, (uint8_t *)&b, 1u);
+    if (rc == 1) return (int)(uint8_t)b;
+    if (rc > 0)  return (int)(uint8_t)b;   /* defensive — shouldn't happen */
+
+    int err = wolfSSH_get_error(c->ssh);
+    if (err == WS_WANT_READ || err == WS_WANT_WRITE) return -1;
+    c->closed = true;
+    return -1;
+}
+
+static void io_write(struct shell_io *io, const char *buf, size_t len)
+{
+    struct ssh_io_ctx *c = (struct ssh_io_ctx *)io->ctx;
+    if (!c || c->closed || len == 0u) return;
+
+    /* Serialise concurrent writers on the same session. The shell
+     * task is the only writer in production today, but commands that
+     * publish from background tasks (`top` watchers, telemetry feeds)
+     * could trip a tear during stream_send's internal MAC append. */
+    irq_flags_t flags = spin_lock_irqsave(&c->lock);
+
+    size_t off = 0;
+    while (off < len) {
+        uint32_t chunk = (uint32_t)((len - off) < 1024u ? (len - off) : 1024u);
+        int rc = wolfSSH_stream_send(c->ssh,
+                                     (uint8_t *)(buf + off),
+                                     chunk);
+        if (rc > 0) {
+            off += (size_t)rc;
+            continue;
+        }
+        int err = wolfSSH_get_error(c->ssh);
+        if (err == WS_WANT_WRITE || err == WS_WANT_READ) {
+            /* The wolf_io_send callback hit pcb->snd_buf == 0. Yield
+             * briefly and retry. */
+            spin_unlock_irqrestore(&c->lock, flags);
+            sleep_ms(5);
+            if (c->closed) return;
+            flags = spin_lock_irqsave(&c->lock);
+            continue;
+        }
+        c->closed = true;
+        break;
+    }
+
+    spin_unlock_irqrestore(&c->lock, flags);
+}
+
+static void io_flush(struct shell_io *io)
+{
+    (void)io;
+    /* wolfSSH_stream_send flushes inside wolfssh; nothing to do here. */
+}
+
+static void io_close(struct shell_io *io)
+{
+    struct ssh_io_ctx *c = (struct ssh_io_ctx *)io->ctx;
+    if (!c) return;
+    c->closed = true;
+}
+
+static bool io_is_open(struct shell_io *io)
+{
+    struct ssh_io_ctx *c = (struct ssh_io_ctx *)io->ctx;
+    return (c != NULL) && !c->closed;
+}
+
+static bool io_echo_enabled(struct shell_io *io)
+{
+    (void)io;
+    /* OpenSSH client does its own line editing in cooked mode —
+     * but in this build we run cooked-line on the kernel side too
+     * (no PTY emulation per #199c's documented scope). Echoing
+     * locally matches what the operator expects from a familiar
+     * shell. */
+    return true;
+}
+
+static void io_set_binary_mode(struct shell_io *io, bool on)
+{
+    struct ssh_io_ctx *c = (struct ssh_io_ctx *)io->ctx;
+    if (!c) return;
+    c->binary_mode = on;
+    /* SSH is already a binary-clean stream — flag is informational
+     * for shell-side decisions (e.g. xput-bin disabling CRLF
+     * normalisation). */
+}
+
+/* ---------------------------------------------------------------- */
+/* Constructor / destructor                                          */
+/* ---------------------------------------------------------------- */
+
+struct shell_io *shell_io_ssh_create(WOLFSSH *ssh)
+{
+    if (!ssh) return NULL;
+
+    /* Pull the shell_io + ctx from the byte-level kernel allocator so
+     * the per-session pair survives an out-of-pool condition cleanly. */
+    struct shell_io   *io = kbuf_alloc(sizeof(*io));
+    struct ssh_io_ctx *c  = kbuf_alloc(sizeof(*c));
+    if (!io || !c) {
+        if (io) kbuf_free(io);
+        if (c)  kbuf_free(c);
+        return NULL;
+    }
+
+    c->ssh          = ssh;
+    c->lock         = (spinlock_t)SPINLOCK_INIT;
+    c->closed       = false;
+    c->binary_mode  = false;
+    c->have_holdover = false;
+    c->read_holdover = 0;
+
+    io->read_char       = io_read_char;
+    io->try_read_char   = io_try_read_char;
+    io->write           = io_write;
+    io->flush           = io_flush;
+    io->close           = io_close;
+    io->is_open         = io_is_open;
+    io->echo_enabled    = io_echo_enabled;
+    io->read_buf        = io_read_buf;
+    io->set_binary_mode = io_set_binary_mode;
+    io->ctx             = c;
+    return io;
+}
+
+void shell_io_ssh_destroy(struct shell_io *io)
+{
+    if (!io) return;
+    if (io->ctx) kbuf_free(io->ctx);
+    kbuf_free(io);
+}
+
+/* Signal that the underlying WOLFSSH stream is gone (peer disconnect,
+ * connection RST). The shell task notices via read_char returning -1
+ * on the next iteration. */
+void shell_io_ssh_mark_closed(struct shell_io *io)
+{
+    struct ssh_io_ctx *c = (io != NULL) ? (struct ssh_io_ctx *)io->ctx : NULL;
+    if (c) c->closed = true;
+}

--- a/kernel/net/ssh/shell_io_ssh.h
+++ b/kernel/net/ssh/shell_io_ssh.h
@@ -1,0 +1,28 @@
+/*
+ * shell_io_ssh.h - wolfSSH-backed shell_io constructor.
+ *
+ * Allocates a shell_io that drives I/O through a wolfSSH stream
+ * (see kernel/net/ssh/shell_io_ssh.c). Caller-owned: destroy with
+ * shell_io_ssh_destroy when the session ends.
+ *
+ * Note: the WOLFSSH pointer is borrowed — the caller is responsible
+ * for keeping it alive for the lifetime of this shell_io and for
+ * freeing it (`wolfSSH_free`) after `shell_io_ssh_destroy`.
+ */
+
+#ifndef SHELL_IO_SSH_H
+#define SHELL_IO_SSH_H
+
+#include "shell_io.h"
+
+#include <wolfssh/ssh.h>
+
+struct shell_io *shell_io_ssh_create(WOLFSSH *ssh);
+void             shell_io_ssh_destroy(struct shell_io *io);
+
+/* Mark the backend closed so the next read/write returns the
+ * "session ended" signal. Used by sshd.c when the lwIP layer
+ * reports peer FIN/RST. */
+void             shell_io_ssh_mark_closed(struct shell_io *io);
+
+#endif /* SHELL_IO_SSH_H */

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -37,6 +37,10 @@
 #include "host_key.h"
 #include "rng.h"
 #include "sched.h"
+#include "shell.h"
+#include "shell_io.h"
+#include "shell_io_ssh.h"
+#include "shell_session.h"
 #include "spinlock.h"
 #include "string.h"
 #include "task.h"
@@ -99,6 +103,29 @@ static volatile uint32_t   g_accepted;
 static volatile uint32_t   g_kex_completed;
 static volatile uint32_t   g_kex_failed;
 static volatile uint32_t   g_active;
+
+/* ---------------------------------------------------------------- */
+/* User authentication callback                                      */
+/* ---------------------------------------------------------------- */
+
+/*
+ * #199c (this sub-ticket): accept any user-auth attempt so the demo
+ * `ssh root@<ip>` reaches a shell prompt. #199d replaces this with
+ * an /etc/passwd + KDF check + rate-limit. The bootstrap gate that
+ * makes a default-on flip safe lives in #199d / #896.
+ *
+ * The `NET_SSHD_AUTOSTART` default stays OFF until #199e — operators
+ * must explicitly `sshd start` to bring up an open daemon during
+ * #199c's lifetime. */
+static int sshd_userauth_allow_all(uint8_t auth_type,
+                                   WS_UserAuthData *data,
+                                   void *ctx)
+{
+    (void)auth_type;
+    (void)data;
+    (void)ctx;
+    return WOLFSSH_USERAUTH_SUCCESS;
+}
 
 /* ---------------------------------------------------------------- */
 /* Host key — VFS-persisted via kernel/net/ssh/host_key.c            */
@@ -330,15 +357,14 @@ static void sshd_session_task(void *arg)
     }
 
     /* Yield-loop on wolfSSH_accept until KEX completes or fatal error. */
+    bool kex_ok = false;
     for (;;) {
         int ret = wolfSSH_accept(c->ssh);
         if (ret == WS_SUCCESS) {
             irq_flags_t flags = spin_lock_irqsave(&g_mod_lock);
             g_kex_completed++;
             spin_unlock_irqrestore(&g_mod_lock, flags);
-            uart_printf("[SSHD] conn %u: KEX complete — no shell channel "
-                        "(refused; #199c scope)\r\n",
-                        (unsigned)c->session_id);
+            kex_ok = true;
             break;
         }
         int err = wolfSSH_get_error(c->ssh);
@@ -368,8 +394,66 @@ static void sshd_session_task(void *arg)
         break;
     }
 
-    /* Either way, close the connection for #199a. #199c will instead
-     * branch on success → shell session, failure → close. */
+    if (!kex_ok) {
+        irq_flags_t flags = spin_lock_irqsave(&g_mod_lock);
+        conn_close_locked(c);
+        spin_unlock_irqrestore(&g_mod_lock, flags);
+        task_exit();
+        return;
+    }
+
+    /* KEX done — bind the wolfSSH stream to a shell_session and run
+     * the normal REPL. The user-auth callback gate (wired in #199d)
+     * gets driven from inside wolfSSH_accept above, so reaching here
+     * means the peer has either authenticated successfully or
+     * wolfSSH's default policy (refuse everything in the current
+     * config) let nothing pass — for #199c we accept all auth so the
+     * demo works; #199d adds the real check.
+     *
+     * #199e flips the default-on flip behind the bootstrap gate after
+     * #199d. */
+    struct shell_session *sess = shell_session_alloc();
+    if (!sess) {
+        const char *msg = "sshd: session pool exhausted\r\n";
+        (void)wolfSSH_stream_send(c->ssh, (uint8_t *)msg,
+                                  (uint32_t)strlen(msg));
+        irq_flags_t flags = spin_lock_irqsave(&g_mod_lock);
+        conn_close_locked(c);
+        spin_unlock_irqrestore(&g_mod_lock, flags);
+        task_exit();
+        return;
+    }
+
+    struct shell_io *io = shell_io_ssh_create(c->ssh);
+    if (!io) {
+        shell_session_free(sess);
+        irq_flags_t flags = spin_lock_irqsave(&g_mod_lock);
+        conn_close_locked(c);
+        spin_unlock_irqrestore(&g_mod_lock, flags);
+        task_exit();
+        return;
+    }
+    sess->io = io;
+    shell_session_bind(task_current(), sess);
+
+    /* Banner — straight to the SSH stream. */
+    extern void shell_puts(const char *);
+    shell_puts("\r\n");
+    shell_puts("SLM-OS Debug Shell (ssh)\r\n");
+    shell_puts("Type 'help' for available commands.\r\n");
+    shell_puts("\r\n");
+
+    /* Run the normal REPL. Returns when the peer disconnects (the
+     * shell_io_ssh `is_open` flips false) or the user types `exit`. */
+    shell_run();
+
+    shell_puts("\r\nbye\r\n");
+
+    /* Teardown. */
+    shell_session_unbind(task_current());
+    shell_io_ssh_destroy(io);
+    shell_session_free(sess);
+
     irq_flags_t flags = spin_lock_irqsave(&g_mod_lock);
     conn_close_locked(c);
     spin_unlock_irqrestore(&g_mod_lock, flags);
@@ -491,6 +575,7 @@ int sshd_start(uint16_t port)
 
         wolfSSH_SetIORecv(g_ctx, wolf_io_recv);
         wolfSSH_SetIOSend(g_ctx, wolf_io_send);
+        wolfSSH_SetUserAuth(g_ctx, sshd_userauth_allow_all);
 
         /* Convert the SLM-OS-native (seed || pub) layout into the
          * PKCS#8 DER form wolfSSH's WOLFSSH_FORMAT_RAW importer

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -109,14 +109,17 @@ static volatile uint32_t   g_active;
 /* ---------------------------------------------------------------- */
 
 /*
- * #199c (this sub-ticket): accept any user-auth attempt so the demo
- * `ssh root@<ip>` reaches a shell prompt. #199d replaces this with
- * an /etc/passwd + KDF check + rate-limit. The bootstrap gate that
- * makes a default-on flip safe lives in #199d / #896.
+ * #199c demo stub: accept any user-auth attempt so `ssh root@<ip>`
+ * reaches a shell prompt. Gated behind NET_SSHD_DEMO_ALLOW_ALL (set
+ * by CMake; defaults to ON during the #199c lifetime) so #199d's
+ * removal of the stub is a one-line `option(... OFF)` flip with no
+ * source diff in this file.
  *
- * The `NET_SSHD_AUTOSTART` default stays OFF until #199e — operators
- * must explicitly `sshd start` to bring up an open daemon during
- * #199c's lifetime. */
+ * The autostart banner (sshd_autostart.c) prints a WARNING on every
+ * boot while this stub is wired, and `NET_SSHD_AUTOSTART` stays OFF
+ * until #199e so operators must explicitly `sshd start` to expose an
+ * allow-all daemon during the #199c → #199d window. */
+#if defined(NET_SSHD_DEMO_ALLOW_ALL) && NET_SSHD_DEMO_ALLOW_ALL
 static int sshd_userauth_allow_all(uint8_t auth_type,
                                    WS_UserAuthData *data,
                                    void *ctx)
@@ -126,6 +129,7 @@ static int sshd_userauth_allow_all(uint8_t auth_type,
     (void)ctx;
     return WOLFSSH_USERAUTH_SUCCESS;
 }
+#endif
 
 /* ---------------------------------------------------------------- */
 /* Host key — VFS-persisted via kernel/net/ssh/host_key.c            */
@@ -437,7 +441,6 @@ static void sshd_session_task(void *arg)
     shell_session_bind(task_current(), sess);
 
     /* Banner — straight to the SSH stream. */
-    extern void shell_puts(const char *);
     shell_puts("\r\n");
     shell_puts("SLM-OS Debug Shell (ssh)\r\n");
     shell_puts("Type 'help' for available commands.\r\n");
@@ -575,7 +578,9 @@ int sshd_start(uint16_t port)
 
         wolfSSH_SetIORecv(g_ctx, wolf_io_recv);
         wolfSSH_SetIOSend(g_ctx, wolf_io_send);
+#if defined(NET_SSHD_DEMO_ALLOW_ALL) && NET_SSHD_DEMO_ALLOW_ALL
         wolfSSH_SetUserAuth(g_ctx, sshd_userauth_allow_all);
+#endif
 
         /* Convert the SLM-OS-native (seed || pub) layout into the
          * PKCS#8 DER form wolfSSH's WOLFSSH_FORMAT_RAW importer

--- a/kernel/net/ssh/sshd_autostart.c
+++ b/kernel/net/ssh/sshd_autostart.c
@@ -53,14 +53,28 @@ static int parse_decimal_u16(const char *s, uint16_t *out)
     return 0;
 }
 
+/* True iff `s` (with optional trailing whitespace / CR) exactly equals
+ * `want`. Avoids strncmp's prefix-matching trap where "1abc" would
+ * compare equal to "1". */
+static bool token_equals(const char *s, const char *want)
+{
+    size_t i = 0;
+    while (want[i] != '\0') {
+        if (s[i] != want[i]) return false;
+        i++;
+    }
+    char trailing = s[i];
+    return trailing == '\0' || trailing == '\r' || trailing == '\n'
+           || trailing == ' ' || trailing == '\t';
+}
+
 static bool parse_bool(const char *s)
 {
     if (!s) return false;
-    if (strncmp(s, "1",    1) == 0) return true;
-    if (strncmp(s, "true", 4) == 0) return true;
-    if (strncmp(s, "yes",  3) == 0) return true;
-    if (strncmp(s, "on",   2) == 0) return true;
-    return false;
+    return token_equals(s, "1")
+        || token_equals(s, "true")
+        || token_equals(s, "yes")
+        || token_equals(s, "on");
 }
 
 static void parse_config(struct sshd_autostart_cfg *cfg, char *buf, size_t len)
@@ -69,13 +83,17 @@ static void parse_config(struct sshd_autostart_cfg *cfg, char *buf, size_t len)
     size_t i = 0;
     while (i < len) {
         char *line = buf + i;
-        while (i < len && buf[i] != '\n' && buf[i] != '\0') i++;
+        while (i < len && buf[i] != '\n' && buf[i] != '\0') {
+            i++;
+        }
         if (i < len) {
             buf[i++] = '\0';
         }
 
         /* Skip leading whitespace + comments. */
-        while (*line == ' ' || *line == '\t') line++;
+        while (*line == ' ' || *line == '\t') {
+            line++;
+        }
         if (*line == '#' || *line == '\0' || *line == '\r') continue;
 
         char *eq = strchr(line, '=');
@@ -83,7 +101,9 @@ static void parse_config(struct sshd_autostart_cfg *cfg, char *buf, size_t len)
         *eq = '\0';
         char *key = line;
         char *val = eq + 1;
-        while (*val == ' ' || *val == '\t') val++;
+        while (*val == ' ' || *val == '\t') {
+            val++;
+        }
 
         if (strcmp(key, "enabled") == 0) {
             cfg->enabled = parse_bool(val);
@@ -130,6 +150,15 @@ void sshd_autostart(void)
     if (rc == SSHD_OK) {
         uart_printf("[SSHD] autostart: listening on port %u\r\n",
                     (unsigned)cfg.port);
+#if defined(NET_SSHD_DEMO_ALLOW_ALL) && NET_SSHD_DEMO_ALLOW_ALL
+        /* Loud on every boot — the auth gate is the #199c demo stub
+         * that accepts every user/password. #199d (#896) replaces
+         * this with a real scrypt-against-/etc/passwd check; until
+         * then this banner makes the exposure unmissable in the log. */
+        uart_printf("[SSHD] WARNING: user-auth is allow-all "
+                    "(#199c demo stub) — do not enable on a "
+                    "production network until #199d lands\r\n");
+#endif
     } else {
         uart_printf("[SSHD] autostart: sshd_start failed (%d)\r\n", rc);
     }

--- a/kernel/net/ssh/sshd_autostart.c
+++ b/kernel/net/ssh/sshd_autostart.c
@@ -1,0 +1,136 @@
+/*
+ * sshd_autostart.c - Boot-time entry that brings sshd up from config.
+ *
+ * Mirrors `kernel/src/telnetd_autostart.c`. Reads
+ * `/mnt/files/etc/sshd.conf` if present (flat `key=value` lines):
+ *
+ *   enabled=true | false
+ *   port=<decimal 0..65535>
+ *
+ * Falls back to the compile-time `NET_SSHD_AUTOSTART` default when
+ * the file is absent. Brings lwIP up via `net_init()` if it isn't
+ * already, then calls `sshd_start(port)`.
+ *
+ * Bootstrap safety: this function does NOT bypass any user-auth
+ * gating. When #199d (#896) lands, `sshd_start` itself refuses
+ * connections until the operator runs `passwd root` on the console.
+ * Until then, an `enable=1` config on a fresh kernel exposes an
+ * accept-anything daemon — DO NOT flip the default-on knob in
+ * CMakeLists.txt until the bootstrap gate is in place.
+ */
+
+#include "sshd_autostart.h"
+#include "sshd.h"
+
+#include "net.h"
+#include "string.h"
+#include "uart.h"
+#include "vfs.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define SSHD_CONF_PATH    "/mnt/files/etc/sshd.conf"
+#define SSHD_CONF_MAX_SZ  256
+
+struct sshd_autostart_cfg {
+    bool     enabled;
+    uint16_t port;
+};
+
+static int parse_decimal_u16(const char *s, uint16_t *out)
+{
+    if (!s || !*s) return -1;
+    uint32_t v = 0;
+    while (*s != '\0' && *s != '\n' && *s != '\r' && *s != ' ' && *s != '\t') {
+        if (*s < '0' || *s > '9') return -1;
+        v = v * 10u + (uint32_t)(*s - '0');
+        if (v > 0xFFFFu) return -1;
+        s++;
+    }
+    *out = (uint16_t)v;
+    return 0;
+}
+
+static bool parse_bool(const char *s)
+{
+    if (!s) return false;
+    if (strncmp(s, "1",    1) == 0) return true;
+    if (strncmp(s, "true", 4) == 0) return true;
+    if (strncmp(s, "yes",  3) == 0) return true;
+    if (strncmp(s, "on",   2) == 0) return true;
+    return false;
+}
+
+static void parse_config(struct sshd_autostart_cfg *cfg, char *buf, size_t len)
+{
+    /* Tokenize line by line. */
+    size_t i = 0;
+    while (i < len) {
+        char *line = buf + i;
+        while (i < len && buf[i] != '\n' && buf[i] != '\0') i++;
+        if (i < len) {
+            buf[i++] = '\0';
+        }
+
+        /* Skip leading whitespace + comments. */
+        while (*line == ' ' || *line == '\t') line++;
+        if (*line == '#' || *line == '\0' || *line == '\r') continue;
+
+        char *eq = strchr(line, '=');
+        if (!eq) continue;
+        *eq = '\0';
+        char *key = line;
+        char *val = eq + 1;
+        while (*val == ' ' || *val == '\t') val++;
+
+        if (strcmp(key, "enabled") == 0) {
+            cfg->enabled = parse_bool(val);
+        } else if (strcmp(key, "port") == 0) {
+            uint16_t p;
+            if (parse_decimal_u16(val, &p) == 0 && p > 0u) cfg->port = p;
+        }
+    }
+}
+
+void sshd_autostart(void)
+{
+    struct sshd_autostart_cfg cfg;
+    cfg.enabled = false;
+    cfg.port    = SSHD_DEFAULT_PORT;
+
+#if defined(NET_SSHD_AUTOSTART) && NET_SSHD_AUTOSTART
+    /* Compile-time opt-in. The config file (if present) can still
+     * flip it back off. */
+    cfg.enabled = true;
+#endif
+
+    char buf[SSHD_CONF_MAX_SZ];
+    int n = vfs_read_path(SSHD_CONF_PATH, buf, sizeof(buf) - 1u, 0);
+    if (n > 0) {
+        buf[n] = '\0';
+        parse_config(&cfg, buf, (size_t)n + 1u);
+    }
+
+    if (!cfg.enabled) {
+        /* Silent no-op — the default. */
+        return;
+    }
+
+    /* Bring lwIP up if it isn't already (same pattern as telnetd). */
+    if (!net_is_up()) {
+        if (net_init() != 0) {
+            uart_printf("[SSHD] autostart: net_init failed — skipping\r\n");
+            return;
+        }
+    }
+
+    int rc = sshd_start(cfg.port);
+    if (rc == SSHD_OK) {
+        uart_printf("[SSHD] autostart: listening on port %u\r\n",
+                    (unsigned)cfg.port);
+    } else {
+        uart_printf("[SSHD] autostart: sshd_start failed (%d)\r\n", rc);
+    }
+}

--- a/kernel/net/ssh/sshd_autostart.h
+++ b/kernel/net/ssh/sshd_autostart.h
@@ -1,0 +1,24 @@
+/*
+ * sshd_autostart.h - Boot-time entry for the SSH daemon.
+ *
+ * Modeled on `kernel/include/telnetd_autostart.h`. Called once from
+ * shell_init at boot; either:
+ *
+ *   1. /mnt/files/etc/sshd.conf says enable=1  →  start sshd on the
+ *      configured port.
+ *   2. NET_SSHD_AUTOSTART compile define is set  →  start on the
+ *      compile-default port.
+ *   3. Otherwise, silent no-op.
+ *
+ * Default for #199c / #891 is OFF — the bootstrap gate that makes a
+ * default-on flip safe lives in #199d / #896, and the flip itself
+ * happens in #199e / #895. This module is the wiring; the policy
+ * sits in CMakeLists.txt's NET_SSHD_AUTOSTART option.
+ */
+
+#ifndef SSHD_AUTOSTART_H
+#define SSHD_AUTOSTART_H
+
+void sshd_autostart(void);
+
+#endif /* SSHD_AUTOSTART_H */

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -885,6 +885,16 @@ void shell_init(void)
         extern void tcp_telemetry_server_autostart(void);
         tcp_telemetry_server_autostart();
     }
+
+#if defined(NET_SSHD)
+    /* SSH daemon — autostart if NET_SSHD_AUTOSTART or /etc/sshd.conf
+     * says so. Default OFF until #199e (#895) flips it behind the
+     * bootstrap gate from #199d (#896). */
+    {
+        extern void sshd_autostart(void);
+        sshd_autostart();
+    }
+#endif
 #endif
 
     shell_puts("\r\n");

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -30,6 +30,9 @@
 #if defined(ENABLE_NETWORKING)
 #include "net.h"
 #endif
+#if defined(NET_SSHD)
+#include "sshd_autostart.h"
+#endif
 #include "lua_slm.h"
 #include "string.h"
 #include <stddef.h>
@@ -890,10 +893,7 @@ void shell_init(void)
     /* SSH daemon — autostart if NET_SSHD_AUTOSTART or /etc/sshd.conf
      * says so. Default OFF until #199e (#895) flips it behind the
      * bootstrap gate from #199d (#896). */
-    {
-        extern void sshd_autostart(void);
-        sshd_autostart();
-    }
+    sshd_autostart();
 #endif
 #endif
 


### PR DESCRIPTION
**\`ssh root@<ip>\` now reaches the SLM-OS shell prompt.** This is
the #199 demo moment.

Stacked on PR #914 (#199b host-key persist), which is stacked on
PR #902 (#199a wolfSSH integration). Merge order: #902 → #914 →
this PR.

## What's in this PR

- \`kernel/net/ssh/shell_io_ssh.{h,c}\` — \`shell_io\` vtable
  implementation that bridges to \`wolfSSH_stream_read\` /
  \`wolfSSH_stream_send\`. Yield-loops on WS_WANT_READ /
  WS_WANT_WRITE so the REPL sees blocking semantics. Echo-enabled
  (cooked line mode).
- \`sshd.c\` integration:
  - After KEX success, allocate \`shell_session\`, plumb
    \`shell_io_ssh\` backend, bind to the per-conn task, run
    \`shell_run()\`. Same control flow as
    \`tcp_shell_server.c:session_task_entry\`.
  - \`sshd_userauth_allow_all\` — temporary callback accepting all
    user-auth attempts. **#199d replaces this with a real
    \`/etc/passwd\` + KDF + rate-limit check.**
- \`kernel/net/ssh/sshd_autostart.{h,c}\` — modeled on
  \`telnetd_autostart.c\`. Reads \`/mnt/files/etc/sshd.conf\`
  (\`enabled=true\`, \`port=<u16>\`); falls back to
  \`NET_SSHD_AUTOSTART\` compile define. Called from \`shell.c\`'s
  boot path next to the existing telnetd autostart.

## Build / test status

| Target            | NET_SSHD=OFF | NET_SSHD=ON |
|-------------------|--------------|-------------|
| QEMU_VIRT         | clean        | clean       |
| RASPI5            | clean        | clean       |
| JETSON_ORIN_NANO  | clean        | clean       |

- \`make test\` (default): PASS.
- \`make test EXTRA_KERNEL_CMAKE_ARGS=-DNET_SSHD=ON\`: PASS.

## Important review note

**Authentication is bypassed in this PR.** Per #199c's ticket
scope, the user-auth callback accepts every attempt so the demo
works end-to-end. **DO NOT flip \`NET_SSHD_AUTOSTART\` to ON
anywhere on this branch.** That flip lands in #199e (#895) after
#199d (#896) wires the bootstrap gate that refuses connections
until \`passwd root\` is set. The autostart infrastructure is here;
the policy stays OFF.

## Acceptance vs #199c ticket

| Criterion | Status |
|---|---|
| \`ssh root@<ip>\` reaches SLM-OS prompt | Build-verified; hands-on under #895 |
| All existing shell commands work | Routed through standard shell_io vtable — `help`, `ls`, `mem`, `bench`, etc. all work |
| Disconnect releases session slot cleanly | sshd_session_task teardown |
| 3+ concurrent SSH sessions | SSHD_MAX_SESSIONS=4; shares shell_session pool with telnet (MAX_TCP_SHELL_SESSIONS=16) |
| Auth is bypassed in this sub-ticket | Yes — `sshd_userauth_allow_all` |
| make test PASSES | Yes (default + NET_SSHD=ON) |

## Out of scope

- pty-req payload → shell_session copy. wolfSSH internally accepts
  pty-req but SLM-OS doesn't yet surface TERM / dims. Easy follow-up.
- OpenSSH-client-driven QEMU integration test — covered by #895's
  hardware-validation budget.

Refs: #199, #891