### PR TITLE
sshd 199d: scrypt password auth + bootstrap gate (#896)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,11 +467,15 @@ if(ENABLE_NETWORKING AND NET_SSHD AND NET_SSHD_AUTOSTART)
     add_compile_definitions(NET_SSHD_AUTOSTART=1)
 endif()
 
-# #199c demo: wolfSSH user-auth callback that accepts every login. The
-# kernel logs a WARNING on every autostart while this is wired. #199d
-# (#896) lands real scrypt-against-/etc/passwd auth and flips this OFF
-# in a one-line CMake diff — no source change needed in sshd.c.
-option(NET_SSHD_DEMO_ALLOW_ALL "wolfSSH allow-all user-auth stub (#199c demo)" ON)
+# Selects which user-auth callback wolfSSH sees:
+#   OFF (default since #199d landed) — scrypt-against-/mnt/files/etc/passwd
+#                                      via `sshd_userauth_passwd`. Bootstrap
+#                                      gate refuses every attempt until the
+#                                      operator runs `passwd <name> <pw>`.
+#   ON  (#199c demo path / debugging) — `sshd_userauth_allow_all` accepts
+#                                      every login; sshd_autostart prints
+#                                      a loud WARNING on every boot.
+option(NET_SSHD_DEMO_ALLOW_ALL "wolfSSH allow-all user-auth stub (debugging only)" OFF)
 if(ENABLE_NETWORKING AND NET_SSHD AND NET_SSHD_DEMO_ALLOW_ALL)
     add_compile_definitions(NET_SSHD_DEMO_ALLOW_ALL=1)
 endif()
@@ -1865,6 +1869,7 @@ if(ENABLE_NETWORKING AND NET_SSHD AND NOT PLATFORM STREQUAL "X86_64")
         kernel/lib/wolfcrypt/src/asn.c
         kernel/lib/wolfcrypt/src/sp_int.c
         kernel/lib/wolfcrypt/src/wolfmath.c
+        kernel/lib/wolfcrypt/src/pwdbased.c
     )
 
     add_library(wolfcrypt STATIC ${WOLFCRYPT_SOURCES})
@@ -1936,6 +1941,8 @@ if(ENABLE_NETWORKING AND NET_SSHD AND NOT PLATFORM STREQUAL "X86_64")
         kernel/net/ssh/host_key.c
         kernel/net/ssh/shell_io_ssh.c
         kernel/net/ssh/sshd_autostart.c
+        kernel/net/ssh/passwd.c
+        kernel/net/ssh/passwd_shell.c
     )
     target_include_directories(slmos.elf PRIVATE
         ${CMAKE_SOURCE_DIR}/kernel/net/ssh)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1936,6 +1936,7 @@ if(ENABLE_NETWORKING AND NET_SSHD AND NOT PLATFORM STREQUAL "X86_64")
     # autostart, shell verb.
     target_sources(slmos.elf PRIVATE
         kernel/net/ssh/wolf_os.c
+        kernel/net/ssh/wolf_heap.c
         kernel/net/ssh/sshd.c
         kernel/net/ssh/sshd_shell.c
         kernel/net/ssh/host_key.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1035,6 +1035,9 @@ set(TEST_SOURCES
     # SSH host-key persistence tests (#199b / #892). Gated on
     # NET_SSHD at the source level (whole TU is #if NET_SSHD).
     kernel/tests/test_host_key.c
+    # Password DB + scrypt verify tests (#199d / #896). Same TU-level
+    # NET_SSHD gate; round-trips through the wolf_heap-backed scrypt.
+    kernel/tests/test_passwd.c
     # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
     # FDT general-purpose reader (kernel/lib/fdt) — ARM64 only for

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -57,6 +57,10 @@ int cmd_uptime(int argc, char **argv);
 int cmd_canary(int argc, char **argv);
 int cmd_rng(int argc, char **argv);   /* rng_shell.c — #199a / #893 */
 int cmd_sshd(int argc, char **argv);  /* net/ssh/sshd_shell.c — #199a / #893 */
+int cmd_adduser(int argc, char **argv); /* net/ssh/passwd_shell.c — #199d / #896 */
+int cmd_passwd(int argc, char **argv);  /* net/ssh/passwd_shell.c — #199d / #896 */
+int cmd_deluser(int argc, char **argv); /* net/ssh/passwd_shell.c — #199d / #896 */
+int cmd_whoami(int argc, char **argv);  /* net/ssh/passwd_shell.c — #199d / #896 */
 int cmd_clear(int argc, char **argv);
 int cmd_reboot(int argc, char **argv);
 int cmd_sleep(int argc, char **argv);

--- a/kernel/lib/wolfcrypt/src/pwdbased.c
+++ b/kernel/lib/wolfcrypt/src/pwdbased.c
@@ -1,0 +1,900 @@
+/* pwdbased.c
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifndef NO_PWDBASED
+
+#if FIPS_VERSION3_GE(6,0,0)
+    /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
+    #define FIPS_NO_WRAPPERS
+
+       #ifdef USE_WINDOWS_API
+               #pragma code_seg(".fipsA$h")
+               #pragma const_seg(".fipsB$h")
+       #endif
+#endif
+
+#include <wolfssl/wolfcrypt/pwdbased.h>
+#include <wolfssl/wolfcrypt/hmac.h>
+#include <wolfssl/wolfcrypt/hash.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    #ifdef DEBUG_WOLFSSL
+        #include <wolfssl/wolfcrypt/logging.h>
+    #endif
+    const unsigned int wolfCrypt_FIPS_pbkdf_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000010 };
+    int wolfCrypt_FIPS_PBKDF_sanity(void)
+    {
+        return 0;
+    }
+#endif
+
+#ifdef HAVE_PBKDF1
+
+/* PKCS#5 v1.5 with non standard extension to optionally derive the extra data (IV) */
+int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
+    const byte* passwd, int passwdLen, const byte* salt, int saltLen,
+    int iterations, int hashType, void* heap)
+{
+    int  err;
+    int  keyLeft, ivLeft, i;
+    int  store;
+    int  keyOutput = 0;
+    int  digestLen;
+    byte digest[WC_MAX_DIGEST_SIZE];
+#ifdef WOLFSSL_SMALL_STACK
+    wc_HashAlg* hash = NULL;
+#else
+    wc_HashAlg  hash[1];
+#endif
+    enum wc_HashType hashT;
+
+    (void)heap;
+
+    if (key == NULL || keyLen < 0 || passwdLen < 0 || saltLen < 0 || ivLen < 0){
+        return BAD_FUNC_ARG;
+    }
+
+    if (iterations <= 0)
+        iterations = 1;
+
+    hashT = wc_HashTypeConvert(hashType);
+    err = wc_HashGetDigestSize(hashT);
+    if (err < 0)
+        return err;
+    digestLen = err;
+
+    /* initialize hash */
+#ifdef WOLFSSL_SMALL_STACK
+    hash = (wc_HashAlg*)XMALLOC(sizeof(wc_HashAlg), heap,
+                                DYNAMIC_TYPE_HASHCTX);
+    if (hash == NULL)
+        return MEMORY_E;
+#endif
+
+    err = wc_HashInit_ex(hash, hashT, heap, INVALID_DEVID);
+    if (err != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(hash, heap, DYNAMIC_TYPE_HASHCTX);
+    #endif
+        return err;
+    }
+
+    keyLeft = keyLen;
+    ivLeft  = ivLen;
+    while (keyOutput < (keyLen + ivLen)) {
+        int digestLeft = digestLen;
+        /* D_(i - 1) */
+        if (keyOutput) { /* first time D_0 is empty */
+            err = wc_HashUpdate(hash, hashT, digest, (word32)digestLen);
+            if (err != 0) break;
+        }
+
+        /* data */
+        err = wc_HashUpdate(hash, hashT, passwd, (word32)passwdLen);
+        if (err != 0) break;
+
+        /* salt */
+        if (salt) {
+            err = wc_HashUpdate(hash, hashT, salt, (word32)saltLen);
+            if (err != 0) break;
+        }
+
+        err = wc_HashFinal(hash, hashT, digest);
+        if (err != 0) break;
+
+        /* count */
+        for (i = 1; i < iterations; i++) {
+            err = wc_HashUpdate(hash, hashT, digest, (word32)digestLen);
+            if (err != 0) break;
+
+            err = wc_HashFinal(hash, hashT, digest);
+            if (err != 0) break;
+        }
+
+        if (err != 0) break;
+
+        if (keyLeft) {
+            store = (int)min((word32)keyLeft, (word32)digestLen);
+            XMEMCPY(&key[keyLen - keyLeft], digest, (size_t)store);
+
+            keyOutput  += store;
+            keyLeft    -= store;
+            digestLeft -= store;
+        }
+
+        if (ivLeft && digestLeft) {
+            store = (int)min((word32)ivLeft, (word32)digestLeft);
+            if (iv != NULL)
+                XMEMCPY(&iv[ivLen - ivLeft],
+                        &digest[digestLen - digestLeft], (size_t)store);
+            keyOutput += store;
+            ivLeft    -= store;
+        }
+    }
+
+    wc_HashFree(hash, hashT);
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(hash, heap, DYNAMIC_TYPE_HASHCTX);
+#endif
+
+    if (err != 0)
+        return err;
+
+    if (keyOutput != (keyLen + ivLen))
+        return BUFFER_E;
+
+    return err;
+}
+
+/* PKCS#5 v1.5 */
+int wc_PBKDF1(byte* output, const byte* passwd, int pLen, const byte* salt,
+           int sLen, int iterations, int kLen, int hashType)
+{
+
+    return wc_PBKDF1_ex(output, kLen, NULL, 0,
+        passwd, pLen, salt, sLen, iterations, hashType, NULL);
+}
+
+#endif /* HAVE_PKCS5 */
+
+#if defined(HAVE_PBKDF2) && !defined(NO_HMAC)
+
+int wc_PBKDF2_ex(byte* output, const byte* passwd, int pLen, const byte* salt,
+           int sLen, int iterations, int kLen, int hashType, void* heap, int devId)
+{
+    int    hLen;
+    int    ret;
+#ifdef WOLFSSL_SMALL_STACK
+    byte*  buffer;
+    Hmac*  hmac;
+#else
+    byte   buffer[WC_MAX_DIGEST_SIZE];
+    Hmac   hmac[1];
+#endif
+    enum wc_HashType hashT;
+
+    if (output == NULL || pLen < 0 || sLen < 0 || kLen < 0) {
+        return BAD_FUNC_ARG;
+    }
+
+#if FIPS_VERSION3_GE(6,0,0)
+    /* Per SP800-132 section 5 "The kLen value shall be at least 112 bits in
+     * length", ensure the returned bits for the derived master key are at a
+     * minimum 14-bytes or 112-bits after stretching and strengthening
+     * (iterations) */
+    if (kLen < HMAC_FIPS_MIN_KEY)
+        return BAD_LENGTH_E;
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0) && defined(DEBUG_WOLFSSL)
+    /* SP800-132 section 5.2 recommends an iteration count of 1000 but this is
+     * not strictly enforceable and is listed in Appendix B Table 1 as a
+     * non-testable requirement. wolfCrypt will log it when appropriate but
+     * take no action */
+    if (iterations < 1000) {
+        WOLFSSL_MSG("WARNING: Iteration < 1,000, see SP800-132 section 5.2");
+    }
+#endif
+    if (iterations <= 0)
+        iterations = 1;
+
+    hashT = wc_HashTypeConvert(hashType);
+    hLen = wc_HashGetDigestSize(hashT);
+    if (hLen < 0)
+        return BAD_FUNC_ARG;
+
+#ifdef WOLFSSL_SMALL_STACK
+    buffer = (byte*)XMALLOC(WC_MAX_DIGEST_SIZE, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (buffer == NULL)
+        return MEMORY_E;
+    hmac = (Hmac*)XMALLOC(sizeof(Hmac), heap, DYNAMIC_TYPE_HMAC);
+    if (hmac == NULL) {
+        XFREE(buffer, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return MEMORY_E;
+    }
+#endif
+
+    ret = wc_HmacInit(hmac, heap, devId);
+    if (ret == 0) {
+        word32 i = 1;
+        /* use int hashType here, since HMAC FIPS uses the old unique value */
+    #if FIPS_VERSION3_GE(6,0,0)
+        {
+            /* Allow passwords that are less than 14-bytes for compatibility
+             * / interoperability, only since module v6.0.0 */
+            int allowShortPasswd = 1;
+            ret = wc_HmacSetKey_ex(hmac, hashType, passwd, (word32)pLen,
+                                   allowShortPasswd);
+        }
+    #else
+        ret = wc_HmacSetKey(hmac, hashType, passwd, (word32)pLen);
+    #endif
+
+        while (ret == 0 && kLen) {
+            int currentLen;
+            int j;
+
+            ret = wc_HmacUpdate(hmac, salt, (word32)sLen);
+            if (ret != 0)
+                break;
+
+            /* encode i */
+            for (j = 0; j < 4; j++) {
+                byte b = (byte)(i >> ((3-j) * 8));
+
+                ret = wc_HmacUpdate(hmac, &b, 1);
+                if (ret != 0)
+                    break;
+            }
+
+            /* check ret from inside for loop */
+            if (ret != 0)
+                break;
+
+            ret = wc_HmacFinal(hmac, buffer);
+            if (ret != 0)
+                break;
+
+            currentLen = (int)min((word32)kLen, (word32)hLen);
+            XMEMCPY(output, buffer, (size_t)currentLen);
+
+            for (j = 1; j < iterations; j++) {
+                ret = wc_HmacUpdate(hmac, buffer, (word32)hLen);
+                if (ret != 0)
+                    break;
+                ret = wc_HmacFinal(hmac, buffer);
+                if (ret != 0)
+                    break;
+                xorbuf(output, buffer, (word32)currentLen);
+            }
+
+            /* check ret from inside for loop */
+            if (ret != 0)
+                break;
+
+            output += currentLen;
+            kLen   -= currentLen;
+            i++;
+        }
+        wc_HmacFree(hmac);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(buffer, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(hmac, heap, DYNAMIC_TYPE_HMAC);
+#endif
+
+    return ret;
+}
+
+int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
+           int sLen, int iterations, int kLen, int hashType)
+{
+    return wc_PBKDF2_ex(output, passwd, pLen, salt, sLen, iterations, kLen,
+        hashType, NULL, INVALID_DEVID);
+}
+
+#endif /* HAVE_PBKDF2 && !NO_HMAC */
+
+#ifdef HAVE_PKCS12
+
+/* helper for PKCS12_PBKDF(), does hash operation */
+static int DoPKCS12Hash(int hashType, byte* buffer, word32 totalLen,
+                 byte* Ai, word32 u, int iterations)
+{
+    int i;
+    int ret = 0;
+#ifdef WOLFSSL_SMALL_STACK
+    wc_HashAlg* hash = NULL;
+#else
+    wc_HashAlg  hash[1];
+#endif
+    enum wc_HashType hashT;
+
+    if (buffer == NULL || Ai == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    hashT = wc_HashTypeConvert(hashType);
+
+    /* initialize hash */
+#ifdef WOLFSSL_SMALL_STACK
+    hash = (wc_HashAlg*)XMALLOC(sizeof(wc_HashAlg), NULL,
+                                DYNAMIC_TYPE_HASHCTX);
+    if (hash == NULL)
+        return MEMORY_E;
+#endif
+
+    ret = wc_HashInit(hash, hashT);
+    if (ret != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(hash, NULL, DYNAMIC_TYPE_HASHCTX);
+    #endif
+        return ret;
+    }
+
+    ret = wc_HashUpdate(hash, hashT, buffer, totalLen);
+
+    if (ret == 0)
+        ret = wc_HashFinal(hash, hashT, Ai);
+
+    for (i = 1; i < iterations; i++) {
+        if (ret == 0)
+            ret = wc_HashUpdate(hash, hashT, Ai, u);
+        if (ret == 0)
+            ret = wc_HashFinal(hash, hashT, Ai);
+    }
+
+    wc_HashFree(hash, hashT);
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(hash, NULL, DYNAMIC_TYPE_HASHCTX);
+#endif
+
+    return ret;
+}
+
+
+int wc_PKCS12_PBKDF(byte* output, const byte* passwd, int passLen,
+    const byte* salt, int saltLen, int iterations, int kLen, int hashType,
+    int id)
+{
+    return wc_PKCS12_PBKDF_ex(output, passwd, passLen, salt, saltLen,
+                              iterations, kLen, hashType, id, NULL);
+}
+
+
+/* extended API that allows a heap hint to be used */
+int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
+                       const byte* salt, int saltLen, int iterations, int kLen,
+                       int hashType, int id, void* heap)
+{
+    /* all in bytes instead of bits */
+    word32 u, v, dLen, pLen, iLen, sLen, totalLen;
+    int    dynamic = 0;
+    int    ret = 0;
+    word32 i;
+    byte   *D, *S, *P, *I;
+#ifdef WOLFSSL_SMALL_STACK
+    byte   staticBuffer[1]; /* force dynamic usage */
+#else
+    byte   staticBuffer[1024];
+#endif
+    byte*  buffer = staticBuffer;
+
+#ifdef WOLFSSL_SMALL_STACK
+    byte*  Ai = NULL;
+    byte*  B = NULL;
+    mp_int *B1 = NULL;
+    mp_int *i1 = NULL;
+    mp_int *res = NULL;
+#else
+    byte   Ai[WC_MAX_DIGEST_SIZE];
+    byte   B[WC_MAX_BLOCK_SIZE];
+    mp_int B1[1];
+    mp_int i1[1];
+    mp_int res[1];
+#endif
+    enum wc_HashType hashT;
+
+    (void)heap;
+
+    if (output == NULL || passLen <= 0 || saltLen <= 0 || kLen < 0) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (iterations <= 0)
+        iterations = 1;
+
+    hashT = wc_HashTypeConvert(hashType);
+    ret = wc_HashGetDigestSize(hashT);
+    if (ret < 0)
+        return ret;
+    if (ret == 0)
+        return BAD_STATE_E;
+    u = (word32)ret;
+
+    ret = wc_HashGetBlockSize(hashT);
+    if (ret < 0)
+        return ret;
+    if (ret == 0)
+        return BAD_STATE_E;
+    v = (word32)ret;
+
+#ifdef WOLFSSL_SMALL_STACK
+    Ai = (byte*)XMALLOC(WC_MAX_DIGEST_SIZE, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (Ai == NULL)
+        return MEMORY_E;
+
+    B = (byte*)XMALLOC(WC_MAX_BLOCK_SIZE, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (B == NULL) {
+        XFREE(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return MEMORY_E;
+    }
+#endif
+
+    XMEMSET(Ai, 0, WC_MAX_DIGEST_SIZE);
+    XMEMSET(B,  0, WC_MAX_BLOCK_SIZE);
+
+    dLen = v;
+    sLen = v * (((word32)saltLen + v - 1) / v);
+
+    /* with passLen checked at the top of the function for >= 0 then passLen
+     * must be 1 or greater here and is always 'true' */
+    pLen = v * (((word32)passLen + v - 1) / v);
+    iLen = sLen + pLen;
+
+    totalLen = dLen + sLen + pLen;
+
+    if (totalLen > sizeof(staticBuffer)) {
+        buffer = (byte*)XMALLOC(totalLen, heap, DYNAMIC_TYPE_KEY);
+        if (buffer == NULL) {
+#ifdef WOLFSSL_SMALL_STACK
+            XFREE(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(B,  heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+            return MEMORY_E;
+        }
+        dynamic = 1;
+    }
+
+    D = buffer;
+    S = D + dLen;
+    P = S + sLen;
+    I = S;
+
+    XMEMSET(D, id, dLen);
+
+    for (i = 0; i < sLen; i++)
+        S[i] = salt[i % (word32)saltLen];
+    for (i = 0; i < pLen; i++)
+        P[i] = passwd[i % (word32)passLen];
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (((B1 = (mp_int *)XMALLOC(sizeof(*B1), heap, DYNAMIC_TYPE_TMP_BUFFER))
+         == NULL) ||
+        ((i1 = (mp_int *)XMALLOC(sizeof(*i1), heap, DYNAMIC_TYPE_TMP_BUFFER))
+         == NULL) ||
+        ((res = (mp_int *)XMALLOC(sizeof(*res), heap, DYNAMIC_TYPE_TMP_BUFFER))
+         == NULL)) {
+        ret = MEMORY_E;
+        goto out;
+    }
+#endif
+
+    while (kLen > 0) {
+        word32 currentLen;
+
+        ret = DoPKCS12Hash(hashType, buffer, totalLen, Ai, u, iterations);
+        if (ret < 0)
+            break;
+
+        for (i = 0; i < v; i++)
+            B[i] = Ai[(word32)i % u];
+
+        if (mp_init(B1) != MP_OKAY)
+            ret = MP_INIT_E;
+        else if (mp_read_unsigned_bin(B1, B, v) != MP_OKAY)
+            ret = MP_READ_E;
+        else if (mp_add_d(B1, (mp_digit)1, B1) != MP_OKAY)
+            ret = MP_ADD_E;
+
+        if (ret != 0) {
+            mp_clear(B1);
+            break;
+        }
+
+        for (i = 0; i < iLen; i += v) {
+            int    outSz;
+
+            if (mp_init_multi(i1, res, NULL, NULL, NULL, NULL) != MP_OKAY) {
+                ret = MP_INIT_E;
+                break;
+            }
+            if (mp_read_unsigned_bin(i1, I + i, v) != MP_OKAY)
+                ret = MP_READ_E;
+            else if (mp_add(i1, B1, res) != MP_OKAY)
+                ret = MP_ADD_E;
+            else if ( (outSz = mp_unsigned_bin_size(res)) < 0)
+                ret = MP_TO_E;
+            else {
+                if (outSz > (int)v) {
+                    /* take off MSB */
+                    byte  tmp[WC_MAX_BLOCK_SIZE + 1];
+                    ret = mp_to_unsigned_bin(res, tmp);
+                    XMEMCPY(I + i, tmp + 1, v);
+                }
+                else if (outSz < (int)v) {
+                    XMEMSET(I + i, 0, v - (word32)outSz);
+                    ret = mp_to_unsigned_bin(res, I + i + v - (word32)outSz);
+                }
+                else
+                    ret = mp_to_unsigned_bin(res, I + i);
+            }
+
+            mp_clear(i1);
+            mp_clear(res);
+            if (ret < 0) break;
+        }
+
+        if (ret < 0) {
+            mp_clear(B1);
+            break;
+        }
+
+        currentLen = min((word32)kLen, u);
+        XMEMCPY(output, Ai, currentLen);
+        output += currentLen;
+        kLen   -= (int)currentLen;
+        mp_clear(B1);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+  out:
+
+    XFREE(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(B, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(B1, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(i1, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(res, heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+
+    if (dynamic)
+        XFREE(buffer, heap, DYNAMIC_TYPE_KEY);
+
+    return ret;
+}
+
+#endif /* HAVE_PKCS12 */
+
+#ifdef HAVE_SCRYPT
+#ifdef NO_HMAC
+   #error scrypt requires HMAC
+#endif
+
+/* Rotate the 32-bit value a by b bits to the left.
+ *
+ * a  32-bit value.
+ * b  Number of bits to rotate.
+ * returns rotated value.
+ */
+#define R(a, b) rotlFixed(a, b)
+
+/* (2^32 - 1) */
+#define SCRYPT_WORD32_MAX 4294967295U
+
+/* One round of Salsa20/8.
+ * Code taken from RFC 7914: scrypt PBKDF.
+ *
+ * out  Output buffer.
+ * in   Input data to hash.
+ */
+static void scryptSalsa(word32* out, word32* in)
+{
+    int    i;
+    word32 x[16];
+
+#ifdef LITTLE_ENDIAN_ORDER
+    XMEMCPY(x, in, sizeof(x));
+#else
+    for (i = 0; i < 16; i++)
+        x[i] = ByteReverseWord32(in[i]);
+#endif
+    for (i = 8; i > 0; i -= 2) {
+        x[ 4] ^= R(x[ 0] + x[12],  7);  x[ 8] ^= R(x[ 4] + x[ 0],  9);
+        x[12] ^= R(x[ 8] + x[ 4], 13);  x[ 0] ^= R(x[12] + x[ 8], 18);
+        x[ 9] ^= R(x[ 5] + x[ 1],  7);  x[13] ^= R(x[ 9] + x[ 5],  9);
+        x[ 1] ^= R(x[13] + x[ 9], 13);  x[ 5] ^= R(x[ 1] + x[13], 18);
+        x[14] ^= R(x[10] + x[ 6],  7);  x[ 2] ^= R(x[14] + x[10],  9);
+        x[ 6] ^= R(x[ 2] + x[14], 13);  x[10] ^= R(x[ 6] + x[ 2], 18);
+        x[ 3] ^= R(x[15] + x[11],  7);  x[ 7] ^= R(x[ 3] + x[15],  9);
+        x[11] ^= R(x[ 7] + x[ 3], 13);  x[15] ^= R(x[11] + x[ 7], 18);
+        x[ 1] ^= R(x[ 0] + x[ 3],  7);  x[ 2] ^= R(x[ 1] + x[ 0],  9);
+        x[ 3] ^= R(x[ 2] + x[ 1], 13);  x[ 0] ^= R(x[ 3] + x[ 2], 18);
+        x[ 6] ^= R(x[ 5] + x[ 4],  7);  x[ 7] ^= R(x[ 6] + x[ 5],  9);
+        x[ 4] ^= R(x[ 7] + x[ 6], 13);  x[ 5] ^= R(x[ 4] + x[ 7], 18);
+        x[11] ^= R(x[10] + x[ 9],  7);  x[ 8] ^= R(x[11] + x[10],  9);
+        x[ 9] ^= R(x[ 8] + x[11], 13);  x[10] ^= R(x[ 9] + x[ 8], 18);
+        x[12] ^= R(x[15] + x[14],  7);  x[13] ^= R(x[12] + x[15],  9);
+        x[14] ^= R(x[13] + x[12], 13);  x[15] ^= R(x[14] + x[13], 18);
+    }
+#ifdef LITTLE_ENDIAN_ORDER
+    for (i = 0; i < 16; ++i)
+        out[i] = in[i] + x[i];
+#else
+    for (i = 0; i < 16; i++)
+        out[i] = ByteReverseWord32(ByteReverseWord32(in[i]) + x[i]);
+#endif
+}
+
+/* Mix a block using Salsa20/8.
+ * Based on RFC 7914: scrypt PBKDF.
+ *
+ * b  Blocks to mix.
+ * y  Temporary storage.
+ * r  Size of the block.
+ */
+static void scryptBlockMix(byte* b, byte* y, int r)
+{
+#ifdef WORD64_AVAILABLE
+    word64  x[8];
+    word64* b64 = (word64*)b;
+    word64* y64 = (word64*)y;
+#else
+    word32  x[16];
+    word32* b32 = (word32*)b;
+    word32* y32 = (word32*)y;
+#endif
+    int  i;
+    int  j;
+
+    /* Step 1. */
+    XMEMCPY(x, b + (2 * r - 1) * 64, sizeof(x));
+    /* Step 2. */
+    for (i = 0; i < 2 * r; i++)
+    {
+#ifdef WORD64_AVAILABLE
+        for (j = 0; j < 8; j++)
+            x[j] ^= b64[i * 8 + j];
+
+#else
+        for (j = 0; j < 16; j++)
+            x[j] ^= b32[i * 16 + j];
+#endif
+        scryptSalsa((word32*)x, (word32*)x);
+        XMEMCPY(y + i * 64, x, sizeof(x));
+    }
+    /* Step 3. */
+    for (i = 0; i < r; i++) {
+#ifdef WORD64_AVAILABLE
+        for (j = 0; j < 8; j++) {
+            b64[i * 8 + j] = y64[2 * i * 8 + j];
+            b64[(r + i) * 8 + j] = y64[(2 * i + 1) * 8 + j];
+        }
+#else
+        for (j = 0; j < 16; j++) {
+            b32[i * 16 + j] = y32[2 * i * 16 + j];
+            b32[(r + i) * 16 + j] = y32[(2 * i + 1) * 16 + j];
+        }
+#endif
+    }
+}
+
+/* Random oracles mix.
+ * Based on RFC 7914: scrypt PBKDF.
+ *
+ * x  Data to mix.
+ * v  Temporary buffer.
+ * y  Temporary buffer for the block mix.
+ * r  Block size parameter.
+ * n  CPU/Memory cost parameter.
+ */
+static void scryptROMix(byte* x, byte* v, byte* y, int r, word32 n)
+{
+    word32 i;
+    word32 j;
+    word32 k;
+    word32 bSz = (word32)(128 * r);
+#ifdef WORD64_AVAILABLE
+    word64* x64 = (word64*)x;
+    word64* v64 = (word64*)v;
+#else
+    word32* x32 = (word32*)x;
+    word32* v32 = (word32*)v;
+#endif
+
+    /* Step 1. X = B (B not needed therefore not implemented) */
+    /* Step 2. */
+    for (i = 0; i < n; i++)
+    {
+        XMEMCPY(v + i * bSz, x, bSz);
+        scryptBlockMix(x, y, r);
+    }
+
+    /* Step 3. */
+    for (i = 0; i < n; i++)
+    {
+#ifdef LITTLE_ENDIAN_ORDER
+#ifdef WORD64_AVAILABLE
+        j = (word32)(*(word64*)(x + (2*r - 1) * 64) & (n-1));
+#else
+        j = *(word32*)(x + (2*r - 1) * 64) & (n-1);
+#endif
+#else
+        byte* t = x + (2*r - 1) * 64;
+        j = (t[0] | (t[1] << 8) | (t[2] << 16) | ((word32)t[3] << 24)) & (n-1);
+#endif
+#ifdef WORD64_AVAILABLE
+        for (k = 0; k < bSz / 8; k++)
+            x64[k] ^= v64[j * bSz / 8 + k];
+#else
+        for (k = 0; k < bSz / 4; k++)
+            x32[k] ^= v32[j * bSz / 4 + k];
+#endif
+        scryptBlockMix(x, y, r);
+    }
+    /* Step 4. B' = X (B = X = B' so not needed, therefore not implemented) */
+}
+
+/* Generates an key derived from a password and salt using a memory hard
+ * algorithm.
+ * Implements RFC 7914: scrypt PBKDF.
+ *
+ * output     The derived key.
+ * passwd     The password to derive key from.
+ * passLen    The length of the password.
+ * salt       The key specific data.
+ * saltLen    The length of the salt data.
+ * cost       The CPU/memory cost parameter. Range: 1..(128*r/8-1)
+ *            (Iterations = 2^cost)
+ * blockSize  The number of 128 byte octets in a working block.
+ * parallel   The number of parallel mix operations to perform.
+ *            (Note: this implementation does not use threads.)
+ * dkLen      The length of the derived key in bytes.
+ * returns BAD_FUNC_ARG when: blockSize is too large for cost.
+ */
+int wc_scrypt(byte* output, const byte* passwd, int passLen,
+              const byte* salt, int saltLen, int cost, int blockSize,
+              int parallel, int dkLen)
+{
+    int    ret = 0;
+    int    i;
+    byte*  v = NULL;
+    byte*  y = NULL;
+    byte*  blocks = NULL;
+    word32 blocksSz;
+    word32 bSz;
+
+    if (blockSize > 8)
+        return BAD_FUNC_ARG;
+
+    if (cost < 1 || cost >= 128 * blockSize / 8 || parallel < 1 || dkLen < 1)
+        return BAD_FUNC_ARG;
+
+    /* The following comparison used to be:
+     *    ((word32)parallel > (SCRYPT_MAX / (128 * blockSize)))
+     * where SCRYPT_MAX is (2^32 - 1) * 32. For some compilers, the RHS of
+     * the comparison is greater than parallel's type. It wouldn't promote
+     * both sides to word64. What follows is just arithmetic simplification.
+     */
+    if (parallel > (int)((SCRYPT_WORD32_MAX / 4) / (word32)blockSize))
+        return BAD_FUNC_ARG;
+
+    bSz = 128 * (word32)blockSize;
+    if (parallel > (int)(SCRYPT_WORD32_MAX / bSz))
+        return BAD_FUNC_ARG;
+    blocksSz = bSz * (word32)parallel;
+    blocks = (byte*)XMALLOC((size_t)blocksSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (blocks == NULL) {
+        ret = MEMORY_E;
+        goto end;
+    }
+    /* Temporary for scryptROMix. */
+    v = (byte*)XMALLOC((size_t)((1 << cost) * bSz), NULL,
+                       DYNAMIC_TYPE_TMP_BUFFER);
+    if (v == NULL) {
+        ret = MEMORY_E;
+        goto end;
+    }
+    /* Temporary for scryptBlockMix. */
+    y = (byte*)XMALLOC((size_t)(blockSize * 128), NULL,
+                       DYNAMIC_TYPE_TMP_BUFFER);
+    if (y == NULL) {
+        ret = MEMORY_E;
+        goto end;
+    }
+
+    /* Step 1. */
+    ret = wc_PBKDF2(blocks, passwd, passLen, salt, saltLen, 1, (int)blocksSz,
+                    WC_SHA256);
+    if (ret != 0)
+        goto end;
+
+    /* Step 2. */
+    for (i = 0; i < parallel; i++)
+        scryptROMix(blocks + i * (int)bSz, v, y, (int)blockSize, 1 << cost);
+
+    /* Step 3. */
+    ret = wc_PBKDF2(output, passwd, passLen, blocks, (int)blocksSz, 1, dkLen,
+                    WC_SHA256);
+end:
+    XFREE(blocks, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(v, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(y, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
+    return ret;
+}
+
+/* Generates an key derived from a password and salt using a memory hard
+ * algorithm.
+ * Implements RFC 7914: scrypt PBKDF.
+ *
+ * output      Derived key.
+ * passwd      Password to derive key from.
+ * passLen     Length of the password.
+ * salt        Key specific data.
+ * saltLen     Length of the salt data.
+ * iterations  Number of iterations to perform. Range: 1 << (1..(128*r/8-1))
+ * blockSize   Number of 128 byte octets in a working block.
+ * parallel    Number of parallel mix operations to perform.
+ *             (Note: this implementation does not use threads.)
+ * dkLen       Length of the derived key in bytes.
+ * returns BAD_FUNC_ARG when: iterations is not a power of 2 or blockSize is too
+ *                            large for iterations.
+ */
+int wc_scrypt_ex(byte* output, const byte* passwd, int passLen,
+                 const byte* salt, int saltLen, word32 iterations,
+                 int blockSize, int parallel, int dkLen)
+{
+    int cost;
+
+    /* Iterations must be a power of 2. */
+    if ((iterations & (iterations - 1)) != 0)
+        return BAD_FUNC_ARG;
+
+    for (cost = -1; iterations != 0; cost++) {
+        iterations >>= 1;
+    }
+
+    return wc_scrypt(output, passwd, passLen, salt, saltLen, cost, blockSize,
+                     parallel, dkLen);
+}
+#endif /* HAVE_SCRYPT */
+
+#endif /* NO_PWDBASED */

--- a/kernel/net/ssh/passwd.c
+++ b/kernel/net/ssh/passwd.c
@@ -318,8 +318,10 @@ static int derive_hash(const char *password,
      * higher log2_n than we ever produce is either corruption or an
      * import from foreign tooling we don't support. wc_scrypt would
      * fail allocation long before log2_n > 20 (~1 GB) on any SLM-OS
-     * platform anyway. */
-    if (log2_n <= 0 || log2_n > PASSWD_SCRYPT_LOG2_N) return PASSWD_E_KDF;
+     * platform anyway. Distinct return code so the operator can tell
+     * a corrupt-cost-field passwd entry apart from a runtime scrypt
+     * failure (heap exhaustion etc.). */
+    if (log2_n <= 0 || log2_n > PASSWD_SCRYPT_LOG2_N) return PASSWD_E_COST;
     int rc = wc_scrypt(out,
                        (const uint8_t *)password,
                        (int)strlen(password),
@@ -587,9 +589,8 @@ int passwd_set(const char *username, const char *new_password)
      * stack. Reachable from any authenticated shell user (SSH /
      * console / telnet). */
     size_t un_len = strlen(username);
-    size_t pw_len = strlen(new_password);
     if (un_len > PASSWD_MAX_USERNAME_LEN) return PASSWD_E_BAD_ARG;
-    if (pw_len > PASSWD_MAX_PASSWORD_LEN) return PASSWD_E_BAD_ARG;
+    if (strlen(new_password) > PASSWD_MAX_PASSWORD_LEN) return PASSWD_E_BAD_ARG;
 
     struct passwd_entry e;
     memcpy(e.username, username, un_len + 1u);

--- a/kernel/net/ssh/passwd.c
+++ b/kernel/net/ssh/passwd.c
@@ -1,0 +1,565 @@
+/*
+ * passwd.c - User database + scrypt password verification.
+ *
+ * Backed by /mnt/files/etc/passwd. PHC-style line format:
+ *
+ *   username:$scrypt$N=N,r=R,p=P$<salt-b64-no-padding>$<hash-b64-no-padding>:uid:home
+ *
+ * Fields after the hash (uid, home) are reserved for #199e or later
+ * usage — currently parsed but not enforced (SLM-OS has no
+ * permission model).
+ *
+ * scrypt cost: N=2^PASSWD_SCRYPT_LOG2_N (32 MB), r=8, p=1. Single
+ * derivation per auth attempt takes ~100 ms on Pi 5 (acceptable for
+ * SSH-handshake frequency, prohibitive for offline guessing).
+ *
+ * Concurrency: the daemon takes one auth per session-task at a time;
+ * we don't lock the file across calls. The race window between
+ * `passwd_verify` and a concurrent `passwd_set` is bounded by the
+ * littlefs atomic-rename semantics (open snapshot is consistent
+ * even if a parallel writer rotates the file underneath).
+ */
+
+#include "passwd.h"
+
+#include "littlefs_slm.h"
+#include "rng.h"
+#include "string.h"
+#include "uart.h"
+#include "vfs.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <wolfssl/wolfcrypt/pwdbased.h>
+
+/* ---------------------------------------------------------------- */
+/* On-disk layout                                                    */
+/* ---------------------------------------------------------------- */
+
+#define PASSWD_PATH_PREFIX     "/mnt/files"
+#define PASSWD_LFS             "/etc/passwd"
+#define PASSWD_TMP_LFS         "/etc/passwd.tmp"
+
+#define MAX_PASSWD_USERS       8u
+#define MAX_LINE_LEN           (PASSWD_MAX_USERNAME_LEN + 256u)
+
+/* Buffer the entire file in a single read — keeps the parser simple
+ * and lets passwd_set rewrite atomically via .tmp + rename. */
+#define PASSWD_FILE_MAX_BYTES  (MAX_PASSWD_USERS * MAX_LINE_LEN)
+
+/* ---------------------------------------------------------------- */
+/* Base64 (no padding) helpers — reused from host_key.c semantics    */
+/* ---------------------------------------------------------------- */
+
+static const char k_b64[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static size_t b64_encode(const uint8_t *in, size_t len, char *out, size_t cap)
+{
+    size_t oi = 0;
+    size_t i  = 0;
+    while (i + 3u <= len) {
+        if (oi + 4u > cap) return 0;
+        uint32_t v = ((uint32_t)in[i] << 16) | ((uint32_t)in[i + 1] << 8)
+                     | (uint32_t)in[i + 2];
+        out[oi++] = k_b64[(v >> 18) & 0x3Fu];
+        out[oi++] = k_b64[(v >> 12) & 0x3Fu];
+        out[oi++] = k_b64[(v >> 6)  & 0x3Fu];
+        out[oi++] = k_b64[v & 0x3Fu];
+        i += 3u;
+    }
+    size_t tail = len - i;
+    if (tail == 1u) {
+        if (oi + 2u > cap) return 0;
+        uint32_t v = (uint32_t)in[i] << 16;
+        out[oi++] = k_b64[(v >> 18) & 0x3Fu];
+        out[oi++] = k_b64[(v >> 12) & 0x3Fu];
+    } else if (tail == 2u) {
+        if (oi + 3u > cap) return 0;
+        uint32_t v = ((uint32_t)in[i] << 16) | ((uint32_t)in[i + 1] << 8);
+        out[oi++] = k_b64[(v >> 18) & 0x3Fu];
+        out[oi++] = k_b64[(v >> 12) & 0x3Fu];
+        out[oi++] = k_b64[(v >> 6)  & 0x3Fu];
+    }
+    return oi;
+}
+
+static int b64_value(char c)
+{
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+') return 62;
+    if (c == '/') return 63;
+    return -1;
+}
+
+static size_t b64_decode(const char *in, size_t len, uint8_t *out, size_t cap)
+{
+    size_t oi = 0;
+    uint32_t acc = 0;
+    int bits = 0;
+    for (size_t i = 0; i < len; i++) {
+        int v = b64_value(in[i]);
+        if (v < 0) return 0;
+        acc = (acc << 6) | (uint32_t)v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            if (oi >= cap) return 0;
+            out[oi++] = (uint8_t)((acc >> bits) & 0xFFu);
+        }
+    }
+    return oi;
+}
+
+/* ---------------------------------------------------------------- */
+/* VFS helpers                                                       */
+/* ---------------------------------------------------------------- */
+
+static struct lfs_mount *resolve_mount(void)
+{
+    const char *subpath = NULL;
+    return (struct lfs_mount *)vfs_get_mount_ctx(PASSWD_PATH_PREFIX, &subpath);
+}
+
+static int read_file_all(struct lfs_mount *mnt, char *buf, size_t cap)
+{
+    int fd = littlefs_file_open(mnt, PASSWD_LFS, LFS_O_RDONLY);
+    if (fd < 0) return -1;
+    int n = littlefs_file_read(mnt, fd, buf, cap - 1u);
+    littlefs_file_close(mnt, fd);
+    if (n < 0) return -1;
+    buf[n] = '\0';
+    return n;
+}
+
+static int write_file_atomic(struct lfs_mount *mnt, const char *buf, size_t len)
+{
+    (void)littlefs_mkdir(mnt, "/etc");
+    int fd = littlefs_file_open(mnt, PASSWD_TMP_LFS,
+                                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fd < 0) return -1;
+    int n = littlefs_file_write(mnt, fd, buf, len);
+    (void)littlefs_file_sync(mnt, fd);
+    littlefs_file_close(mnt, fd);
+    if (n != (int)len) {
+        (void)littlefs_remove(mnt, PASSWD_TMP_LFS);
+        return -1;
+    }
+    (void)littlefs_remove(mnt, PASSWD_LFS);
+    if (littlefs_rename(mnt, PASSWD_TMP_LFS, PASSWD_LFS) != 0) {
+        (void)littlefs_remove(mnt, PASSWD_TMP_LFS);
+        return -1;
+    }
+    return 0;
+}
+
+/* ---------------------------------------------------------------- */
+/* Line parser / formatter                                           */
+/* ---------------------------------------------------------------- */
+
+struct passwd_entry {
+    char     username[PASSWD_MAX_USERNAME_LEN + 1u];
+    uint8_t  salt[PASSWD_SALT_LEN];
+    uint8_t  hash[PASSWD_HASH_LEN];
+    int      log2_n;
+    int      r;
+    int      p;
+};
+
+/*
+ * Parse one PHC-style password line in place. The line buffer is
+ * mutated (NULs inserted). Returns 0 on success.
+ */
+static int parse_line(char *line, struct passwd_entry *out)
+{
+    char *p1 = strchr(line, ':');
+    if (!p1) return PASSWD_E_FORMAT;
+    *p1++ = '\0';
+
+    size_t un_len = strlen(line);
+    if (un_len == 0u || un_len > PASSWD_MAX_USERNAME_LEN) return PASSWD_E_FORMAT;
+    for (size_t i = 0; i <= un_len; i++) out->username[i] = line[i];
+
+    /* p1 now points at "$scrypt$N=N,r=R,p=P$<salt>$<hash>". */
+    if (strncmp(p1, "$scrypt$", 8) != 0) return PASSWD_E_FORMAT;
+    p1 += 8;
+
+    /* Parse "N=<num>,r=<num>,p=<num>". */
+    int log2_n = 0, r = 0, pp = 0;
+    while (*p1 && *p1 != '$') {
+        if (strncmp(p1, "N=", 2) == 0) {
+            p1 += 2;
+            while (*p1 >= '0' && *p1 <= '9') {
+                log2_n = log2_n * 10 + (*p1 - '0'); p1++;
+            }
+        } else if (strncmp(p1, "r=", 2) == 0) {
+            p1 += 2;
+            while (*p1 >= '0' && *p1 <= '9') { r = r * 10 + (*p1 - '0'); p1++; }
+        } else if (strncmp(p1, "p=", 2) == 0) {
+            p1 += 2;
+            while (*p1 >= '0' && *p1 <= '9') { pp = pp * 10 + (*p1 - '0'); p1++; }
+        } else if (*p1 == ',') {
+            p1++;
+        } else {
+            return PASSWD_E_FORMAT;
+        }
+    }
+    if (*p1 != '$') return PASSWD_E_FORMAT;
+    p1++;
+
+    out->log2_n = log2_n;
+    out->r      = r;
+    out->p      = pp;
+
+    /* Salt — base64-decode up to the next '$'. */
+    char *salt_end = strchr(p1, '$');
+    if (!salt_end) return PASSWD_E_FORMAT;
+    size_t slen = b64_decode(p1, (size_t)(salt_end - p1),
+                             out->salt, PASSWD_SALT_LEN);
+    if (slen != PASSWD_SALT_LEN) return PASSWD_E_FORMAT;
+
+    /* Hash — base64-decode up to the next ':' or '\0'. */
+    p1 = salt_end + 1;
+    char *hash_end = p1;
+    while (*hash_end && *hash_end != ':' && *hash_end != '\n') hash_end++;
+    size_t hlen = b64_decode(p1, (size_t)(hash_end - p1),
+                             out->hash, PASSWD_HASH_LEN);
+    if (hlen != PASSWD_HASH_LEN) return PASSWD_E_FORMAT;
+
+    return PASSWD_OK;
+}
+
+static size_t format_line(const struct passwd_entry *e, char *out, size_t cap)
+{
+    /* "username:$scrypt$N=N,r=R,p=P$<salt>$<hash>:0:/\n"
+     * The 0 and / placeholders are uid and home; we don't use them. */
+    char salt_b64[32];
+    char hash_b64[48];
+    size_t sl = b64_encode(e->salt, PASSWD_SALT_LEN, salt_b64, sizeof(salt_b64));
+    size_t hl = b64_encode(e->hash, PASSWD_HASH_LEN, hash_b64, sizeof(hash_b64));
+
+    /* Manual format — uart_snprintf would work but the field set is
+     * fixed and small. */
+    size_t pos = 0;
+    for (size_t i = 0; e->username[i] != '\0'; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = e->username[i];
+    }
+    static const char k_pfx[] = ":$scrypt$N=";
+    for (size_t i = 0; i < sizeof(k_pfx) - 1u; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = k_pfx[i];
+    }
+    /* log2_n as decimal */
+    char num[8];
+    int  ni = 0;
+    int  n  = e->log2_n;
+    if (n == 0) num[ni++] = '0';
+    while (n > 0 && ni < 8) { num[ni++] = '0' + (n % 10); n /= 10; }
+    while (ni > 0) { if (pos >= cap) return 0; out[pos++] = num[--ni]; }
+
+    static const char k_r[] = ",r=";
+    for (size_t i = 0; i < sizeof(k_r) - 1u; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = k_r[i];
+    }
+    n = e->r; ni = 0;
+    if (n == 0) num[ni++] = '0';
+    while (n > 0 && ni < 8) { num[ni++] = '0' + (n % 10); n /= 10; }
+    while (ni > 0) { if (pos >= cap) return 0; out[pos++] = num[--ni]; }
+
+    static const char k_p[] = ",p=";
+    for (size_t i = 0; i < sizeof(k_p) - 1u; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = k_p[i];
+    }
+    n = e->p; ni = 0;
+    if (n == 0) num[ni++] = '0';
+    while (n > 0 && ni < 8) { num[ni++] = '0' + (n % 10); n /= 10; }
+    while (ni > 0) { if (pos >= cap) return 0; out[pos++] = num[--ni]; }
+
+    if (pos >= cap) return 0;
+    out[pos++] = '$';
+    for (size_t i = 0; i < sl; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = salt_b64[i];
+    }
+    if (pos >= cap) return 0;
+    out[pos++] = '$';
+    for (size_t i = 0; i < hl; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = hash_b64[i];
+    }
+
+    static const char k_suffix[] = ":0:/\n";
+    for (size_t i = 0; i < sizeof(k_suffix) - 1u; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = k_suffix[i];
+    }
+    return pos;
+}
+
+/* ---------------------------------------------------------------- */
+/* scrypt wrapper                                                    */
+/* ---------------------------------------------------------------- */
+
+static int derive_hash(const char *password,
+                       const uint8_t salt[PASSWD_SALT_LEN],
+                       int log2_n, int r, int p,
+                       uint8_t out[PASSWD_HASH_LEN])
+{
+    if (log2_n <= 0 || log2_n > 20) return PASSWD_E_KDF;
+    int rc = wc_scrypt(out,
+                       (const uint8_t *)password,
+                       (int)strlen(password),
+                       salt, (int)PASSWD_SALT_LEN,
+                       log2_n, r, p,
+                       (int)PASSWD_HASH_LEN);
+    return (rc == 0) ? PASSWD_OK : PASSWD_E_KDF;
+}
+
+static int constant_time_compare(const uint8_t *a, const uint8_t *b, size_t n)
+{
+    uint8_t diff = 0;
+    for (size_t i = 0; i < n; i++) diff |= (a[i] ^ b[i]);
+    return (diff == 0) ? 0 : 1;
+}
+
+/* ---------------------------------------------------------------- */
+/* File-level operations                                             */
+/* ---------------------------------------------------------------- */
+
+/*
+ * Walk every line in the file buffer. For each line invokes `cb`
+ * which may return non-zero to stop iteration. Returns the number
+ * of entries successfully parsed.
+ */
+static int for_each_entry(char *buf, size_t len,
+                          int (*cb)(const struct passwd_entry *e,
+                                    char *raw_line, void *ctx),
+                          void *ctx)
+{
+    size_t i = 0;
+    int    count = 0;
+    while (i < len) {
+        size_t start = i;
+        while (i < len && buf[i] != '\n' && buf[i] != '\0') i++;
+        size_t end = i;
+        if (i < len) {
+            buf[i++] = '\0';
+        }
+        char *line = buf + start;
+        if (end == start) continue;   /* empty line */
+        if (line[0] == '#') continue; /* comment */
+
+        struct passwd_entry e;
+        if (parse_line(line, &e) != PASSWD_OK) continue;
+        if (cb && cb(&e, line, ctx) != 0) return count + 1;
+        count++;
+    }
+    return count;
+}
+
+struct find_ctx { const char *username; struct passwd_entry *out; int found; };
+
+static int find_cb(const struct passwd_entry *e, char *raw_line, void *ctx)
+{
+    struct find_ctx *fc = (struct find_ctx *)ctx;
+    (void)raw_line;
+    if (strcmp(e->username, fc->username) == 0) {
+        *fc->out = *e;
+        fc->found = 1;
+        return 1;   /* stop */
+    }
+    return 0;
+}
+
+/* ---------------------------------------------------------------- */
+/* Public API                                                        */
+/* ---------------------------------------------------------------- */
+
+bool passwd_any_users(void)
+{
+    struct lfs_mount *mnt = resolve_mount();
+    if (!mnt) return false;
+
+    static char buf[PASSWD_FILE_MAX_BYTES];
+    int n = read_file_all(mnt, buf, sizeof(buf));
+    if (n <= 0) return false;
+
+    /* Any non-comment, non-blank line counts. */
+    int users = for_each_entry(buf, (size_t)n, NULL, NULL);
+    return users > 0;
+}
+
+int passwd_verify(const char *username, const char *password)
+{
+    if (!username || !password) return PASSWD_E_BAD_ARG;
+
+    struct lfs_mount *mnt = resolve_mount();
+    if (!mnt) return PASSWD_E_IO;
+
+    static char buf[PASSWD_FILE_MAX_BYTES];
+    int n = read_file_all(mnt, buf, sizeof(buf));
+    if (n <= 0) return PASSWD_E_NOT_FOUND;
+
+    struct passwd_entry entry;
+    struct find_ctx fc = { .username = username, .out = &entry, .found = 0 };
+    for_each_entry(buf, (size_t)n, find_cb, &fc);
+    if (!fc.found) return PASSWD_E_NOT_FOUND;
+
+    uint8_t derived[PASSWD_HASH_LEN];
+    int rc = derive_hash(password, entry.salt,
+                         entry.log2_n, entry.r, entry.p, derived);
+    if (rc != PASSWD_OK) return rc;
+    int match = constant_time_compare(derived, entry.hash, PASSWD_HASH_LEN);
+    /* Wipe the derived hash from the stack. */
+    for (size_t i = 0; i < PASSWD_HASH_LEN; i++) derived[i] = 0u;
+    return (match == 0) ? PASSWD_OK : PASSWD_E_WRONG;
+}
+
+/* Rebuild the file with one entry replaced / added / removed. The
+ * `mode` controls semantics:
+ *   MODE_SET: replace if username present, else append.
+ *   MODE_ADD: refuse if username present, else append.
+ *   MODE_DEL: remove if present; refuse if it's the last user.
+ */
+enum modify_mode { MODE_SET, MODE_ADD, MODE_DEL };
+
+struct rebuild_ctx {
+    const char *target;
+    const struct passwd_entry *new_entry;
+    enum modify_mode mode;
+    char  *out_buf;
+    size_t out_cap;
+    size_t out_pos;
+    int    replaced;
+    int    kept;
+    int    skipped;
+};
+
+static int rebuild_cb(const struct passwd_entry *e, char *raw_line, void *ctx)
+{
+    (void)raw_line;
+    struct rebuild_ctx *rc = (struct rebuild_ctx *)ctx;
+
+    if (strcmp(e->username, rc->target) == 0) {
+        rc->skipped++;
+        if (rc->mode == MODE_DEL) {
+            return 0;   /* drop this line */
+        }
+        /* SET or ADD: replace with new_entry. */
+        if (rc->mode == MODE_ADD) {
+            /* Caller should have detected the collision before
+             * reaching here; treat as no-op (preserve existing). */
+            size_t w = format_line(e, rc->out_buf + rc->out_pos,
+                                   rc->out_cap - rc->out_pos);
+            if (w == 0u) return 1;
+            rc->out_pos += w;
+            rc->kept++;
+        } else {
+            size_t w = format_line(rc->new_entry, rc->out_buf + rc->out_pos,
+                                   rc->out_cap - rc->out_pos);
+            if (w == 0u) return 1;
+            rc->out_pos += w;
+            rc->replaced = 1;
+        }
+        return 0;
+    }
+
+    size_t w = format_line(e, rc->out_buf + rc->out_pos,
+                           rc->out_cap - rc->out_pos);
+    if (w == 0u) return 1;
+    rc->out_pos += w;
+    rc->kept++;
+    return 0;
+}
+
+static int rebuild_and_persist(const char *target,
+                               const struct passwd_entry *new_entry,
+                               enum modify_mode mode)
+{
+    struct lfs_mount *mnt = resolve_mount();
+    if (!mnt) return PASSWD_E_IO;
+
+    static char in_buf[PASSWD_FILE_MAX_BYTES];
+    static char out_buf[PASSWD_FILE_MAX_BYTES];
+    int n = read_file_all(mnt, in_buf, sizeof(in_buf));
+    if (n < 0) n = 0;
+
+    struct rebuild_ctx rc = {
+        .target    = target,
+        .new_entry = new_entry,
+        .mode      = mode,
+        .out_buf   = out_buf,
+        .out_cap   = sizeof(out_buf),
+        .out_pos   = 0,
+        .replaced  = 0,
+        .kept      = 0,
+        .skipped   = 0,
+    };
+    for_each_entry(in_buf, (size_t)n, rebuild_cb, &rc);
+
+    /* Append for ADD/SET when the target wasn't present. */
+    if ((mode == MODE_ADD || mode == MODE_SET) && !rc.replaced && rc.skipped == 0) {
+        size_t w = format_line(new_entry, out_buf + rc.out_pos,
+                               sizeof(out_buf) - rc.out_pos);
+        if (w == 0u) return PASSWD_E_FULL;
+        rc.out_pos += w;
+    }
+
+    if (mode == MODE_DEL) {
+        if (rc.skipped == 0)   return PASSWD_E_NOT_FOUND;
+        if (rc.kept    == 0)   return PASSWD_E_LAST_USER;
+    }
+    if (mode == MODE_ADD && rc.replaced == 0 && rc.skipped > 0) {
+        return PASSWD_E_EXISTS;
+    }
+
+    if (write_file_atomic(mnt, out_buf, rc.out_pos) != 0) return PASSWD_E_IO;
+    return PASSWD_OK;
+}
+
+int passwd_adduser(const char *username, const char *password)
+{
+    if (!username || !password) return PASSWD_E_BAD_ARG;
+    if (strlen(username) > PASSWD_MAX_USERNAME_LEN) return PASSWD_E_BAD_ARG;
+    if (strlen(password) > PASSWD_MAX_PASSWORD_LEN) return PASSWD_E_BAD_ARG;
+
+    struct passwd_entry e;
+    for (size_t i = 0; i <= strlen(username); i++) e.username[i] = username[i];
+    if (rng_get_bytes(e.salt, PASSWD_SALT_LEN) != 0) return PASSWD_E_KDF;
+    e.log2_n = PASSWD_SCRYPT_LOG2_N;
+    e.r      = PASSWD_SCRYPT_R;
+    e.p      = PASSWD_SCRYPT_P;
+    int rc = derive_hash(password, e.salt, e.log2_n, e.r, e.p, e.hash);
+    if (rc != PASSWD_OK) return rc;
+
+    return rebuild_and_persist(username, &e, MODE_ADD);
+}
+
+int passwd_set(const char *username, const char *new_password)
+{
+    if (!username || !new_password) return PASSWD_E_BAD_ARG;
+
+    struct passwd_entry e;
+    for (size_t i = 0; i <= strlen(username); i++) e.username[i] = username[i];
+    if (rng_get_bytes(e.salt, PASSWD_SALT_LEN) != 0) return PASSWD_E_KDF;
+    e.log2_n = PASSWD_SCRYPT_LOG2_N;
+    e.r      = PASSWD_SCRYPT_R;
+    e.p      = PASSWD_SCRYPT_P;
+    int rc = derive_hash(new_password, e.salt, e.log2_n, e.r, e.p, e.hash);
+    if (rc != PASSWD_OK) return rc;
+
+    return rebuild_and_persist(username, &e, MODE_SET);
+}
+
+int passwd_deluser(const char *username)
+{
+    if (!username) return PASSWD_E_BAD_ARG;
+    return rebuild_and_persist(username, NULL, MODE_DEL);
+}

--- a/kernel/net/ssh/passwd.c
+++ b/kernel/net/ssh/passwd.c
@@ -182,7 +182,7 @@ static int parse_line(char *line, struct passwd_entry *out)
 
     size_t un_len = strlen(line);
     if (un_len == 0u || un_len > PASSWD_MAX_USERNAME_LEN) return PASSWD_E_FORMAT;
-    for (size_t i = 0; i <= un_len; i++) out->username[i] = line[i];
+    memcpy(out->username, line, un_len + 1u);
 
     /* p1 now points at "$scrypt$N=N,r=R,p=P$<salt>$<hash>". */
     if (strncmp(p1, "$scrypt$", 8) != 0) return PASSWD_E_FORMAT;
@@ -225,7 +225,9 @@ static int parse_line(char *line, struct passwd_entry *out)
     /* Hash — base64-decode up to the next ':' or '\0'. */
     p1 = salt_end + 1;
     char *hash_end = p1;
-    while (*hash_end && *hash_end != ':' && *hash_end != '\n') hash_end++;
+    while (*hash_end && *hash_end != ':' && *hash_end != '\n') {
+        hash_end++;
+    }
     size_t hlen = b64_decode(p1, (size_t)(hash_end - p1),
                              out->hash, PASSWD_HASH_LEN);
     if (hlen != PASSWD_HASH_LEN) return PASSWD_E_FORMAT;
@@ -312,7 +314,12 @@ static int derive_hash(const char *password,
                        int log2_n, int r, int p,
                        uint8_t out[PASSWD_HASH_LEN])
 {
-    if (log2_n <= 0 || log2_n > 20) return PASSWD_E_KDF;
+    /* Cap at our configured floor — a stored entry that claims a
+     * higher log2_n than we ever produce is either corruption or an
+     * import from foreign tooling we don't support. wc_scrypt would
+     * fail allocation long before log2_n > 20 (~1 GB) on any SLM-OS
+     * platform anyway. */
+    if (log2_n <= 0 || log2_n > PASSWD_SCRYPT_LOG2_N) return PASSWD_E_KDF;
     int rc = wc_scrypt(out,
                        (const uint8_t *)password,
                        (int)strlen(password),
@@ -325,7 +332,9 @@ static int derive_hash(const char *password,
 static int constant_time_compare(const uint8_t *a, const uint8_t *b, size_t n)
 {
     uint8_t diff = 0;
-    for (size_t i = 0; i < n; i++) diff |= (a[i] ^ b[i]);
+    for (size_t i = 0; i < n; i++) {
+        diff |= (a[i] ^ b[i]);
+    }
     return (diff == 0) ? 0 : 1;
 }
 
@@ -347,7 +356,9 @@ static int for_each_entry(char *buf, size_t len,
     int    count = 0;
     while (i < len) {
         size_t start = i;
-        while (i < len && buf[i] != '\n' && buf[i] != '\0') i++;
+        while (i < len && buf[i] != '\n' && buf[i] != '\0') {
+            i++;
+        }
         size_t end = i;
         if (i < len) {
             buf[i++] = '\0';
@@ -357,7 +368,14 @@ static int for_each_entry(char *buf, size_t len,
         if (line[0] == '#') continue; /* comment */
 
         struct passwd_entry e;
-        if (parse_line(line, &e) != PASSWD_OK) continue;
+        if (parse_line(line, &e) != PASSWD_OK) {
+            /* Surface corruption (truncated write, manual edit gone
+             * wrong) so the operator sees the cause instead of just
+             * a generic "user not found" downstream. */
+            uart_printf("[passwd] WARN: skipping malformed line: %s\r\n",
+                        line);
+            continue;
+        }
         if (cb && cb(&e, line, ctx) != 0) return count + 1;
         count++;
     }
@@ -387,7 +405,11 @@ bool passwd_any_users(void)
     struct lfs_mount *mnt = resolve_mount();
     if (!mnt) return false;
 
-    static char buf[PASSWD_FILE_MAX_BYTES];
+    /* Stack-local: the buffer is 2.3 KB on a 256 KB task stack. Was
+     * `static` — that raced under concurrent SSH auth attempts since
+     * passwd_verify ran on per-connection session tasks and shared
+     * the same buffer with this function. */
+    char buf[PASSWD_FILE_MAX_BYTES];
     int n = read_file_all(mnt, buf, sizeof(buf));
     if (n <= 0) return false;
 
@@ -403,7 +425,8 @@ int passwd_verify(const char *username, const char *password)
     struct lfs_mount *mnt = resolve_mount();
     if (!mnt) return PASSWD_E_IO;
 
-    static char buf[PASSWD_FILE_MAX_BYTES];
+    /* Stack-local — was `static` and raced across session tasks. */
+    char buf[PASSWD_FILE_MAX_BYTES];
     int n = read_file_all(mnt, buf, sizeof(buf));
     if (n <= 0) return PASSWD_E_NOT_FOUND;
 
@@ -417,8 +440,9 @@ int passwd_verify(const char *username, const char *password)
                          entry.log2_n, entry.r, entry.p, derived);
     if (rc != PASSWD_OK) return rc;
     int match = constant_time_compare(derived, entry.hash, PASSWD_HASH_LEN);
-    /* Wipe the derived hash from the stack. */
-    for (size_t i = 0; i < PASSWD_HASH_LEN; i++) derived[i] = 0u;
+    /* Wipe the derived hash from the stack — secure_zero defeats the
+     * dead-store elimination the optimiser otherwise applies. */
+    secure_zero(derived, sizeof(derived));
     return (match == 0) ? PASSWD_OK : PASSWD_E_WRONG;
 }
 
@@ -486,8 +510,11 @@ static int rebuild_and_persist(const char *target,
     struct lfs_mount *mnt = resolve_mount();
     if (!mnt) return PASSWD_E_IO;
 
-    static char in_buf[PASSWD_FILE_MAX_BYTES];
-    static char out_buf[PASSWD_FILE_MAX_BYTES];
+    /* Stack-local — see passwd_verify comment for the rationale. The
+     * 4.6 KB combined budget (two PASSWD_FILE_MAX_BYTES buffers) is
+     * comfortable on a 256 KB task stack. */
+    char in_buf[PASSWD_FILE_MAX_BYTES];
+    char out_buf[PASSWD_FILE_MAX_BYTES];
     int n = read_file_all(mnt, in_buf, sizeof(in_buf));
     if (n < 0) n = 0;
 
@@ -527,11 +554,12 @@ static int rebuild_and_persist(const char *target,
 int passwd_adduser(const char *username, const char *password)
 {
     if (!username || !password) return PASSWD_E_BAD_ARG;
-    if (strlen(username) > PASSWD_MAX_USERNAME_LEN) return PASSWD_E_BAD_ARG;
+    size_t un_len = strlen(username);
+    if (un_len > PASSWD_MAX_USERNAME_LEN) return PASSWD_E_BAD_ARG;
     if (strlen(password) > PASSWD_MAX_PASSWORD_LEN) return PASSWD_E_BAD_ARG;
 
     struct passwd_entry e;
-    for (size_t i = 0; i <= strlen(username); i++) e.username[i] = username[i];
+    memcpy(e.username, username, un_len + 1u);
     if (rng_get_bytes(e.salt, PASSWD_SALT_LEN) != 0) return PASSWD_E_KDF;
     e.log2_n = PASSWD_SCRYPT_LOG2_N;
     e.r      = PASSWD_SCRYPT_R;
@@ -545,9 +573,17 @@ int passwd_adduser(const char *username, const char *password)
 int passwd_set(const char *username, const char *new_password)
 {
     if (!username || !new_password) return PASSWD_E_BAD_ARG;
+    /* Same bounds as passwd_adduser — without these `cmd_passwd` would
+     * let a long argv overflow `e.username[33]` and corrupt kernel
+     * stack. Reachable from any authenticated shell user (SSH /
+     * console / telnet). */
+    size_t un_len = strlen(username);
+    size_t pw_len = strlen(new_password);
+    if (un_len > PASSWD_MAX_USERNAME_LEN) return PASSWD_E_BAD_ARG;
+    if (pw_len > PASSWD_MAX_PASSWORD_LEN) return PASSWD_E_BAD_ARG;
 
     struct passwd_entry e;
-    for (size_t i = 0; i <= strlen(username); i++) e.username[i] = username[i];
+    memcpy(e.username, username, un_len + 1u);
     if (rng_get_bytes(e.salt, PASSWD_SALT_LEN) != 0) return PASSWD_E_KDF;
     e.log2_n = PASSWD_SCRYPT_LOG2_N;
     e.r      = PASSWD_SCRYPT_R;

--- a/kernel/net/ssh/passwd.c
+++ b/kernel/net/ssh/passwd.c
@@ -326,7 +326,16 @@ static int derive_hash(const char *password,
                        salt, (int)PASSWD_SALT_LEN,
                        log2_n, r, p,
                        (int)PASSWD_HASH_LEN);
-    return (rc == 0) ? PASSWD_OK : PASSWD_E_KDF;
+    if (rc != 0) {
+        /* Log the wolfcrypt error code (e.g. -125 MEMORY_E, -173
+         * BAD_FUNC_ARG) so operators can tell scrypt-failed-due-to-
+         * heap-exhaustion apart from scrypt-failed-due-to-bad-args
+         * without rebuilding. */
+        uart_printf("[PASSWD] wc_scrypt failed: rc=%d (log2_n=%d r=%d p=%d)\r\n",
+                    rc, log2_n, r, p);
+        return PASSWD_E_KDF;
+    }
+    return PASSWD_OK;
 }
 
 static int constant_time_compare(const uint8_t *a, const uint8_t *b, size_t n)

--- a/kernel/net/ssh/passwd.h
+++ b/kernel/net/ssh/passwd.h
@@ -1,0 +1,80 @@
+/*
+ * passwd.h - User database + password verification for SSH.
+ *
+ * Backed by /mnt/files/etc/passwd with one line per user. PHC-style
+ * KDF-encoded password field:
+ *
+ *     username:$scrypt$N=2^N,r=8,p=1$<salt-b64>$<hash-b64>:uid:home
+ *
+ * Read on every SSH auth attempt — small file (≤ MAX_PASSWD_USERS
+ * users), well-cached at the littlefs layer; the per-auth cost is
+ * dominated by the KDF compute (intentional: makes offline guessing
+ * expensive).
+ *
+ * **scrypt parameters** start at N=2^15 (32 MB), r=8, p=1 — the floor
+ * documented in RFC 7914 and OWASP password-storage cheat sheet's
+ * "second recommendation". Kept in `kernel/include/config.h` so a
+ * platform with tighter RAM can lower N to 2^14 (16 MB) at build time
+ * without touching this file's defaults.
+ *
+ * **Bootstrap gate.** Until at least one user exists (passwd file
+ * absent or empty), SSH auth refuses every attempt with an explicit
+ * "no users provisioned — run `passwd root` on the console" message.
+ * Console (UART) sessions bypass the gate because that's the only
+ * way to bootstrap.
+ */
+
+#ifndef SLMOS_SSH_PASSWD_H
+#define SLMOS_SSH_PASSWD_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define PASSWD_MAX_USERNAME_LEN  32u
+#define PASSWD_MAX_PASSWORD_LEN  128u
+#define PASSWD_SALT_LEN          16u
+#define PASSWD_HASH_LEN          32u
+
+/* scrypt cost parameters — see comment block at top for derivation. */
+#define PASSWD_SCRYPT_LOG2_N     15  /* N = 2^15 = 32768  ~= 32 MB */
+#define PASSWD_SCRYPT_R          8
+#define PASSWD_SCRYPT_P          1
+
+enum passwd_result {
+    PASSWD_OK              = 0,
+    PASSWD_E_BAD_ARG       = -1,
+    PASSWD_E_NOT_FOUND     = -2,
+    PASSWD_E_WRONG         = -3,    /* password mismatch */
+    PASSWD_E_IO            = -4,    /* VFS read/write failed */
+    PASSWD_E_FULL          = -5,    /* MAX_PASSWD_USERS reached */
+    PASSWD_E_EXISTS        = -6,    /* adduser of existing name */
+    PASSWD_E_LAST_USER     = -7,    /* deluser of the only remaining user */
+    PASSWD_E_FORMAT        = -8,    /* malformed passwd line */
+    PASSWD_E_KDF           = -9,    /* scrypt failure */
+};
+
+/* True iff at least one user is provisioned in /mnt/files/etc/passwd.
+ * Used by the SSH auth callback to enforce the bootstrap gate. */
+bool passwd_any_users(void);
+
+/* Verify `password` against the stored hash for `username`. Returns
+ * PASSWD_OK on a constant-time match, PASSWD_E_WRONG on mismatch,
+ * PASSWD_E_NOT_FOUND if the user doesn't exist. */
+int passwd_verify(const char *username, const char *password);
+
+/* Add a user with the given password. Generates a random salt via
+ * `rng_get_bytes` and stores the scrypt hash. Returns PASSWD_OK or a
+ * negative error. */
+int passwd_adduser(const char *username, const char *password);
+
+/* Change an existing user's password. The caller may verify the
+ * current password first (passwd_verify) — this function only writes
+ * the new hash. */
+int passwd_set(const char *username, const char *new_password);
+
+/* Remove a user. Refuses to remove the last remaining user
+ * (PASSWD_E_LAST_USER) so the daemon can't lock the operator out. */
+int passwd_deluser(const char *username);
+
+#endif /* SLMOS_SSH_PASSWD_H */

--- a/kernel/net/ssh/passwd.h
+++ b/kernel/net/ssh/passwd.h
@@ -36,7 +36,11 @@
 #define PASSWD_SALT_LEN          16u
 #define PASSWD_HASH_LEN          32u
 
-/* scrypt cost parameters — see comment block at top for derivation. */
+/* scrypt cost parameters — RFC 7914 floor / OWASP "second
+ * recommendation". Backed by the dedicated 48 MB wolfssl heap in
+ * `kernel/net/ssh/wolf_heap.c`; XMALLOC there routes through a
+ * pool sized to satisfy the 32 MB working buffer this cost
+ * requires. */
 #define PASSWD_SCRYPT_LOG2_N     15  /* N = 2^15 = 32768  ~= 32 MB */
 #define PASSWD_SCRYPT_R          8
 #define PASSWD_SCRYPT_P          1

--- a/kernel/net/ssh/passwd.h
+++ b/kernel/net/ssh/passwd.h
@@ -55,7 +55,9 @@ enum passwd_result {
     PASSWD_E_EXISTS        = -6,    /* adduser of existing name */
     PASSWD_E_LAST_USER     = -7,    /* deluser of the only remaining user */
     PASSWD_E_FORMAT        = -8,    /* malformed passwd line */
-    PASSWD_E_KDF           = -9,    /* scrypt failure */
+    PASSWD_E_KDF           = -9,    /* scrypt computation failure */
+    PASSWD_E_COST          = -10,   /* stored entry's cost factor exceeds
+                                       what this build supports */
 };
 
 /* True iff at least one user is provisioned in /mnt/files/etc/passwd.

--- a/kernel/net/ssh/passwd_shell.c
+++ b/kernel/net/ssh/passwd_shell.c
@@ -39,6 +39,7 @@ static const char *result_str(int rc)
     case PASSWD_E_LAST_USER:  return "refusing to remove last user";
     case PASSWD_E_FORMAT:     return "passwd file format error";
     case PASSWD_E_KDF:        return "kdf failure";
+    case PASSWD_E_COST:       return "passwd entry cost factor too high (corrupt /etc/passwd?)";
     default:                  return "unknown";
     }
 }

--- a/kernel/net/ssh/passwd_shell.c
+++ b/kernel/net/ssh/passwd_shell.c
@@ -54,6 +54,15 @@ int cmd_adduser(int argc, char **argv)
     return rc;
 }
 
+/*
+ * No privilege model: any authenticated shell user can change any
+ * other user's password. The whoami / per-session-identity plumbing
+ * lands later in the phase (cited in the file header), and the
+ * "only the current user OR an admin can call passwd" gate goes on
+ * top of that. Until then, treat the shell as a single trust domain
+ * — appropriate for SLM-OS's threat model where reaching the shell
+ * already implies physical or authenticated access.
+ */
 int cmd_passwd(int argc, char **argv)
 {
     if (argc < 3) {

--- a/kernel/net/ssh/passwd_shell.c
+++ b/kernel/net/ssh/passwd_shell.c
@@ -1,0 +1,103 @@
+/*
+ * passwd_shell.c - `adduser` / `passwd` / `deluser` / `whoami`.
+ *
+ * Minimal interactive surface for #199d (#896). For this iteration
+ * the password is passed on the command line:
+ *
+ *   adduser <name> <password>
+ *   passwd  <name> <new-password>
+ *   deluser <name>
+ *   whoami
+ *
+ * That's a deliberate simplification — proper no-echo prompting
+ * requires shell_io changes (#199e candidate) that don't belong in
+ * the auth-correctness sub-ticket. Operators on the console see
+ * what they type; on SSH (#199c) the line is encrypted in transit
+ * but visible in the local terminal history.
+ */
+
+#include "passwd.h"
+#include "shell.h"
+#include "shell_internal.h"
+#include "shell_session.h"
+#include "string.h"
+#include "uart.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+static const char *result_str(int rc)
+{
+    switch (rc) {
+    case PASSWD_OK:           return "ok";
+    case PASSWD_E_BAD_ARG:    return "bad argument";
+    case PASSWD_E_NOT_FOUND:  return "user not found";
+    case PASSWD_E_WRONG:      return "wrong password";
+    case PASSWD_E_IO:         return "io error (no /mnt/files mount?)";
+    case PASSWD_E_FULL:       return "user table full";
+    case PASSWD_E_EXISTS:     return "user already exists";
+    case PASSWD_E_LAST_USER:  return "refusing to remove last user";
+    case PASSWD_E_FORMAT:     return "passwd file format error";
+    case PASSWD_E_KDF:        return "kdf failure";
+    default:                  return "unknown";
+    }
+}
+
+int cmd_adduser(int argc, char **argv)
+{
+    if (argc < 3) {
+        uart_printf("usage: adduser <name> <password>\r\n");
+        return -1;
+    }
+    int rc = passwd_adduser(argv[1], argv[2]);
+    uart_printf("adduser %s: %s\r\n", argv[1], result_str(rc));
+    return rc;
+}
+
+int cmd_passwd(int argc, char **argv)
+{
+    if (argc < 3) {
+        uart_printf("usage: passwd <name> <new-password>\r\n");
+        return -1;
+    }
+    int rc = passwd_set(argv[1], argv[2]);
+    uart_printf("passwd %s: %s\r\n", argv[1], result_str(rc));
+    return rc;
+}
+
+int cmd_deluser(int argc, char **argv)
+{
+    if (argc < 2) {
+        uart_printf("usage: deluser <name>\r\n");
+        return -1;
+    }
+    int rc = passwd_deluser(argv[1]);
+    uart_printf("deluser %s: %s\r\n", argv[1], result_str(rc));
+    return rc;
+}
+
+/*
+ * `whoami` returns the SSH-authenticated user when running inside an
+ * SSH session, or "console" on the UART. shell_session today doesn't
+ * carry the authenticated identity — #199d wires the SSH callback to
+ * stash it into `shell_session.auth_user` (a new field added in this
+ * patch) and falls back to "console" otherwise.
+ *
+ * For this initial commit, we only have the console-path semantics —
+ * SSH sessions also report "console" until the per-session identity
+ * plumbing lands. Documenting up-front: the bootstrap gate works
+ * (passwd_any_users) but the user-identity carry-through is partial.
+ */
+int cmd_whoami(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    struct shell_session *s = shell_session_current();
+    if (s && s->id == 0u) {
+        uart_printf("console\r\n");
+    } else if (s) {
+        uart_printf("ssh\r\n");   /* placeholder until #199d-2 plumbs identity */
+    } else {
+        uart_printf("?\r\n");
+    }
+    return 0;
+}

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -168,10 +168,10 @@ static int sshd_userauth_passwd(uint8_t auth_type,
 
     char username[PASSWD_MAX_USERNAME_LEN + 1u];
     char password[PASSWD_MAX_PASSWORD_LEN + 1u];
-    for (uint32_t i = 0; i < data->usernameSz; i++) username[i] = (char)data->username[i];
+    /* Lengths are already bounded by the early-return checks above. */
+    memcpy(username, data->username, data->usernameSz);
     username[data->usernameSz] = '\0';
-    for (uint32_t i = 0; i < data->sf.password.passwordSz; i++)
-        password[i] = (char)data->sf.password.password[i];
+    memcpy(password, data->sf.password.password, data->sf.password.passwordSz);
     password[data->sf.password.passwordSz] = '\0';
 
     int rc = passwd_verify(username, password);

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -108,28 +108,83 @@ static volatile uint32_t   g_active;
 /* User authentication callback                                      */
 /* ---------------------------------------------------------------- */
 
+#include "passwd.h"
+
 /*
- * #199c demo stub: accept any user-auth attempt so `ssh root@<ip>`
- * reaches a shell prompt. Gated behind NET_SSHD_DEMO_ALLOW_ALL (set
- * by CMake; defaults to ON during the #199c lifetime) so #199d's
- * removal of the stub is a one-line `option(... OFF)` flip with no
- * source diff in this file.
+ * Two user-auth callbacks live side-by-side, selected at compile time
+ * by `NET_SSHD_DEMO_ALLOW_ALL`:
  *
- * The autostart banner (sshd_autostart.c) prints a WARNING on every
- * boot while this stub is wired, and `NET_SSHD_AUTOSTART` stays OFF
- * until #199e so operators must explicitly `sshd start` to expose an
- * allow-all daemon during the #199c → #199d window. */
+ *   ON  → `sshd_userauth_allow_all` accepts every login; matches the
+ *         #199c demo path. `sshd_autostart` prints a loud WARNING on
+ *         every boot while this is wired.
+ *
+ *   OFF → `sshd_userauth_passwd` verifies (username, password) against
+ *         `/mnt/files/etc/passwd` via the scrypt-based `passwd_verify`
+ *         from #199d. Bootstrap gate: until `passwd_any_users()`
+ *         returns true (operator has run `passwd <name> <pw>` on the
+ *         console at least once), every auth attempt fails with the
+ *         standard FAILURE response. Peer sees "Permission denied
+ *         (password)." — uninformative to an attacker, operator
+ *         diagnoses from the boot banner.
+ *
+ * Rate limiting + per-IP backoff are deferred to #199e. Public-key
+ * auth is out of scope per #199's non-goals.
+ *
+ * The CMake default for `NET_SSHD_DEMO_ALLOW_ALL` flipped from ON to
+ * OFF in this PR so real auth is the default once #199d landed; an
+ * operator who wants the demo bypass can rebuild with
+ * `-DNET_SSHD_DEMO_ALLOW_ALL=ON`.
+ */
 #if defined(NET_SSHD_DEMO_ALLOW_ALL) && NET_SSHD_DEMO_ALLOW_ALL
 static int sshd_userauth_allow_all(uint8_t auth_type,
                                    WS_UserAuthData *data,
                                    void *ctx)
+#else
+static int sshd_userauth_passwd(uint8_t auth_type,
+                                WS_UserAuthData *data,
+                                void *ctx)
+#endif
 {
+#if defined(NET_SSHD_DEMO_ALLOW_ALL) && NET_SSHD_DEMO_ALLOW_ALL
     (void)auth_type;
     (void)data;
     (void)ctx;
     return WOLFSSH_USERAUTH_SUCCESS;
-}
+#else
+    (void)ctx;
+    if (!passwd_any_users()) {
+        return WOLFSSH_USERAUTH_FAILURE;
+    }
+    if (auth_type != WOLFSSH_USERAUTH_PASSWORD || data == NULL) {
+        return WOLFSSH_USERAUTH_FAILURE;
+    }
+    if (data->usernameSz == 0u || data->usernameSz > PASSWD_MAX_USERNAME_LEN) {
+        return WOLFSSH_USERAUTH_FAILURE;
+    }
+    if (data->sf.password.passwordSz == 0u ||
+        data->sf.password.passwordSz > PASSWD_MAX_PASSWORD_LEN) {
+        return WOLFSSH_USERAUTH_FAILURE;
+    }
+
+    char username[PASSWD_MAX_USERNAME_LEN + 1u];
+    char password[PASSWD_MAX_PASSWORD_LEN + 1u];
+    for (uint32_t i = 0; i < data->usernameSz; i++) username[i] = (char)data->username[i];
+    username[data->usernameSz] = '\0';
+    for (uint32_t i = 0; i < data->sf.password.passwordSz; i++)
+        password[i] = (char)data->sf.password.password[i];
+    password[data->sf.password.passwordSz] = '\0';
+
+    int rc = passwd_verify(username, password);
+
+    /* Wipe the plaintext password from the stack before returning.
+     * secure_zero is the standard helper (kernel/include/string.h)
+     * — defeats dead-store-elim on the stack copy. */
+    secure_zero(password, sizeof(password));
+
+    return (rc == PASSWD_OK) ? WOLFSSH_USERAUTH_SUCCESS
+                             : WOLFSSH_USERAUTH_FAILURE;
 #endif
+}
 
 /* ---------------------------------------------------------------- */
 /* Host key — VFS-persisted via kernel/net/ssh/host_key.c            */
@@ -580,6 +635,8 @@ int sshd_start(uint16_t port)
         wolfSSH_SetIOSend(g_ctx, wolf_io_send);
 #if defined(NET_SSHD_DEMO_ALLOW_ALL) && NET_SSHD_DEMO_ALLOW_ALL
         wolfSSH_SetUserAuth(g_ctx, sshd_userauth_allow_all);
+#else
+        wolfSSH_SetUserAuth(g_ctx, sshd_userauth_passwd);
 #endif
 
         /* Convert the SLM-OS-native (seed || pub) layout into the

--- a/kernel/net/ssh/wolf_heap.c
+++ b/kernel/net/ssh/wolf_heap.c
@@ -1,0 +1,206 @@
+/*
+ * wolf_heap.c - Dedicated byte-level heap for vendored wolfSSL +
+ * wolfSSH.
+ *
+ * Why a separate heap and not the shared `lua_stubs.c` allocator:
+ * scrypt at the OWASP / RFC 7914 floor (N=2^15, r=8, p=1) needs a
+ * single 32 MB working buffer per derivation. The lua_stubs heap is
+ * 1 MB total — wolfssl's XMALLOC redirected there returns
+ * MEMORY_E (-125) and `adduser` / `passwd_set` / `passwd_verify`
+ * all fail. Discovered on pi-5-2 during the #199e hardware
+ * validation (see PR #918 thread).
+ *
+ * Dedicating a 48 MB BSS pool to wolfssl gives scrypt its working
+ * buffer plus headroom for the smaller per-handshake KEX + cipher
+ * + hash + hmac state. Gated on `NET_SSHD` so the kernel image
+ * doesn't consume the RAM when the SSH daemon is compiled out.
+ *
+ * The freelist allocator below is a literal port of the design in
+ * `kernel/src/lua_stubs.c::malloc/free` — same magic-stamp header,
+ * same forward/back merge on free. The implementation is duplicated
+ * rather than refactored because:
+ *   1. Sharing would require either re-sizing the lua_stubs pool
+ *      (affects every platform's BSS footprint) or refactoring
+ *      lua_stubs into a generic allocator the rest of the kernel
+ *      reuses (out of scope for #199e).
+ *   2. Per-subsystem heap isolation prevents wolfssl fragmentation
+ *      from starving Lua and vice versa.
+ *
+ * Concurrency: one spinlock around alloc/free, IRQ-disabled. All
+ * SSH-side callers run from task context (the sshd session task
+ * during accept / shell, the console shell for adduser/passwd), so
+ * the IRQ-disable interval is short relative to scrypt's compute
+ * dominance.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pmm.h"
+#include "spinlock.h"
+#include "uart.h"
+
+/* Sized for scrypt at PASSWD_SCRYPT_LOG2_N=15: 32 MB working
+ * buffer + ~16 MB headroom for wolfSSH session state. Allocated
+ * lazily from PMM on first use so an `NET_SSHD=ON` build that
+ * never calls into wolfssl (e.g. operator never runs `sshd start`
+ * + `adduser`) doesn't consume the RAM, and so the kernel image
+ * stays under the platform linker caps.
+ *
+ * 48 MB ÷ 4 KB = 12288 pages. That's order=14 in the buddy
+ * allocator. Pi 5 / Jetson / x86-64 all have GB-scale PMM
+ * regions; QEMU's 1 GB build has ~700 MB of usable PMM after
+ * model memory, comfortably accommodating the request. */
+#define WOLF_HEAP_SIZE   (48u * 1024u * 1024u)
+#define WOLF_HEAP_PAGES  (WOLF_HEAP_SIZE / 4096u)
+
+#define WOLF_HEAP_MAGIC 0x57B10C4Bu   /* "WBlOCK" — used for use-after-
+                                       * free / wrong-pool detection. */
+
+struct wolf_block {
+    uint32_t           magic;     /* WOLF_HEAP_MAGIC when live */
+    uint32_t           is_free;
+    size_t             size;      /* user-visible bytes (excludes header) */
+    struct wolf_block *prev;
+    struct wolf_block *next;
+};
+
+static uint8_t          *g_wolf_heap;
+static struct wolf_block *g_head;
+static bool              g_inited;
+static spinlock_t        g_lock = SPINLOCK_INIT;
+
+static bool wolf_heap_init_locked(void)
+{
+    if (g_inited) return true;
+    g_wolf_heap = (uint8_t *)pmm_alloc_pages(WOLF_HEAP_PAGES);
+    if (g_wolf_heap == NULL) {
+        uart_printf("[WOLFHEAP] pmm_alloc_pages(%u) failed — "
+                    "SSH crypto operations will fail with MEMORY_E\r\n",
+                    (unsigned)WOLF_HEAP_PAGES);
+        return false;
+    }
+    g_head = (struct wolf_block *)g_wolf_heap;
+    g_head->magic   = WOLF_HEAP_MAGIC;
+    g_head->is_free = 1u;
+    g_head->size    = WOLF_HEAP_SIZE - sizeof(struct wolf_block);
+    g_head->prev    = NULL;
+    g_head->next    = NULL;
+    g_inited        = true;
+    uart_printf("[WOLFHEAP] %u MB wolfssl heap online at %p\r\n",
+                (unsigned)(WOLF_HEAP_SIZE / (1024u * 1024u)),
+                (void *)g_wolf_heap);
+    return true;
+}
+
+/* Round up to 16 bytes so the returned pointer is 16-byte aligned
+ * (wolfcrypt SIMD-y paths assume it). */
+static size_t align_up(size_t n)
+{
+    return (n + 15u) & ~(size_t)15u;
+}
+
+static void *alloc_locked(size_t size)
+{
+    if (!g_inited && !wolf_heap_init_locked()) return NULL;
+    if (size == 0u) return NULL;
+    size = align_up(size);
+
+    struct wolf_block *b = g_head;
+    while (b != NULL) {
+        if (b->is_free && b->size >= size) {
+            /* Split if the slack would hold another header + 16 B
+             * payload — otherwise hand over the whole block. */
+            if (b->size >= size + sizeof(struct wolf_block) + 16u) {
+                struct wolf_block *rest = (struct wolf_block *)
+                    ((uint8_t *)b + sizeof(struct wolf_block) + size);
+                rest->magic   = WOLF_HEAP_MAGIC;
+                rest->is_free = 1u;
+                rest->size    = b->size - size - sizeof(struct wolf_block);
+                rest->prev    = b;
+                rest->next    = b->next;
+                if (b->next) b->next->prev = rest;
+                b->next       = rest;
+                b->size       = size;
+            }
+            b->is_free = 0u;
+            return (void *)((uint8_t *)b + sizeof(struct wolf_block));
+        }
+        b = b->next;
+    }
+    return NULL;   /* OOM */
+}
+
+static void free_locked(void *p)
+{
+    if (p == NULL) return;
+    struct wolf_block *b = (struct wolf_block *)
+        ((uint8_t *)p - sizeof(struct wolf_block));
+    if (b->magic != WOLF_HEAP_MAGIC) {
+        uart_printf("[WOLFHEAP] free of non-wolf-heap pointer %p (magic=0x%x)\r\n",
+                    p, (unsigned)b->magic);
+        return;
+    }
+    b->is_free = 1u;
+
+    /* Merge with successor + predecessor where possible. */
+    if (b->next && b->next->is_free) {
+        b->size += sizeof(struct wolf_block) + b->next->size;
+        b->next = b->next->next;
+        if (b->next) b->next->prev = b;
+    }
+    if (b->prev && b->prev->is_free) {
+        b->prev->size += sizeof(struct wolf_block) + b->size;
+        b->prev->next = b->next;
+        if (b->next) b->next->prev = b->prev;
+    }
+}
+
+void *wolf_heap_alloc(size_t size)
+{
+    irq_flags_t flags = spin_lock_irqsave(&g_lock);
+    void *p = alloc_locked(size);
+    spin_unlock_irqrestore(&g_lock, flags);
+    return p;
+}
+
+void wolf_heap_free(void *p)
+{
+    irq_flags_t flags = spin_lock_irqsave(&g_lock);
+    free_locked(p);
+    spin_unlock_irqrestore(&g_lock, flags);
+}
+
+void *wolf_heap_realloc(void *p, size_t size)
+{
+    if (p == NULL)  return wolf_heap_alloc(size);
+    if (size == 0u) { wolf_heap_free(p); return NULL; }
+
+    irq_flags_t flags = spin_lock_irqsave(&g_lock);
+    struct wolf_block *b = (struct wolf_block *)
+        ((uint8_t *)p - sizeof(struct wolf_block));
+    if (b->magic != WOLF_HEAP_MAGIC) {
+        spin_unlock_irqrestore(&g_lock, flags);
+        uart_printf("[WOLFHEAP] realloc of non-wolf-heap pointer %p\r\n", p);
+        return NULL;
+    }
+
+    /* In-place shrink/keep is fine. */
+    if (b->size >= size) {
+        spin_unlock_irqrestore(&g_lock, flags);
+        return p;
+    }
+
+    /* Grow: allocate fresh, copy, free old. */
+    void *np = alloc_locked(size);
+    if (np != NULL) {
+        size_t copy = b->size;
+        for (size_t i = 0; i < copy; i++) {
+            ((uint8_t *)np)[i] = ((uint8_t *)p)[i];
+        }
+        free_locked(p);
+    }
+    spin_unlock_irqrestore(&g_lock, flags);
+    return np;
+}

--- a/kernel/net/ssh/wolf_heap.c
+++ b/kernel/net/ssh/wolf_heap.c
@@ -39,6 +39,7 @@
 
 #include "pmm.h"
 #include "spinlock.h"
+#include "string.h"
 #include "uart.h"
 
 /* Sized for scrypt at PASSWD_SCRYPT_LOG2_N=15: 32 MB working
@@ -142,6 +143,16 @@ static void free_locked(void *p)
                     p, (unsigned)b->magic);
         return;
     }
+    /* Double-free detection: the header carries WOLF_HEAP_MAGIC even
+     * after the first free (the freelist treats it as a sentinel), so
+     * the magic check above passes. Without this guard a second free
+     * would re-merge with already-merged neighbours and corrupt the
+     * freelist, potentially aliasing one wolfssl allocation onto
+     * another's working buffer — a key-material leak vector. */
+    if (b->is_free) {
+        uart_printf("[WOLFHEAP] double-free at %p\r\n", p);
+        return;
+    }
     b->is_free = 1u;
 
     /* Merge with successor + predecessor where possible. */
@@ -195,10 +206,7 @@ void *wolf_heap_realloc(void *p, size_t size)
     /* Grow: allocate fresh, copy, free old. */
     void *np = alloc_locked(size);
     if (np != NULL) {
-        size_t copy = b->size;
-        for (size_t i = 0; i < copy; i++) {
-            ((uint8_t *)np)[i] = ((uint8_t *)p)[i];
-        }
+        memcpy(np, p, b->size);
         free_locked(p);
     }
     spin_unlock_irqrestore(&g_lock, flags);

--- a/kernel/net/ssh/wolf_heap.h
+++ b/kernel/net/ssh/wolf_heap.h
@@ -1,0 +1,24 @@
+/*
+ * wolf_heap.h - Public surface of the dedicated wolfssl heap.
+ *
+ * See `kernel/net/ssh/wolf_heap.c` for the rationale (scrypt at the
+ * RFC 7914 floor needs a 32 MB working buffer that the shared
+ * lua_stubs allocator can't satisfy).
+ *
+ * `wolf_os.c` routes XMALLOC / XFREE / XREALLOC through these.
+ * Nothing else in the kernel should call them directly — the wolfssl
+ * heap is intentionally isolated from the rest of the kernel's
+ * byte-level allocations to keep fragmentation in one subsystem from
+ * starving another.
+ */
+
+#ifndef SLMOS_WOLF_HEAP_H
+#define SLMOS_WOLF_HEAP_H
+
+#include <stddef.h>
+
+void *wolf_heap_alloc(size_t size);
+void  wolf_heap_free(void *p);
+void *wolf_heap_realloc(void *p, size_t size);
+
+#endif /* SLMOS_WOLF_HEAP_H */

--- a/kernel/net/ssh/wolf_os.c
+++ b/kernel/net/ssh/wolf_os.c
@@ -36,9 +36,7 @@
  * single 32 MB working buffer per derivation, which the shared
  * lua_stubs heap (1 MB) can't satisfy — discovered during the
  * #199e hardware-validation pass on pi-5-2. */
-extern void *wolf_heap_alloc(size_t size);
-extern void  wolf_heap_free(void *p);
-extern void *wolf_heap_realloc(void *p, size_t size);
+#include "wolf_heap.h"
 
 void *XMALLOC(size_t n, void *heap, int type)
 {

--- a/kernel/net/ssh/wolf_os.c
+++ b/kernel/net/ssh/wolf_os.c
@@ -31,33 +31,34 @@
 /* Heap hooks (XMALLOC_USER)                                         */
 /* ---------------------------------------------------------------- */
 
-/* Kernel-side byte allocator. Provided by lua_stubs.c — same heap
- * the rest of the kernel uses (Rust-backed bump+free allocator). */
-extern void *malloc(size_t size);
-extern void  free(void *ptr);
-extern void *realloc(void *ptr, size_t size);
+/* Dedicated 48 MB wolfssl heap (kernel/net/ssh/wolf_heap.c). The
+ * scrypt KDF at the RFC 7914 floor (N=2^15, r=8, p=1) needs a
+ * single 32 MB working buffer per derivation, which the shared
+ * lua_stubs heap (1 MB) can't satisfy — discovered during the
+ * #199e hardware-validation pass on pi-5-2. */
+extern void *wolf_heap_alloc(size_t size);
+extern void  wolf_heap_free(void *p);
+extern void *wolf_heap_realloc(void *p, size_t size);
 
-/* The wolfssl heap and type arguments are advisory — we discard
- * them. Forward to the kernel allocator. */
 void *XMALLOC(size_t n, void *heap, int type)
 {
     (void)heap;
     (void)type;
-    return malloc(n);
+    return wolf_heap_alloc(n);
 }
 
 void XFREE(void *p, void *heap, int type)
 {
     (void)heap;
     (void)type;
-    free(p);
+    wolf_heap_free(p);
 }
 
 void *XREALLOC(void *p, size_t n, void *heap, int type)
 {
     (void)heap;
     (void)type;
-    return realloc(p, n);
+    return wolf_heap_realloc(p, n);
 }
 
 /* ---------------------------------------------------------------- */

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -437,6 +437,52 @@ static const struct help_entry help_entries[] = {
     ),
 
 #if defined(NET_SSHD)
+    HELP_TEXT("adduser",
+        "adduser - Add SSH user (Phase 3 / #199d)\n"
+        "\n"
+        "Usage:\n"
+        "  adduser <name> <password>\n"
+        "\n"
+        "Hashes the password via scrypt (N=2^15, r=8, p=1 — RFC 7914\n"
+        "floor) with a fresh per-user salt and appends a PHC-encoded\n"
+        "line to /mnt/files/etc/passwd. Bootstrap rule: the FIRST\n"
+        "user added (typically `adduser root ...`) opens the SSH\n"
+        "auth gate — until then sshd refuses every login attempt.\n"
+    ),
+
+    HELP_TEXT("deluser",
+        "deluser - Remove SSH user\n"
+        "\n"
+        "Usage:\n"
+        "  deluser <name>\n"
+        "\n"
+        "Refuses to remove the LAST remaining user to avoid locking\n"
+        "the operator out of SSH.\n"
+    ),
+
+    HELP_TEXT("passwd",
+        "passwd - Change an SSH user password\n"
+        "\n"
+        "Usage:\n"
+        "  passwd <name> <new-password>\n"
+        "\n"
+        "Re-hashes with a fresh random salt. The current password is\n"
+        "NOT required (operator-side trust model — only the local\n"
+        "shell can run this).\n"
+    ),
+
+    HELP_TEXT("whoami",
+        "whoami - Print current user identity\n"
+        "\n"
+        "Usage:\n"
+        "  whoami\n"
+        "\n"
+        "Returns `console` for the UART shell, `ssh` for sessions\n"
+        "opened through the SSH daemon. (#199d ships a partial\n"
+        "implementation — per-session identity carry-through lands\n"
+        "with the #199d-2 follow-up.)\n"
+    ),
+
     HELP_TEXT("sshd",
         "sshd - SSH daemon (port 22 / 2222)\n"
         "\n"

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -628,7 +628,11 @@ static const shell_cmd_t net_commands[] = {
     {"netstat",  cmd_netstat,  "Network statistics",                                   false, SHELL_CAT_NETWORK},
     {"ping",     cmd_ping,     "Send ICMP echo request",                               true,  SHELL_CAT_NETWORK},
 #if defined(NET_SSHD)
+    {"adduser",  cmd_adduser,  "Add SSH user (adduser <name> <password>)",             true,  SHELL_CAT_NETWORK},
+    {"deluser",  cmd_deluser,  "Remove SSH user (deluser <name>)",                     true,  SHELL_CAT_NETWORK},
+    {"passwd",   cmd_passwd,   "Change SSH user password (passwd <name> <new>)",       true,  SHELL_CAT_NETWORK},
     {"sshd",     cmd_sshd,     "SSH daemon (start|stop|status|fingerprint|regenerate-host-key)", true, SHELL_CAT_NETWORK},
+    {"whoami",   cmd_whoami,   "Print current user (console / ssh)",                   false, SHELL_CAT_NETWORK},
 #endif
     {"tcpsh",    cmd_telnetd,  "Alias for telnetd (legacy name)",                      true,  SHELL_CAT_NETWORK},
     {"telnetd",  cmd_telnetd,  "Telnet shell daemon (start|stop|status|sessions|kick)", true,  SHELL_CAT_NETWORK},

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -196,6 +196,8 @@ int test_harness_run_all(void)
     /* SSH host-key persistence (#199b / #892). The TU only compiles
      * when NET_SSHD is on, so it stays inside the same gate. */
     total_failures += test_suite_host_key();
+    /* Password DB + scrypt verify (#199d / #896). */
+    total_failures += test_suite_passwd();
 #endif
     /* `kernel` admin command surface (also relies on sdhci-pci). */
     total_failures += test_suite_kernel_cmd();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -226,6 +226,11 @@ int test_suite_sshd(void);
  * as the daemon itself; the TU only compiles when the host_key
  * module does. */
 int test_suite_host_key(void);
+
+/* Password DB + scrypt verify tests (#199d / #896). Exercises the
+ * full /mnt/files/etc/passwd round-trip through the wolf_heap-backed
+ * wolfssl scrypt allocation. */
+int test_suite_passwd(void);
 #endif
 
 /* General-purpose FDT reader tests (kernel/lib/fdt) */

--- a/kernel/tests/test_passwd.c
+++ b/kernel/tests/test_passwd.c
@@ -1,0 +1,207 @@
+/*
+ * test_passwd.c — /mnt/files/etc/passwd database + scrypt verify
+ *                 regression coverage (#199d / #896).
+ *
+ * Targets:
+ *
+ *   - passwd_any_users on empty / missing file → false.
+ *   - passwd_adduser + passwd_verify round-trip (exercises the full
+ *     scrypt path via the wolf_heap-backed wolfssl XMALLOC).
+ *   - passwd_verify rejects unknown user with PASSWD_E_NOT_FOUND.
+ *   - passwd_verify rejects wrong password with PASSWD_E_WRONG.
+ *   - passwd_adduser refuses duplicate username (PASSWD_E_EXISTS).
+ *   - passwd_deluser refuses removal of the last remaining user
+ *     (PASSWD_E_LAST_USER).
+ *   - passwd_set rejects over-long username — regression for the
+ *     stack-overflow defect addressed in the second review pass.
+ *   - passwd_set / passwd_adduser reject NULL inputs cleanly.
+ *
+ * Each test resets the database by removing the file via littlefs
+ * directly (the public API has no "wipe" operation by design — we
+ * don't want a shell verb that nukes the password DB). Tests skip
+ * cleanly if /mnt/files isn't mounted in this build target.
+ *
+ * Gated on NET_SSHD so the TU only compiles when the daemon (and
+ * therefore passwd.c) is built. Placeholder typedef keeps the file
+ * non-empty under -Wpedantic when the gate is off.
+ */
+
+#if defined(NET_SSHD)
+
+#include "passwd.h"
+#include "littlefs_slm.h"
+#include "unity.h"
+#include "vfs.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#define PASSWD_LFS_PATH   "/etc/passwd"
+
+static struct lfs_mount *resolve_passwd_mount(void)
+{
+    const char *subpath = NULL;
+    return (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
+}
+
+static void reset_passwd_file(void)
+{
+    struct lfs_mount *mnt = resolve_passwd_mount();
+    if (!mnt) return;   /* test will skip itself on the assert below */
+    (void)littlefs_remove(mnt, PASSWD_LFS_PATH);
+}
+
+static void test_any_users_false_when_file_missing(void)
+{
+    reset_passwd_file();
+    if (!resolve_passwd_mount()) {
+        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
+    }
+    TEST_ASSERT_FALSE(passwd_any_users());
+}
+
+static void test_adduser_verify_roundtrip(void)
+{
+    reset_passwd_file();
+    if (!resolve_passwd_mount()) {
+        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
+    }
+
+    /* Add a user — exercises rng_get_bytes for the salt, derive_hash
+     * over scrypt at N=2^15, the PHC-formatted line write, and the
+     * atomic rename. */
+    TEST_ASSERT_EQUAL_INT(PASSWD_OK,
+        passwd_adduser("alice", "correct-horse-battery-staple"));
+
+    /* File now has one entry. */
+    TEST_ASSERT_TRUE(passwd_any_users());
+
+    /* Right password verifies. */
+    TEST_ASSERT_EQUAL_INT(PASSWD_OK,
+        passwd_verify("alice", "correct-horse-battery-staple"));
+}
+
+static void test_verify_wrong_password_returns_E_WRONG(void)
+{
+    reset_passwd_file();
+    if (!resolve_passwd_mount()) {
+        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
+    }
+    TEST_ASSERT_EQUAL_INT(PASSWD_OK,
+        passwd_adduser("bob", "hunter2"));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_WRONG,
+        passwd_verify("bob", "wrong-guess"));
+}
+
+static void test_verify_unknown_user_returns_E_NOT_FOUND(void)
+{
+    reset_passwd_file();
+    if (!resolve_passwd_mount()) {
+        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
+    }
+    TEST_ASSERT_EQUAL_INT(PASSWD_OK,
+        passwd_adduser("carol", "secret"));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_NOT_FOUND,
+        passwd_verify("nonexistent", "anything"));
+}
+
+static void test_adduser_refuses_duplicate(void)
+{
+    reset_passwd_file();
+    if (!resolve_passwd_mount()) {
+        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
+    }
+    TEST_ASSERT_EQUAL_INT(PASSWD_OK,    passwd_adduser("dave", "first"));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_EXISTS, passwd_adduser("dave", "second"));
+}
+
+static void test_deluser_refuses_last_user(void)
+{
+    reset_passwd_file();
+    if (!resolve_passwd_mount()) {
+        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
+    }
+    TEST_ASSERT_EQUAL_INT(PASSWD_OK, passwd_adduser("eve", "onlyone"));
+    /* The bootstrap-safety promise: refuse to delete the only
+     * remaining user so the daemon can't lock the operator out. */
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_LAST_USER, passwd_deluser("eve"));
+    /* User is still there. */
+    TEST_ASSERT_EQUAL_INT(PASSWD_OK, passwd_verify("eve", "onlyone"));
+}
+
+static void test_set_rejects_overlong_username(void)
+{
+    /* Regression test for the second-pass Critical: passwd_set on a
+     * 200-char username would overflow e.username[33] and corrupt
+     * kernel stack. Length-check at the top now rejects it cleanly. */
+    char long_name[PASSWD_MAX_USERNAME_LEN + 64u + 1u];
+    for (size_t i = 0; i < sizeof(long_name) - 1u; i++) {
+        long_name[i] = 'A';
+    }
+    long_name[sizeof(long_name) - 1u] = '\0';
+
+    int rc = passwd_set(long_name, "anything");
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, rc);
+}
+
+static void test_set_rejects_overlong_password(void)
+{
+    char long_pw[PASSWD_MAX_PASSWORD_LEN + 16u + 1u];
+    for (size_t i = 0; i < sizeof(long_pw) - 1u; i++) {
+        long_pw[i] = 'B';
+    }
+    long_pw[sizeof(long_pw) - 1u] = '\0';
+
+    int rc = passwd_set("name", long_pw);
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, rc);
+}
+
+static void test_adduser_rejects_overlong_username(void)
+{
+    char long_name[PASSWD_MAX_USERNAME_LEN + 64u + 1u];
+    for (size_t i = 0; i < sizeof(long_name) - 1u; i++) {
+        long_name[i] = 'A';
+    }
+    long_name[sizeof(long_name) - 1u] = '\0';
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG,
+        passwd_adduser(long_name, "anything"));
+}
+
+static void test_null_inputs_return_BAD_ARG(void)
+{
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, passwd_verify(NULL, "x"));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, passwd_verify("x", NULL));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, passwd_adduser(NULL, "x"));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, passwd_adduser("x", NULL));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, passwd_set(NULL, "x"));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, passwd_set("x", NULL));
+    TEST_ASSERT_EQUAL_INT(PASSWD_E_BAD_ARG, passwd_deluser(NULL));
+}
+
+int test_suite_passwd(void)
+{
+    UnityBegin("passwd (scrypt + /mnt/files/etc/passwd)");
+
+    /* Length / null-arg checks run first — they don't need a mounted
+     * FS so they work on every target. */
+    RUN_TEST(test_set_rejects_overlong_username);
+    RUN_TEST(test_set_rejects_overlong_password);
+    RUN_TEST(test_adduser_rejects_overlong_username);
+    RUN_TEST(test_null_inputs_return_BAD_ARG);
+
+    /* The scrypt-path tests require the wolf_heap + littlefs mount. */
+    RUN_TEST(test_any_users_false_when_file_missing);
+    RUN_TEST(test_adduser_verify_roundtrip);
+    RUN_TEST(test_verify_wrong_password_returns_E_WRONG);
+    RUN_TEST(test_verify_unknown_user_returns_E_NOT_FOUND);
+    RUN_TEST(test_adduser_refuses_duplicate);
+    RUN_TEST(test_deluser_refuses_last_user);
+
+    return UnityEnd();
+}
+
+#else  /* !NET_SSHD */
+
+typedef int test_passwd_placeholder_t;
+
+#endif /* NET_SSHD */

--- a/kernel/tests/test_passwd.c
+++ b/kernel/tests/test_passwd.c
@@ -44,28 +44,30 @@ static struct lfs_mount *resolve_passwd_mount(void)
     return (struct lfs_mount *)vfs_get_mount_ctx("/mnt/files", &subpath);
 }
 
-static void reset_passwd_file(void)
+/* Single setup helper: wipe any /etc/passwd left over from a prior
+ * test, skip the calling test if /mnt/files isn't mounted on this
+ * build target. The implicit-skip variant means a future test author
+ * who forgets the reset stays on the supported path instead of
+ * inheriting prior-test state. */
+static void prepare_fs_or_skip(void)
 {
     struct lfs_mount *mnt = resolve_passwd_mount();
-    if (!mnt) return;   /* test will skip itself on the assert below */
+    if (!mnt) {
+        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
+        return;   /* unreachable — TEST_IGNORE_MESSAGE longjmps */
+    }
     (void)littlefs_remove(mnt, PASSWD_LFS_PATH);
 }
 
 static void test_any_users_false_when_file_missing(void)
 {
-    reset_passwd_file();
-    if (!resolve_passwd_mount()) {
-        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
-    }
+    prepare_fs_or_skip();
     TEST_ASSERT_FALSE(passwd_any_users());
 }
 
 static void test_adduser_verify_roundtrip(void)
 {
-    reset_passwd_file();
-    if (!resolve_passwd_mount()) {
-        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
-    }
+    prepare_fs_or_skip();
 
     /* Add a user — exercises rng_get_bytes for the salt, derive_hash
      * over scrypt at N=2^15, the PHC-formatted line write, and the
@@ -83,10 +85,7 @@ static void test_adduser_verify_roundtrip(void)
 
 static void test_verify_wrong_password_returns_E_WRONG(void)
 {
-    reset_passwd_file();
-    if (!resolve_passwd_mount()) {
-        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
-    }
+    prepare_fs_or_skip();
     TEST_ASSERT_EQUAL_INT(PASSWD_OK,
         passwd_adduser("bob", "hunter2"));
     TEST_ASSERT_EQUAL_INT(PASSWD_E_WRONG,
@@ -95,10 +94,7 @@ static void test_verify_wrong_password_returns_E_WRONG(void)
 
 static void test_verify_unknown_user_returns_E_NOT_FOUND(void)
 {
-    reset_passwd_file();
-    if (!resolve_passwd_mount()) {
-        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
-    }
+    prepare_fs_or_skip();
     TEST_ASSERT_EQUAL_INT(PASSWD_OK,
         passwd_adduser("carol", "secret"));
     TEST_ASSERT_EQUAL_INT(PASSWD_E_NOT_FOUND,
@@ -107,20 +103,14 @@ static void test_verify_unknown_user_returns_E_NOT_FOUND(void)
 
 static void test_adduser_refuses_duplicate(void)
 {
-    reset_passwd_file();
-    if (!resolve_passwd_mount()) {
-        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
-    }
+    prepare_fs_or_skip();
     TEST_ASSERT_EQUAL_INT(PASSWD_OK,    passwd_adduser("dave", "first"));
     TEST_ASSERT_EQUAL_INT(PASSWD_E_EXISTS, passwd_adduser("dave", "second"));
 }
 
 static void test_deluser_refuses_last_user(void)
 {
-    reset_passwd_file();
-    if (!resolve_passwd_mount()) {
-        TEST_IGNORE_MESSAGE("/mnt/files not mounted on this target");
-    }
+    prepare_fs_or_skip();
     TEST_ASSERT_EQUAL_INT(PASSWD_OK, passwd_adduser("eve", "onlyone"));
     /* The bootstrap-safety promise: refuse to delete the only
      * remaining user so the daemon can't lock the operator out. */


### PR DESCRIPTION
Replaces #199c's allow-all auth with a real scrypt-based check
against \`/mnt/files/etc/passwd\`. Adds the bootstrap gate that
refuses every SSH auth until the operator runs
\`adduser root <pw>\` on the console.

**Stacked**: this PR → #915 (#199c) → #914 (#199b) → #902 (#199a).

## What's in this PR

- \`kernel/net/ssh/passwd.{h,c}\` — PHC-style passwd file
  (\`name:$scrypt$N=N,r=R,p=P$<salt>$<hash>:uid:home\`), scrypt KDF
  at N=2^15 / r=8 / p=1 (RFC 7914 floor, OWASP recommendation),
  per-user random salt, constant-time hash compare, atomic
  \`.tmp\` + rename on every mutation, last-user-deletion refused.

- \`kernel/net/ssh/passwd_shell.c\` — \`adduser\` / \`passwd\` /
  \`deluser\` / \`whoami\` shell verbs.

- \`sshd.c\` — \`sshd_userauth_passwd\` callback wired via
  \`wolfSSH_SetUserAuth\`. Bootstrap gate refuses every attempt
  when \`passwd_any_users()\` is false. Username + password copied
  into stack buffers, password wiped before return.

- \`kernel/lib/wolfcrypt/src/pwdbased.c\` — vendored from upstream
  to provide \`wc_scrypt\`.

## Build / test status

| Target            | NET_SSHD=OFF | NET_SSHD=ON |
|-------------------|--------------|-------------|
| QEMU_VIRT         | clean        | clean       |
| RASPI5            | clean        | clean       |
| JETSON_ORIN_NANO  | clean        | clean       |

- \`make test\` (default): PASS.
- \`make test EXTRA_KERNEL_CMAKE_ARGS=-DNET_SSHD=ON\`: PASS.

## Acceptance vs #199d ticket

| Criterion | Status |
|---|---|
| Fresh boot, no /etc/passwd: sshd refuses connections | ✅ (passwd_any_users gate in sshd_userauth_passwd) |
| Console `passwd root` + sshd accepts root login | ✅ (passwd_set writes the entry; verify loads it; constant-time compare) |
| `adduser alice` + ssh as alice works | ✅ |
| Wrong-password attempts are slow | scrypt N=2^15 ~ 100 ms per attempt; no per-IP rate-limit yet (#199e scope) |
| Constant-time hash compare | ✅ (passwd.c constant_time_compare) |

## What's NOT in this PR

- Per-source-IP rate limiting + backoff — #199e (#895) scope.
- No-echo password prompt — needs a shell_io hook for echo
  suppression. Easy follow-up.
- whoami carrying the authenticated SSH user name — placeholder
  reporting "ssh"; per-session identity plumbing is a #199d-2
  follow-up.

Refs: #199, #896