### PR TITLE
Dynamic batching 55c: admin toggle + concurrent stress workload

### DIFF
--- a/docs/lua.md
+++ b/docs/lua.md
@@ -197,6 +197,10 @@ without a compile-time guard.
 | `slm.model_pin(index)` | Admin surface only. Pin a model to prevent LRU eviction. Returns 0 on success, -1 on error. |
 | `slm.model_unpin(index)` | Admin surface only. Unpin a model (allow LRU eviction). Returns 0 on success, -1 on error. |
 | `slm.infer_stats()` | Cumulative inference statistics: `{total, total_ns, min_ns, max_ns, last_ns, errors}`. |
+| `slm.infer_batch_status()` | Dynamic-batching dispatcher snapshot: `{enabled, batch_size, timeout_us, queue_depth, total_submitted, completed, failed, batches_dispatched, batches_full, batches_timeout, bypassed_deadline, singleton_dispatches}`. Read-only; safe surface. |
+| `slm.infer_batch_mode(s)` | Admin surface only. `s = "on"` enables batched dispatch; `"off"` disables (default). Returns the resulting mode as a boolean. SLM-OS exposes batching as a runtime-toggleable option (#848); the default is OFF — flip it on for multi-tenant inference workloads. |
+| `slm.infer_batch_config({size=N, timeout_us=T})` | Admin surface only. Configure the batch-size threshold (1..32, default 8) and the partial-batch flush timeout (100..100000 µs, default 5000). Returns `{size, timeout_us}` reflecting the actually-applied values (out-of-range inputs clamp to the nearest bound). Either field may be omitted to keep the current value. |
+| `slm.infer_stress(N, iters)` | Admin surface only. Spawn `N` (1..32) concurrent task workers, each calling `submit_inference_sync` against MNIST for `iters` (1..100000) iterations. Returns a results table: `{n_workers, iters_per_worker, success, errors, wall_us, min_us, avg_us, max_us, req_per_s, batches_dispatched, batches_full, batches_timeout, bypassed_deadline, singleton_dispatches}`. MNIST must be loaded first. The exact ratio of batched vs singleton dispatches depends on the current `infer_batch_mode`/`infer_batch_config`. |
 | `slm.gpu_status()` | GPU subsystem info: `{available, name, device, compute_ready, unified_memory, memory_size}`. `.available` is always set; other fields populated when a driver is present. |
 
 ### Hailo NPU (AI HAT+)

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -162,6 +162,10 @@ Hardware control & diagnostics:       # mix of always-available + platform-gated
 | `model pools` | Show weight and workspace memory pool statistics |
 | `model stats` | Show inference performance statistics (latency, throughput, errors) |
 | `model bench <name> [N]` | Benchmark model inference latency (default 10 iterations) |
+| `infer batch on\|off` | Enable/disable runtime batched inference dispatch (default OFF). Per the exploratory-OS framing in #848, batching is a runtime-toggleable mode rather than a default behavior change. |
+| `infer batch config <size> <us>` | Configure batch threshold (1..32) and partial-batch flush timeout in microseconds (100..100000). Defaults: 8 / 5000. |
+| `infer batch status` | Print the dynamic-batching dispatcher state: mode, batch size, timeout, queue depth, and the `SchedulerStats` counter snapshot (`batches_full`, `batches_timeout`, `bypassed_deadline`, `singleton_dispatches`, etc.). |
+| `bench infer-stress N [iters]` | Spawn N concurrent task workers (1..32), each running `iters` MNIST inferences (default 50) against the batched dispatcher. Reports aggregate req/s, min/avg/max per-iteration latency, and the per-run counter deltas. Loads MNIST automatically if not already present. |
 | `gpu use status` | Tabular view of the three GPU consumer toggles (sched, eviction, inference) with last-change timestamps |
 | `gpu use inference <on\|off>` | Master toggle for GPU inference dispatch. Default OFF. On Jetson with `--no-gpu-suspend` kexec + a v6 channel handoff, flipping ON routes the MNIST model through the GA10B fastpath. Other platforms accept the flag but engine still uses CPU NEON. |
 | `gpu use sched <on\|off>` | Master toggle for AI-scheduler GPU dispatch (`ai_mlp` policy). When ON and a sched-MLP v6 handoff is in DRAM (Jetson with `--no-gpu-suspend` kexec + `gpu-kernel-sched-mlp` host helper running pre-kexec), every `ai_mlp_assign_cpu` runs the 4-layer forward on GA10B and falls back to CPU NEON only on dispatch error. Default OFF. Other policies (`heuristic`, `ai_ppo`, `ai_hailo`) ignore the flag. |

--- a/kernel/include/shell_internal.h
+++ b/kernel/include/shell_internal.h
@@ -69,6 +69,7 @@ int cmd_diag(int argc, char **argv);
 int cmd_vmm(int argc, char **argv);
 int cmd_ipc(int argc, char **argv);
 int cmd_model(int argc, char **argv);
+int cmd_infer(int argc, char **argv);
 int cmd_slm(int argc, char **argv);
 int cmd_dtb(int argc, char **argv);
 int cmd_gpu(int argc, char **argv);

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -808,6 +808,7 @@ extern void rust_infer_batch_reset_stats(void);
  *   -2 — MNIST not loaded (call rust_model_load_builtin_mnist first)
  *   -3 — another stress run is in flight
  *   -4 — task spawn failure
+ *   -5 — join deadline exceeded
  */
 extern int32_t rust_infer_stress_run(uint32_t n_workers,
                                      uint32_t iters_per_worker,

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -796,9 +796,6 @@ extern int32_t rust_infer_batch_set_config(uint32_t batch_size, uint32_t timeout
  * success, -1 if `out` is null. */
 extern int32_t rust_infer_batch_status(RustBatchStatus *out);
 
-/* Reset the SchedulerStats counters. */
-extern void rust_infer_batch_reset_stats(void);
-
 /* Run the concurrent stress workload. Spawns `n_workers` tasks each
  * running `iters_per_worker` MNIST inferences against the batched
  * dispatcher, joins, and writes the aggregated result into `out`.

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -742,6 +742,78 @@ extern int rust_inference_test(void);
 extern int rust_batch_inference_test(void);
 
 /*
+ * Dynamic-batching admin + stress FFI (#860). All entrypoints are
+ * safe to call from any task context; the shell and Lua bindings
+ * forward to them directly.
+ */
+
+/* Status snapshot — must stay in lockstep with `RustBatchStatus` in
+ * runtime/src/lib.rs. */
+typedef struct {
+    uint32_t enabled;
+    uint32_t batch_size;
+    uint32_t timeout_us;
+    uint32_t queue_depth;
+    uint64_t total_submitted;
+    uint64_t completed;
+    uint64_t failed;
+    uint64_t batches_dispatched;
+    uint64_t batches_full;
+    uint64_t batches_timeout;
+    uint64_t bypassed_deadline;
+    uint64_t singleton_dispatches;
+} RustBatchStatus;
+
+/* Stress workload result — must stay in lockstep with
+ * `RustStressResult` in runtime/src/lib.rs. */
+typedef struct {
+    uint32_t n_workers;
+    uint32_t iters_per_worker;
+    uint64_t success_count;
+    uint64_t error_count;
+    uint64_t wall_ns;
+    uint64_t total_lat_ns;
+    uint64_t min_lat_ns;
+    uint64_t max_lat_ns;
+    uint64_t batches_dispatched;
+    uint64_t batches_full;
+    uint64_t batches_timeout;
+    uint64_t bypassed_deadline;
+    uint64_t singleton_dispatches;
+} RustStressResult;
+
+/* `on != 0` enables batched dispatch; `on == 0` disables. Default OFF. */
+extern void rust_infer_batch_set_mode(int32_t on);
+
+/* Returns 1 if batched dispatch is currently enabled, 0 otherwise. */
+extern int32_t rust_infer_batch_get_mode(void);
+
+/* Configure batch-size threshold + flush timeout. Out-of-range values
+ * clamp to the nearest bound. Returns 0 on success. */
+extern int32_t rust_infer_batch_set_config(uint32_t batch_size, uint32_t timeout_us);
+
+/* Fill `out` with the current batching status snapshot. Returns 0 on
+ * success, -1 if `out` is null. */
+extern int32_t rust_infer_batch_status(RustBatchStatus *out);
+
+/* Reset the SchedulerStats counters. */
+extern void rust_infer_batch_reset_stats(void);
+
+/* Run the concurrent stress workload. Spawns `n_workers` tasks each
+ * running `iters_per_worker` MNIST inferences against the batched
+ * dispatcher, joins, and writes the aggregated result into `out`.
+ *
+ * Returns 0 on success, negative on error:
+ *   -1 — `out` is null, or n_workers/iters out of range
+ *   -2 — MNIST not loaded (call rust_model_load_builtin_mnist first)
+ *   -3 — another stress run is in flight
+ *   -4 — task spawn failure
+ */
+extern int32_t rust_infer_stress_run(uint32_t n_workers,
+                                     uint32_t iters_per_worker,
+                                     RustStressResult *out);
+
+/*
  * Inference statistics structure.
  */
 typedef struct {

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -600,6 +600,27 @@ static const struct help_entry help_entries[] = {
         "Displays message queue and shared buffer statistics.\n"
     ),
 
+    HELP_TEXT("infer",
+        "infer - Inference engine admin (dynamic batching)\n"
+        "\n"
+        "Usage:\n"
+        "  infer batch on                        Enable batched dispatch\n"
+        "  infer batch off                       Disable (default)\n"
+        "  infer batch config <size> <us>        Set batch threshold + flush timeout\n"
+        "  infer batch status                    Show batching state + counters\n"
+        "\n"
+        "Default at boot is OFF. With batching ON, concurrent inference\n"
+        "requests are collected into a batch of up to <size> (default 8)\n"
+        "and dispatched together via a single engine call once the queue\n"
+        "fills or <us> microseconds (default 5000) elapse since the first\n"
+        "request landed. Requests carrying a tight `TaskDeadline` bypass\n"
+        "the queue and dispatch as singletons. SLM-OS is an exploratory\n"
+        "OS — batching is a runtime-toggleable mode, not a default.\n"
+        "\n"
+        "See `bench infer-stress N [iters]` for the concurrent workload\n"
+        "that exercises the feature.\n"
+    ),
+
     HELP_TEXT("model",
         "model - Model registry and inference control\n"
         "\n"

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -3243,6 +3243,169 @@ static int l_infer_stats(lua_State *L) {
 }
 
 /**
+ * slm.infer_batch_status() — Read-only snapshot of the dynamic-batching
+ * dispatcher (#860). Returns table:
+ *   {enabled, batch_size, timeout_us, queue_depth,
+ *    total_submitted, completed, failed,
+ *    batches_dispatched, batches_full, batches_timeout,
+ *    bypassed_deadline, singleton_dispatches}
+ *
+ * Returns nil on error.
+ */
+static int l_infer_batch_status(lua_State *L) {
+    if (!L) return 0;
+    RustBatchStatus s;
+    if (rust_infer_batch_status(&s) != 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_createtable(L, 0, 12);
+    lua_pushboolean(L, s.enabled != 0);  lua_setfield(L, -2, "enabled");
+    lua_pushinteger(L, (lua_Integer)s.batch_size);
+    lua_setfield(L, -2, "batch_size");
+    lua_pushinteger(L, (lua_Integer)s.timeout_us);
+    lua_setfield(L, -2, "timeout_us");
+    lua_pushinteger(L, (lua_Integer)s.queue_depth);
+    lua_setfield(L, -2, "queue_depth");
+    lua_pushinteger(L, (lua_Integer)s.total_submitted);
+    lua_setfield(L, -2, "total_submitted");
+    lua_pushinteger(L, (lua_Integer)s.completed);
+    lua_setfield(L, -2, "completed");
+    lua_pushinteger(L, (lua_Integer)s.failed);
+    lua_setfield(L, -2, "failed");
+    lua_pushinteger(L, (lua_Integer)s.batches_dispatched);
+    lua_setfield(L, -2, "batches_dispatched");
+    lua_pushinteger(L, (lua_Integer)s.batches_full);
+    lua_setfield(L, -2, "batches_full");
+    lua_pushinteger(L, (lua_Integer)s.batches_timeout);
+    lua_setfield(L, -2, "batches_timeout");
+    lua_pushinteger(L, (lua_Integer)s.bypassed_deadline);
+    lua_setfield(L, -2, "bypassed_deadline");
+    lua_pushinteger(L, (lua_Integer)s.singleton_dispatches);
+    lua_setfield(L, -2, "singleton_dispatches");
+    return 1;
+}
+
+/**
+ * slm.infer_batch_mode("on"|"off") — admin toggle for batched
+ * dispatch. Returns the resulting mode as a boolean.
+ */
+static int l_infer_batch_mode(lua_State *L) {
+    if (!L) return 0;
+    const char *arg = luaL_checkstring(L, 1);
+    int on = 0;
+    if (strcmp(arg, "on") == 0) {
+        on = 1;
+    } else if (strcmp(arg, "off") != 0) {
+        return luaL_error(L, "infer_batch_mode: argument must be 'on' or 'off'");
+    }
+    rust_infer_batch_set_mode(on);
+    lua_pushboolean(L, rust_infer_batch_get_mode() != 0);
+    return 1;
+}
+
+/**
+ * slm.infer_batch_config({size=N, timeout_us=T}) — configure batch
+ * threshold and partial-batch timeout. Out-of-range values clamp to
+ * the nearest accepted bound: size to [1, 32], timeout_us to
+ * [100, 100000]. Returns the applied table.
+ */
+static int l_infer_batch_config(lua_State *L) {
+    if (!L) return 0;
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_getfield(L, 1, "size");
+    lua_Integer size = luaL_optinteger(L, -1, 0);
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "timeout_us");
+    lua_Integer timeout = luaL_optinteger(L, -1, 0);
+    lua_pop(L, 1);
+
+    /* Read current config; only overwrite fields the caller supplied. */
+    RustBatchStatus cur;
+    rust_infer_batch_status(&cur);
+    uint32_t new_size = (size > 0) ? (uint32_t)size : cur.batch_size;
+    uint32_t new_timeout = (timeout > 0) ? (uint32_t)timeout : cur.timeout_us;
+    rust_infer_batch_set_config(new_size, new_timeout);
+
+    RustBatchStatus after;
+    rust_infer_batch_status(&after);
+    lua_createtable(L, 0, 2);
+    lua_pushinteger(L, (lua_Integer)after.batch_size);
+    lua_setfield(L, -2, "size");
+    lua_pushinteger(L, (lua_Integer)after.timeout_us);
+    lua_setfield(L, -2, "timeout_us");
+    return 1;
+}
+
+/**
+ * slm.infer_stress(N, iters) — spawn N concurrent task workers, each
+ * running `iters` MNIST inferences against the batched dispatcher.
+ * Returns a table with the aggregated stress result, or nil on error.
+ *
+ *   {n_workers, iters_per_worker, success, errors,
+ *    wall_us, min_us, avg_us, max_us, req_per_s,
+ *    batches_dispatched, batches_full, batches_timeout,
+ *    bypassed_deadline, singleton_dispatches}
+ */
+static int l_infer_stress(lua_State *L) {
+    if (!L) return 0;
+    lua_Integer n = luaL_checkinteger(L, 1);
+    lua_Integer iters = luaL_optinteger(L, 2, 50);
+    if (n <= 0 || n > 32 || iters <= 0 || iters > 100000) {
+        return luaL_error(L, "infer_stress: N must be 1..32, iters 1..100000");
+    }
+    RustStressResult r;
+    int32_t rc = rust_infer_stress_run((uint32_t)n, (uint32_t)iters, &r);
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushinteger(L, rc);
+        return 2;
+    }
+
+    lua_Integer success = (lua_Integer)r.success_count;
+    lua_Integer wall_us = (lua_Integer)(r.wall_ns / 1000);
+    lua_Integer avg_us = (success > 0)
+        ? (lua_Integer)((r.total_lat_ns / (uint64_t)success) / 1000)
+        : 0;
+    lua_Integer req_per_s = (r.wall_ns > 0)
+        ? (lua_Integer)((r.success_count * 1000000000ULL) / r.wall_ns)
+        : 0;
+
+    lua_createtable(L, 0, 14);
+    lua_pushinteger(L, (lua_Integer)r.n_workers);
+    lua_setfield(L, -2, "n_workers");
+    lua_pushinteger(L, (lua_Integer)r.iters_per_worker);
+    lua_setfield(L, -2, "iters_per_worker");
+    lua_pushinteger(L, success);
+    lua_setfield(L, -2, "success");
+    lua_pushinteger(L, (lua_Integer)r.error_count);
+    lua_setfield(L, -2, "errors");
+    lua_pushinteger(L, wall_us);
+    lua_setfield(L, -2, "wall_us");
+    lua_pushinteger(L, (lua_Integer)(r.min_lat_ns / 1000));
+    lua_setfield(L, -2, "min_us");
+    lua_pushinteger(L, avg_us);
+    lua_setfield(L, -2, "avg_us");
+    lua_pushinteger(L, (lua_Integer)(r.max_lat_ns / 1000));
+    lua_setfield(L, -2, "max_us");
+    lua_pushinteger(L, req_per_s);
+    lua_setfield(L, -2, "req_per_s");
+    lua_pushinteger(L, (lua_Integer)r.batches_dispatched);
+    lua_setfield(L, -2, "batches_dispatched");
+    lua_pushinteger(L, (lua_Integer)r.batches_full);
+    lua_setfield(L, -2, "batches_full");
+    lua_pushinteger(L, (lua_Integer)r.batches_timeout);
+    lua_setfield(L, -2, "batches_timeout");
+    lua_pushinteger(L, (lua_Integer)r.bypassed_deadline);
+    lua_setfield(L, -2, "bypassed_deadline");
+    lua_pushinteger(L, (lua_Integer)r.singleton_dispatches);
+    lua_setfield(L, -2, "singleton_dispatches");
+    return 1;
+}
+
+/**
  * slm.gpu_status() - Get GPU subsystem status
  * Returns table: {available, name, device, compute_ready, unified_memory, memory_size}
  */
@@ -4378,6 +4541,8 @@ static const luaL_Reg slm_lib_safe[] = {
     {"model_list", l_model_list},
     {"model_info", l_model_info},
     {"infer_stats", l_infer_stats},
+    /* Dynamic batching — read-only status (#860). */
+    {"infer_batch_status", l_infer_batch_status},
     {"gpu_status", l_gpu_status},
     /* Shell integration */
     {"read_line", l_read_line},
@@ -4417,6 +4582,10 @@ static const luaL_Reg slm_lib_admin[] = {
     {"gpu_use_set", l_gpu_use_set},
     /* Admin & telemetry suite (M5) — model launch (instantiates) */
     {"model_launch", l_model_launch},
+    /* Dynamic batching admin (#860). */
+    {"infer_batch_mode", l_infer_batch_mode},
+    {"infer_batch_config", l_infer_batch_config},
+    {"infer_stress", l_infer_stress},
     /* Scheduler / task mutation */
     {"sched_set_policy", l_sched_set_policy},
     {"task_migrate", l_task_migrate},

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -3322,6 +3322,19 @@ static int l_infer_batch_config(lua_State *L) {
     lua_Integer timeout = luaL_optinteger(L, -1, 0);
     lua_pop(L, 1);
 
+    /* Reject out-of-range values explicitly so callers don't end up
+     * silently truncated through the uint32_t cast below. The FFI
+     * still clamps internally, but a 5e10 value at the script layer
+     * is almost certainly a typo. 0 = keep current. */
+    if (size < 0 || size > 32) {
+        return luaL_error(L,
+            "infer_batch_config: size must be 0..32 (0 = keep current)");
+    }
+    if (timeout < 0 || timeout > 100000) {
+        return luaL_error(L,
+            "infer_batch_config: timeout_us must be 0..100000 (0 = keep current)");
+    }
+
     /* Read current config; only overwrite fields the caller supplied. */
     RustBatchStatus cur;
     rust_infer_batch_status(&cur);
@@ -3402,6 +3415,11 @@ static int l_infer_stress(lua_State *L) {
     lua_setfield(L, -2, "bypassed_deadline");
     lua_pushinteger(L, (lua_Integer)r.singleton_dispatches);
     lua_setfield(L, -2, "singleton_dispatches");
+    /* Surface the partial-spawn case explicitly — `n_workers` already
+     * reflects the actual count, but a boolean field is easier for
+     * Lua callers to assert on. */
+    lua_pushboolean(L, r.n_workers < (uint32_t)n);
+    lua_setfield(L, -2, "partial_spawn");
     return 1;
 }
 

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -124,6 +124,7 @@ const shell_cmd_t builtin_commands[] = {
     /* --- Process / scheduling / AI runtime --- */
     {"bench",    cmd_bench,    "Performance benchmarks (bench <context|irq|ipc|stats|all>)", true, SHELL_CAT_PROCESS},
     {"eviction", cmd_eviction, "AI eviction (eviction [policy [<name>] | stats])",          true, SHELL_CAT_PROCESS},
+    {"infer",    cmd_infer,    "Inference engine (infer batch <on|off|config|status>)",    true, SHELL_CAT_PROCESS},
     {"kill",     cmd_kill,     "Terminate a task by ID",                                    true, SHELL_CAT_PROCESS},
 #if !defined(PLATFORM_X86_64)
     {"mmaptest", cmd_mmaptest, "Run the EL0 sys_mmap/munmap smoke task (mmap follow-up)",   false, SHELL_CAT_PROCESS},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1841,9 +1841,11 @@ int cmd_bench(int argc, char *argv[])
         }
         if (argc >= 4) {
             uint32_t n;
-            if (shell_parse_uint(argv[3], &n) == 0 && n > 0 && n <= 100000) {
-                iters = n;
+            if (shell_parse_uint(argv[3], &n) != 0 || n == 0 || n > 100000) {
+                shell_puts("bench infer-stress: iters must be 1..100000\r\n");
+                return 1;
             }
+            iters = n;
         }
 
         /* Ensure MNIST is loaded — the stress runner refuses without it. */
@@ -1873,6 +1875,11 @@ int cmd_bench(int argc, char *argv[])
         if (rc != 0) {
             shell_printf("  Stress run failed: rc=%d\r\n", (int)rc);
             return 1;
+        }
+        if (res.n_workers < n_workers) {
+            shell_printf("  WARNING: only %u of %u workers spawned "
+                         "(task-table likely exhausted)\r\n",
+                         res.n_workers, n_workers);
         }
 
         uint64_t completed = res.success_count;
@@ -3091,11 +3098,7 @@ static const char *const slm_op_type_names[] = {
  */
 int cmd_infer(int argc, char *argv[])
 {
-    if (argc < 2 || strcmp(argv[1], "batch") != 0) {
-        shell_puts("Usage: infer batch <on|off|config <size> <timeout_us>|status>\r\n");
-        return 1;
-    }
-    if (argc < 3) {
+    if (argc < 3 || strcmp(argv[1], "batch") != 0) {
         shell_puts("Usage: infer batch <on|off|config <size> <timeout_us>|status>\r\n");
         return 1;
     }

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1418,7 +1418,7 @@ static void s3_steal_work_task(void *arg)
 int cmd_bench(int argc, char *argv[])
 {
     if (argc < 2) {
-        shell_puts("Usage: bench <context|irq|ipc|eviction|deadline|isolate|shared|smp|stealing|matmul|conv|quant|q4kdot|gpu|stats|all>\r\n");
+        shell_puts("Usage: bench <context|irq|ipc|eviction|deadline|isolate|shared|smp|stealing|matmul|conv|quant|q4kdot|gpu|infer-stress|stats|all>\r\n");
         return 1;
     }
 
@@ -1817,6 +1817,98 @@ int cmd_bench(int argc, char *argv[])
     } else if (strcmp(argv[1], "sched-policy") == 0) {
         bench_sched_policy();
 #endif
+    } else if (strcmp(argv[1], "infer-stress") == 0) {
+        /* Concurrent inference stress workload (#860).
+         *
+         * Usage: bench infer-stress N [iters]
+         *
+         *   N       — number of concurrent task workers (1..32).
+         *   iters   — inferences per worker (default 50).
+         *
+         * Exercises the dynamic-batching dispatcher with N workers
+         * sharing a single MNIST model. The exact ratio of batched
+         * vs singleton dispatches depends on the runtime mode (`infer
+         * batch on|off`) and the configured batch size. Reports
+         * aggregate req/s, min/avg/max latency, and the
+         * SchedulerStats counter deltas captured around the run.
+         */
+        uint32_t n_workers = 0;
+        uint32_t iters = 50;
+        if (argc < 3 || shell_parse_uint(argv[2], &n_workers) != 0
+            || n_workers == 0 || n_workers > 32) {
+            shell_puts("Usage: bench infer-stress <N (1..32)> [iters]\r\n");
+            return 1;
+        }
+        if (argc >= 4) {
+            uint32_t n;
+            if (shell_parse_uint(argv[3], &n) == 0 && n > 0 && n <= 100000) {
+                iters = n;
+            }
+        }
+
+        /* Ensure MNIST is loaded — the stress runner refuses without it. */
+        int mnist_idx = rust_model_find("mnist");
+        if (mnist_idx < 0) {
+            shell_puts("Loading MNIST...\r\n");
+            mnist_idx = rust_model_load_builtin_mnist();
+            if (mnist_idx < 0) {
+                shell_puts("  FAILED to load MNIST — cannot run stress\r\n");
+                return 1;
+            }
+        }
+
+        shell_puts("Dynamic Batching Stress Workload\r\n");
+        shell_puts("================================\r\n");
+        RustBatchStatus pre_status;
+        rust_infer_batch_status(&pre_status);
+        shell_printf("  Batching mode: %s\r\n", pre_status.enabled ? "ON" : "off");
+        if (pre_status.enabled) {
+            shell_printf("  Batch size:    %u\r\n", pre_status.batch_size);
+            shell_printf("  Timeout:       %u us\r\n", pre_status.timeout_us);
+        }
+        shell_printf("  Workers:       %u  Iters/worker: %u\r\n", n_workers, iters);
+
+        RustStressResult res;
+        int32_t rc = rust_infer_stress_run(n_workers, iters, &res);
+        if (rc != 0) {
+            shell_printf("  Stress run failed: rc=%d\r\n", (int)rc);
+            return 1;
+        }
+
+        uint64_t completed = res.success_count;
+        uint64_t total_iter = (uint64_t)res.n_workers * (uint64_t)res.iters_per_worker;
+        unsigned long min_us = (unsigned long)(res.min_lat_ns / 1000);
+        unsigned long max_us = (unsigned long)(res.max_lat_ns / 1000);
+        unsigned long avg_us = completed > 0
+            ? (unsigned long)((res.total_lat_ns / completed) / 1000)
+            : 0;
+        unsigned long wall_us = (unsigned long)(res.wall_ns / 1000);
+        unsigned long req_per_s = res.wall_ns > 0
+            ? (unsigned long)((completed * 1000000000ULL) / res.wall_ns)
+            : 0;
+
+        shell_puts("\r\nResults:\r\n");
+        shell_printf("  Successful infers: %lu / %lu\r\n",
+                    (unsigned long)completed, (unsigned long)total_iter);
+        if (res.error_count > 0) {
+            shell_printf("  Errors:            %lu\r\n",
+                        (unsigned long)res.error_count);
+        }
+        shell_printf("  Wall time:         %lu us\r\n", wall_us);
+        shell_printf("  Aggregate req/s:   %lu\r\n", req_per_s);
+        shell_printf("  Per-iter latency:  min=%lu us  avg=%lu us  max=%lu us\r\n",
+                    min_us, avg_us, max_us);
+        shell_puts("\r\nCounter deltas (this run):\r\n");
+        shell_printf("  batches_dispatched: %lu\r\n",
+                    (unsigned long)res.batches_dispatched);
+        shell_printf("  batches_full:       %lu  (size-threshold)\r\n",
+                    (unsigned long)res.batches_full);
+        shell_printf("  batches_timeout:    %lu  (timer flush)\r\n",
+                    (unsigned long)res.batches_timeout);
+        shell_printf("  bypassed_deadline:  %lu\r\n",
+                    (unsigned long)res.bypassed_deadline);
+        shell_printf("  singleton_dispatches: %lu\r\n",
+                    (unsigned long)res.singleton_dispatches);
     } else if (strcmp(argv[1], "all") == 0) {
         shell_puts("SLM-OS Performance Benchmarks\r\n");
         shell_puts("=============================\r\n\r\n");
@@ -1835,7 +1927,7 @@ int cmd_bench(int argc, char *argv[])
         bench_sched_stats();
     } else {
         shell_printf("Unknown benchmark: %s\r\n", argv[1]);
-        shell_puts("Available: context, irq, ipc, deadline, isolate, shared, smp, gpu, sched-policy, stats, all\r\n");
+        shell_puts("Available: context, irq, ipc, deadline, isolate, shared, smp, gpu, sched-policy, infer-stress, stats, all\r\n");
         return 1;
     }
 
@@ -2988,6 +3080,92 @@ static const char *const slm_op_type_names[] = {
 };
 #define SLM_OP_TYPE_NAME_COUNT \
     (sizeof(slm_op_type_names) / sizeof(slm_op_type_names[0]))
+
+/*
+ * `infer batch on|off|config <size> <timeout_us>|status` — admin
+ * toggle for the dynamic-batching dispatcher (#860).
+ *
+ * Default at boot is OFF. Flip on for a multi-tenant inference
+ * workload (e.g., `bench infer-stress`) and back off to restore the
+ * historical singleton-dispatch behaviour.
+ */
+int cmd_infer(int argc, char *argv[])
+{
+    if (argc < 2 || strcmp(argv[1], "batch") != 0) {
+        shell_puts("Usage: infer batch <on|off|config <size> <timeout_us>|status>\r\n");
+        return 1;
+    }
+    if (argc < 3) {
+        shell_puts("Usage: infer batch <on|off|config <size> <timeout_us>|status>\r\n");
+        return 1;
+    }
+
+    const char *sub = argv[2];
+
+    if (strcmp(sub, "on") == 0) {
+        rust_infer_batch_set_mode(1);
+        shell_puts("infer batch: ON\r\n");
+        return 0;
+    }
+    if (strcmp(sub, "off") == 0) {
+        rust_infer_batch_set_mode(0);
+        shell_puts("infer batch: off\r\n");
+        return 0;
+    }
+    if (strcmp(sub, "config") == 0) {
+        if (argc < 5) {
+            shell_puts("Usage: infer batch config <size (1..32)> <timeout_us (100..100000)>\r\n");
+            return 1;
+        }
+        uint32_t size, timeout;
+        if (shell_parse_uint(argv[3], &size) != 0 || size == 0 || size > 32) {
+            shell_puts("infer batch config: size must be 1..32\r\n");
+            return 1;
+        }
+        if (shell_parse_uint(argv[4], &timeout) != 0
+            || timeout < 100 || timeout > 100000) {
+            shell_puts("infer batch config: timeout_us must be 100..100000\r\n");
+            return 1;
+        }
+        rust_infer_batch_set_config(size, timeout);
+        shell_printf("infer batch config: size=%u timeout_us=%u\r\n", size, timeout);
+        return 0;
+    }
+    if (strcmp(sub, "status") == 0) {
+        RustBatchStatus s;
+        if (rust_infer_batch_status(&s) != 0) {
+            shell_puts("infer batch status: failed\r\n");
+            return 1;
+        }
+        shell_puts("Dynamic Batching Status\r\n");
+        shell_puts("=======================\r\n");
+        shell_printf("  Mode:                  %s\r\n", s.enabled ? "ON" : "off");
+        shell_printf("  Batch size:            %u\r\n", s.batch_size);
+        shell_printf("  Timeout:               %u us\r\n", s.timeout_us);
+        shell_printf("  Queue depth:           %u\r\n", s.queue_depth);
+        shell_puts("  Counters (since reset):\r\n");
+        shell_printf("    total_submitted:     %lu\r\n",
+                    (unsigned long)s.total_submitted);
+        shell_printf("    completed:           %lu\r\n",
+                    (unsigned long)s.completed);
+        shell_printf("    failed:              %lu\r\n",
+                    (unsigned long)s.failed);
+        shell_printf("    batches_dispatched:  %lu\r\n",
+                    (unsigned long)s.batches_dispatched);
+        shell_printf("    batches_full:        %lu\r\n",
+                    (unsigned long)s.batches_full);
+        shell_printf("    batches_timeout:     %lu\r\n",
+                    (unsigned long)s.batches_timeout);
+        shell_printf("    bypassed_deadline:   %lu\r\n",
+                    (unsigned long)s.bypassed_deadline);
+        shell_printf("    singleton_dispatches:%lu\r\n",
+                    (unsigned long)s.singleton_dispatches);
+        return 0;
+    }
+
+    shell_printf("infer batch: unknown subcommand '%s'\r\n", sub);
+    return 1;
+}
 
 int cmd_model(int argc, char *argv[])
 {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5663,6 +5663,321 @@ pub unsafe extern "C" fn rust_slm_stats(session_id: u32, out: *mut SlmStatsC) ->
 }
 
 // =============================================================================
+// Dynamic-batching admin + stress FFI (#860)
+// =============================================================================
+
+/// Status snapshot exposed via `rust_infer_batch_status` to the C
+/// shell + Lua bindings.
+///
+/// Field order is part of the FFI contract — extending this struct
+/// requires updating `kernel/include/slm_ffi.h` in lockstep.
+#[repr(C)]
+pub struct RustBatchStatus {
+    /// Non-zero when batched dispatch is currently enabled.
+    pub enabled: u32,
+    /// Configured batch-size threshold (clamped to [1, MAX_BATCH]).
+    pub batch_size: u32,
+    /// Configured partial-batch flush timeout (microseconds).
+    pub timeout_us: u32,
+    /// Current pending queue depth.
+    pub queue_depth: u32,
+    /// Total requests submitted since boot (or last reset).
+    pub total_submitted: u64,
+    /// Successful completions.
+    pub completed: u64,
+    /// Engine errors.
+    pub failed: u64,
+    /// Total batched dispatches (size + timeout).
+    pub batches_dispatched: u64,
+    /// Batched dispatches triggered by hitting the size threshold.
+    pub batches_full: u64,
+    /// Batched dispatches triggered by the partial-batch timer.
+    pub batches_timeout: u64,
+    /// Requests that bypassed the queue due to a tight deadline.
+    pub bypassed_deadline: u64,
+    /// Requests that fell through to the singleton path.
+    pub singleton_dispatches: u64,
+}
+
+/// Toggle batched dispatch mode.
+///
+/// `on == 0` disables (default); any non-zero enables.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_set_mode(on: i32) {
+    sched::set_batching_enabled(on != 0);
+}
+
+/// Read the current batched-dispatch mode (1 = on, 0 = off).
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_get_mode() -> i32 {
+    if sched::batching_enabled() { 1 } else { 0 }
+}
+
+/// Configure batch size + timeout.
+///
+/// Bounds: `1 ≤ batch_size ≤ MAX_BATCH`, `100 µs ≤ timeout_us ≤ 100_000 µs`
+/// (out-of-range values clamp to the nearest bound). Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_set_config(batch_size: u32, timeout_us: u32) -> i32 {
+    sched::set_batch_size(batch_size as usize);
+    sched::set_batch_timeout_us(timeout_us.min(100_000));
+    0
+}
+
+/// Fill `out` with the current batching status snapshot.
+///
+/// Returns 0 on success, -1 if `out` is null.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_status(out: *mut RustBatchStatus) -> i32 {
+    if out.is_null() {
+        return -1;
+    }
+    let s = sched::scheduler_stats();
+    let status = RustBatchStatus {
+        enabled: if sched::batching_enabled() { 1 } else { 0 },
+        batch_size: sched::batch_size() as u32,
+        timeout_us: sched::batch_timeout_us(),
+        queue_depth: s.queued as u32,
+        total_submitted: s.total_submitted,
+        completed: s.completed,
+        failed: s.failed,
+        batches_dispatched: s.batches_dispatched,
+        batches_full: s.batches_full,
+        batches_timeout: s.batches_timeout,
+        bypassed_deadline: s.bypassed_deadline,
+        singleton_dispatches: s.singleton_dispatches,
+    };
+    unsafe { *out = status; }
+    0
+}
+
+/// Reset the scheduler stats counters. Useful before a stress run so
+/// the post-run snapshot reflects only that run's activity.
+#[no_mangle]
+pub extern "C" fn rust_infer_batch_reset_stats() {
+    sched::reset_scheduler_stats();
+}
+
+// -----------------------------------------------------------------------------
+// Stress workload — spawn N worker tasks each running M iterations
+// of `submit_inference_sync` against MNIST. Exercises the batched
+// dispatch path end-to-end (the OS has no other concurrent inference
+// call site today).
+// -----------------------------------------------------------------------------
+
+#[repr(C)]
+pub struct RustStressResult {
+    /// N workers actually spawned.
+    pub n_workers: u32,
+    /// Iterations per worker requested by the caller.
+    pub iters_per_worker: u32,
+    /// Total successful inferences across all workers.
+    pub success_count: u64,
+    /// Total failed inferences across all workers.
+    pub error_count: u64,
+    /// Wall-clock time the stress run took, in nanoseconds (from the
+    /// first worker spawn to the last worker completion).
+    pub wall_ns: u64,
+    /// Sum of per-iteration latencies across all workers, nanoseconds.
+    pub total_lat_ns: u64,
+    /// Minimum observed per-iteration latency, nanoseconds.
+    pub min_lat_ns: u64,
+    /// Maximum observed per-iteration latency, nanoseconds.
+    pub max_lat_ns: u64,
+    /// Counter deltas captured between pre-run and post-run snapshots.
+    pub batches_dispatched: u64,
+    pub batches_full: u64,
+    pub batches_timeout: u64,
+    pub bypassed_deadline: u64,
+    pub singleton_dispatches: u64,
+}
+
+// Stress workload shared state — file-static atomics. The stress
+// workload is single-run at a time (the shell + Lua entry points
+// serialise via the global `STRESS_BUSY` flag).
+static STRESS_BUSY: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static STRESS_WORKERS_DONE: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+static STRESS_ITERS_PER_WORKER: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+static STRESS_MODEL_INDEX: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+static STRESS_SUCCESS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static STRESS_ERROR: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static STRESS_LAT_TOTAL: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static STRESS_LAT_MIN: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(u64::MAX);
+static STRESS_LAT_MAX: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+/// Worker-task entry point. Runs `STRESS_ITERS_PER_WORKER` inferences
+/// against `STRESS_MODEL_INDEX` and signals completion via
+/// `STRESS_WORKERS_DONE`.
+extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
+    use core::sync::atomic::Ordering;
+
+    // Per-worker buffers on this task's stack. INPUT stays uniform —
+    // for stress testing the engine doesn't need varied input; the
+    // counter-update path is what we want to exercise.
+    let input: [f32; 784] = [0.0; 784];
+    let mut output: [f32; 64] = [0.0; 64];
+    let iters = STRESS_ITERS_PER_WORKER.load(Ordering::Acquire);
+    let model_index = STRESS_MODEL_INDEX.load(Ordering::Acquire) as usize;
+
+    for _ in 0..iters {
+        let start = kernel_ffi::get_time_ns();
+        let r = unsafe {
+            sched::submit_inference_sync(
+                model_index,
+                input.as_ptr(), input.len(),
+                output.as_mut_ptr(), output.len(),
+                sched::TaskDeadline::NONE,
+            )
+        };
+        let elapsed = kernel_ffi::get_time_ns().saturating_sub(start);
+        STRESS_LAT_TOTAL.fetch_add(elapsed, Ordering::Relaxed);
+        // min via CAS loop.
+        let mut cur = STRESS_LAT_MIN.load(Ordering::Relaxed);
+        while elapsed < cur {
+            match STRESS_LAT_MIN.compare_exchange_weak(cur, elapsed, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(v) => cur = v,
+            }
+        }
+        // max via CAS loop.
+        cur = STRESS_LAT_MAX.load(Ordering::Relaxed);
+        while elapsed > cur {
+            match STRESS_LAT_MAX.compare_exchange_weak(cur, elapsed, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(v) => cur = v,
+            }
+        }
+        if r.is_ok() {
+            STRESS_SUCCESS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            STRESS_ERROR.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    STRESS_WORKERS_DONE.fetch_add(1, Ordering::Release);
+}
+
+/// Run a concurrent stress workload.
+///
+/// Spawns `n_workers` task workers (each `CPU_AFFINITY_ANY`), waits
+/// for completion, then writes the aggregated result into `out`.
+/// MNIST must be loaded (use `rust_model_load_builtin_mnist` first);
+/// the model index is looked up by name.
+///
+/// Returns 0 on success, negative on error:
+///  -1 — `out` is null, or n_workers/iters out of range
+///  -2 — MNIST not loaded
+///  -3 — stress workload already running
+///  -4 — task spawn failure
+///
+/// # Safety
+///
+/// Caller obligations match `rust_infer_classify` (must run in task
+/// context with an initialised scheduler).
+#[no_mangle]
+pub unsafe extern "C" fn rust_infer_stress_run(
+    n_workers: u32,
+    iters_per_worker: u32,
+    out: *mut RustStressResult,
+) -> i32 {
+    use core::sync::atomic::Ordering;
+
+    if out.is_null() {
+        return -1;
+    }
+    if n_workers == 0 || n_workers > 32 || iters_per_worker == 0 || iters_per_worker > 100_000 {
+        return -1;
+    }
+
+    // Serialise concurrent stress invocations.
+    if STRESS_BUSY
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+        .is_err()
+    {
+        return -3;
+    }
+    struct BusyGuard;
+    impl Drop for BusyGuard {
+        fn drop(&mut self) {
+            STRESS_BUSY.store(false, Ordering::Release);
+        }
+    }
+    let _busy = BusyGuard;
+
+    // Resolve MNIST model index.
+    let model_idx = match loader::registry::find_by_name(b"mnist") {
+        Some(i) => i as u32,
+        None => return -2,
+    };
+
+    // Snapshot pre-run counters so we can compute deltas.
+    let pre = sched::scheduler_stats();
+
+    // Reset worker-shared counters.
+    STRESS_WORKERS_DONE.store(0, Ordering::Release);
+    STRESS_SUCCESS.store(0, Ordering::Release);
+    STRESS_ERROR.store(0, Ordering::Release);
+    STRESS_LAT_TOTAL.store(0, Ordering::Release);
+    STRESS_LAT_MIN.store(u64::MAX, Ordering::Release);
+    STRESS_LAT_MAX.store(0, Ordering::Release);
+    STRESS_ITERS_PER_WORKER.store(iters_per_worker, Ordering::Release);
+    STRESS_MODEL_INDEX.store(model_idx, Ordering::Release);
+
+    let start_ns = kernel_ffi::get_time_ns();
+    let mut spawned: u32 = 0;
+    for _ in 0..n_workers {
+        let r = kernel_ffi::task_create(
+            b"infer-stress\0",
+            stress_worker_entry,
+            core::ptr::null_mut(),
+        );
+        if r.is_ok() {
+            spawned += 1;
+        }
+    }
+
+    if spawned == 0 {
+        return -4;
+    }
+
+    // Join: spin-yield until all spawned workers signal done.
+    // The yield budget is generous — each worker runs
+    // `iters_per_worker` MNIST inferences (~1 ms each on QEMU CPU).
+    loop {
+        if STRESS_WORKERS_DONE.load(Ordering::Acquire) >= spawned {
+            break;
+        }
+        extern "C" {
+            #[link_name = "yield"]
+            fn sched_yield();
+        }
+        sched_yield();
+    }
+
+    let end_ns = kernel_ffi::get_time_ns();
+
+    let post = sched::scheduler_stats();
+    let min_lat = STRESS_LAT_MIN.load(Ordering::Acquire);
+    let result = RustStressResult {
+        n_workers: spawned,
+        iters_per_worker,
+        success_count: STRESS_SUCCESS.load(Ordering::Acquire),
+        error_count: STRESS_ERROR.load(Ordering::Acquire),
+        wall_ns: end_ns.saturating_sub(start_ns),
+        total_lat_ns: STRESS_LAT_TOTAL.load(Ordering::Acquire),
+        min_lat_ns: if min_lat == u64::MAX { 0 } else { min_lat },
+        max_lat_ns: STRESS_LAT_MAX.load(Ordering::Acquire),
+        batches_dispatched: post.batches_dispatched.saturating_sub(pre.batches_dispatched),
+        batches_full: post.batches_full.saturating_sub(pre.batches_full),
+        batches_timeout: post.batches_timeout.saturating_sub(pre.batches_timeout),
+        bypassed_deadline: post.bypassed_deadline.saturating_sub(pre.bypassed_deadline),
+        singleton_dispatches: post.singleton_dispatches.saturating_sub(pre.singleton_dispatches),
+    };
+    *out = result;
+    0
+}
+
+// =============================================================================
 // Inference API (Phase 5, M2)
 // =============================================================================
 
@@ -7776,6 +8091,63 @@ pub extern "C" fn rust_batch_inference_test() -> i32 {
 
         sched::set_batching_enabled(false);
         sched::set_batch_timeout_us(DEFAULT_BATCH_TIMEOUT_US); // restore default
+    }
+
+    // Test 9 (#860): admin FFI round-trip. The shell + Lua bindings
+    // all forward to `rust_infer_batch_set_mode`, `_set_config`, and
+    // `_status`; verify the read/write contract.
+    {
+        rust_infer_batch_set_mode(0);
+        let off_mode = rust_infer_batch_get_mode();
+        rust_infer_batch_set_mode(1);
+        let on_mode = rust_infer_batch_get_mode();
+        rust_infer_batch_set_config(4, 1234);
+        let mut s: RustBatchStatus = unsafe { core::mem::zeroed() };
+        let rc = rust_infer_batch_status(&mut s as *mut _);
+        let null_rc = rust_infer_batch_status(core::ptr::null_mut());
+        let passed = off_mode == 0
+            && on_mode == 1
+            && rc == 0
+            && null_rc == -1
+            && s.enabled == 1
+            && s.batch_size == 4
+            && s.timeout_us == 1234;
+        print_test_result(b"batch: admin FFI set/get round-trip\0", passed);
+        if !passed { failures += 1; }
+        rust_infer_batch_set_mode(0);
+        rust_infer_batch_set_config(8, 5000);
+    }
+
+    // Test 10 (#860): concurrent stress workload. Spawns N=4 task
+    // workers, each running 8 inferences. Verifies the run reports the
+    // expected success count and that the FFI rejects out-of-range
+    // arguments.
+    {
+        rust_infer_batch_set_mode(1);
+        rust_infer_batch_set_config(8, 5000);
+
+        // Out-of-range guard.
+        let mut bogus: RustStressResult = unsafe { core::mem::zeroed() };
+        let bad_n = unsafe { rust_infer_stress_run(0, 1, &mut bogus as *mut _) };
+        let bad_null = unsafe { rust_infer_stress_run(2, 2, core::ptr::null_mut()) };
+        let bad_iter = unsafe { rust_infer_stress_run(2, 0, &mut bogus as *mut _) };
+
+        let mut res: RustStressResult = unsafe { core::mem::zeroed() };
+        let rc = unsafe { rust_infer_stress_run(4, 8, &mut res as *mut _) };
+
+        let expected = (res.n_workers as u64) * (res.iters_per_worker as u64);
+        let passed = bad_n == -1
+            && bad_null == -1
+            && bad_iter == -1
+            && rc == 0
+            && res.n_workers == 4
+            && res.iters_per_worker == 8
+            && res.success_count == expected
+            && res.error_count == 0;
+        print_test_result(b"batch: stress workload (4x8) completes + rejects bad args\0", passed);
+        if !passed { failures += 1; }
+
+        rust_infer_batch_set_mode(0);
     }
 
     // Summary

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5869,6 +5869,7 @@ extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
 ///  -2 — MNIST not loaded
 ///  -3 — stress workload already running
 ///  -4 — task spawn failure
+///  -5 — join deadline exceeded (workers didn't finish in time)
 ///
 /// # Safety
 ///
@@ -5941,15 +5942,29 @@ pub unsafe extern "C" fn rust_infer_stress_run(
     }
 
     // Join: spin-yield until all spawned workers signal done.
-    // The yield budget is generous — each worker runs
-    // `iters_per_worker` MNIST inferences (~1 ms each on QEMU CPU).
+    //
+    // Generous deadline so a regression in the dispatcher can't hang
+    // the shell forever: 30 s of headroom plus an iteration budget
+    // (one second per 10 iterations on top, which fits MNIST's
+    // ~1 ms/inference on QEMU and the ~3 ms/inference worst case on
+    // Pi 5/Jetson without batching). On timeout we return -5 so the
+    // operator can recover; in-flight workers will still finish and
+    // signal the busy guard, but `out` won't be populated.
+    let join_deadline_ns = kernel_ffi::get_time_ns().saturating_add(
+        30_000_000_000u64.saturating_add(
+            (iters_per_worker as u64).saturating_mul(100_000_000), // 100 ms/iter
+        ),
+    );
+    extern "C" {
+        #[link_name = "yield"]
+        fn sched_yield();
+    }
     loop {
         if STRESS_WORKERS_DONE.load(Ordering::Acquire) >= spawned {
             break;
         }
-        extern "C" {
-            #[link_name = "yield"]
-            fn sched_yield();
+        if kernel_ffi::get_time_ns() >= join_deadline_ns {
+            return -5;
         }
         sched_yield();
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5876,6 +5876,20 @@ extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
         // forward (e.g. our run timed out and the operator started a
         // new one). The inference itself still ran — we just don't
         // contaminate the next run's counters.
+        //
+        // Residual race window (known-and-bounded): the four atomic
+        // writes below are NOT gated. A straggler that passes this
+        // check at the same instant a new run bumps GENERATION and
+        // resets counters will still apply up to those four writes —
+        // a sub-microsecond window. Worst case is a handful of stale
+        // increments leaking into the next run's `total_lat_ns` /
+        // `success_count` / min / max. The stress workload is a
+        // diagnostic, not a load-bearing measurement, so this is
+        // accepted. `WORKERS_DONE` is gated separately below and is
+        // race-free; the join loop therefore never exits early on a
+        // straggler bump. Eliminating the window entirely would mean
+        // moving to per-worker private counters summed at the end —
+        // overkill for the current use case.
         if STRESS_GENERATION.load(Ordering::Acquire) != gen_at_entry {
             return;
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5713,14 +5713,21 @@ pub extern "C" fn rust_infer_batch_get_mode() -> i32 {
     if sched::batching_enabled() { 1 } else { 0 }
 }
 
+/// Upper bound on the partial-batch flush timeout exposed via the FFI.
+/// `sched::set_batch_timeout_us` applies the matching lower bound (100 µs).
+const MAX_BATCH_TIMEOUT_US: u32 = 100_000;
+
 /// Configure batch size + timeout.
 ///
 /// Bounds: `1 ≤ batch_size ≤ MAX_BATCH`, `100 µs ≤ timeout_us ≤ 100_000 µs`
-/// (out-of-range values clamp to the nearest bound). Returns 0 on success.
+/// (out-of-range values clamp to the nearest bound — upper bound on
+/// `timeout_us` is enforced here, lower bound on `timeout_us` and the
+/// full clamp on `batch_size` are enforced by the underlying setters).
+/// Returns 0 on success.
 #[no_mangle]
 pub extern "C" fn rust_infer_batch_set_config(batch_size: u32, timeout_us: u32) -> i32 {
     sched::set_batch_size(batch_size as usize);
-    sched::set_batch_timeout_us(timeout_us.min(100_000));
+    sched::set_batch_timeout_us(timeout_us.min(MAX_BATCH_TIMEOUT_US));
     0
 }
 
@@ -5749,13 +5756,6 @@ pub extern "C" fn rust_infer_batch_status(out: *mut RustBatchStatus) -> i32 {
     };
     unsafe { *out = status; }
     0
-}
-
-/// Reset the scheduler stats counters. Useful before a stress run so
-/// the post-run snapshot reflects only that run's activity.
-#[no_mangle]
-pub extern "C" fn rust_infer_batch_reset_stats() {
-    sched::reset_scheduler_stats();
 }
 
 // -----------------------------------------------------------------------------
@@ -5792,10 +5792,23 @@ pub struct RustStressResult {
     pub singleton_dispatches: u64,
 }
 
+// Base join-deadline budget for a stress run: 30 s of headroom plus a
+// per-iteration allowance. Sized so MNIST's ~1 ms/inference (QEMU)
+// and ~3 ms (Pi 5 / Jetson without batching) leave ~30× safety
+// margin — a timeout therefore indicates a real regression in the
+// dispatcher rather than under-budgeting.
+const STRESS_JOIN_BASE_NS: u64 = 30_000_000_000;
+const STRESS_JOIN_PER_ITER_NS: u64 = 100_000_000;
+
 // Stress workload shared state — file-static atomics. The stress
 // workload is single-run at a time (the shell + Lua entry points
-// serialise via the global `STRESS_BUSY` flag).
+// serialise via the global `STRESS_BUSY` flag). `STRESS_GENERATION`
+// is incremented at the top of every run; workers cache the current
+// generation at entry and a stale-generation check on the back-edge
+// drops straggler writes if a prior run's join deadline expired and
+// a fresh run started before the straggler finished.
 static STRESS_BUSY: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static STRESS_GENERATION: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
 static STRESS_WORKERS_DONE: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
 static STRESS_ITERS_PER_WORKER: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
 static STRESS_MODEL_INDEX: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
@@ -5805,9 +5818,36 @@ static STRESS_LAT_TOTAL: core::sync::atomic::AtomicU64 = core::sync::atomic::Ato
 static STRESS_LAT_MIN: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(u64::MAX);
 static STRESS_LAT_MAX: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
+/// Atomically minimise `atom` against `candidate`. Used by stress
+/// workers to track the per-iteration latency floor; identical pattern
+/// to the max helper below.
+fn atomic_min_u64(atom: &core::sync::atomic::AtomicU64, candidate: u64) {
+    use core::sync::atomic::Ordering;
+    let mut cur = atom.load(Ordering::Relaxed);
+    while candidate < cur {
+        match atom.compare_exchange_weak(cur, candidate, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(v) => cur = v,
+        }
+    }
+}
+
+/// Atomically maximise `atom` against `candidate`.
+fn atomic_max_u64(atom: &core::sync::atomic::AtomicU64, candidate: u64) {
+    use core::sync::atomic::Ordering;
+    let mut cur = atom.load(Ordering::Relaxed);
+    while candidate > cur {
+        match atom.compare_exchange_weak(cur, candidate, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(v) => cur = v,
+        }
+    }
+}
+
 /// Worker-task entry point. Runs `STRESS_ITERS_PER_WORKER` inferences
 /// against `STRESS_MODEL_INDEX` and signals completion via
-/// `STRESS_WORKERS_DONE`.
+/// `STRESS_WORKERS_DONE`. Cached `gen` at entry isolates this worker
+/// from a later run that bumps `STRESS_GENERATION` — see W1 fix below.
 extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
     use core::sync::atomic::Ordering;
 
@@ -5818,6 +5858,7 @@ extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
     let mut output: [f32; 64] = [0.0; 64];
     let iters = STRESS_ITERS_PER_WORKER.load(Ordering::Acquire);
     let model_index = STRESS_MODEL_INDEX.load(Ordering::Acquire) as usize;
+    let gen_at_entry = STRESS_GENERATION.load(Ordering::Acquire);
 
     for _ in 0..iters {
         let start = kernel_ffi::get_time_ns();
@@ -5830,23 +5871,18 @@ extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
             )
         };
         let elapsed = kernel_ffi::get_time_ns().saturating_sub(start);
+
+        // Drop the write if a later run has rolled the generation
+        // forward (e.g. our run timed out and the operator started a
+        // new one). The inference itself still ran — we just don't
+        // contaminate the next run's counters.
+        if STRESS_GENERATION.load(Ordering::Acquire) != gen_at_entry {
+            return;
+        }
+
         STRESS_LAT_TOTAL.fetch_add(elapsed, Ordering::Relaxed);
-        // min via CAS loop.
-        let mut cur = STRESS_LAT_MIN.load(Ordering::Relaxed);
-        while elapsed < cur {
-            match STRESS_LAT_MIN.compare_exchange_weak(cur, elapsed, Ordering::Relaxed, Ordering::Relaxed) {
-                Ok(_) => break,
-                Err(v) => cur = v,
-            }
-        }
-        // max via CAS loop.
-        cur = STRESS_LAT_MAX.load(Ordering::Relaxed);
-        while elapsed > cur {
-            match STRESS_LAT_MAX.compare_exchange_weak(cur, elapsed, Ordering::Relaxed, Ordering::Relaxed) {
-                Ok(_) => break,
-                Err(v) => cur = v,
-            }
-        }
+        atomic_min_u64(&STRESS_LAT_MIN, elapsed);
+        atomic_max_u64(&STRESS_LAT_MAX, elapsed);
         if r.is_ok() {
             STRESS_SUCCESS.fetch_add(1, Ordering::Relaxed);
         } else {
@@ -5854,7 +5890,12 @@ extern "C" fn stress_worker_entry(_arg: *mut core::ffi::c_void) {
         }
     }
 
-    STRESS_WORKERS_DONE.fetch_add(1, Ordering::Release);
+    // Last-chance generation check before signalling done — a straggler
+    // from a timed-out run must not bump WORKERS_DONE for the current
+    // run.
+    if STRESS_GENERATION.load(Ordering::Acquire) == gen_at_entry {
+        STRESS_WORKERS_DONE.fetch_add(1, Ordering::Release);
+    }
 }
 
 /// Run a concurrent stress workload.
@@ -5914,6 +5955,11 @@ pub unsafe extern "C" fn rust_infer_stress_run(
     // Snapshot pre-run counters so we can compute deltas.
     let pre = sched::scheduler_stats();
 
+    // Bump the generation FIRST so any straggler workers from a prior
+    // timed-out run will observe a generation mismatch and abandon
+    // their writes before we reset the shared counters.
+    STRESS_GENERATION.fetch_add(1, Ordering::AcqRel);
+
     // Reset worker-shared counters.
     STRESS_WORKERS_DONE.store(0, Ordering::Release);
     STRESS_SUCCESS.store(0, Ordering::Release);
@@ -5941,18 +5987,13 @@ pub unsafe extern "C" fn rust_infer_stress_run(
         return -4;
     }
 
-    // Join: spin-yield until all spawned workers signal done.
-    //
-    // Generous deadline so a regression in the dispatcher can't hang
-    // the shell forever: 30 s of headroom plus an iteration budget
-    // (one second per 10 iterations on top, which fits MNIST's
-    // ~1 ms/inference on QEMU and the ~3 ms/inference worst case on
-    // Pi 5/Jetson without batching). On timeout we return -5 so the
-    // operator can recover; in-flight workers will still finish and
-    // signal the busy guard, but `out` won't be populated.
+    // Join: spin-yield until all spawned workers signal done. On
+    // timeout we return -5 and rely on the generation counter (bumped
+    // at the top of each run) to keep straggler workers from
+    // contaminating the next run's counters.
     let join_deadline_ns = kernel_ffi::get_time_ns().saturating_add(
-        30_000_000_000u64.saturating_add(
-            (iters_per_worker as u64).saturating_mul(100_000_000), // 100 ms/iter
+        STRESS_JOIN_BASE_NS.saturating_add(
+            (iters_per_worker as u64).saturating_mul(STRESS_JOIN_PER_ITER_NS),
         ),
     );
     extern "C" {


### PR DESCRIPTION
## Summary

Exposes the dynamic-batching dispatcher (#862 / #908) to the operator and gives the OS its first concurrent inference call site. Per the exploratory-OS framing in #848, batching ships as a runtime-toggleable mode rather than a default — `infer batch on` (shell) / `slm.infer_batch_mode("on")` (Lua) flip it on; default is OFF.

Rebased onto main after #862 + #908 squash-merged; replaces closed PR #889.

## Changes

### Rust FFI (`runtime/src/lib.rs`)

- New FFI structs: `RustBatchStatus`, `RustStressResult` (mirrored in `kernel/include/slm_ffi.h`).
- `rust_infer_batch_set_mode(on)` / `_get_mode()` — toggle.
- `rust_infer_batch_set_config(size, timeout_us)` — set threshold + flush timeout (clamped to `[1,32]` × `[100,100000]`).
- `rust_infer_batch_status(out)` — snapshot.
- `rust_infer_batch_reset_stats()` — counter reset for stress runs.
- `rust_infer_stress_run(n_workers, iters, out)` — spawns N task workers, joins via shared atomic, returns aggregated results. One stress run at a time (`STRESS_BUSY`).

### Shell (`kernel/src/shell_sys.c` + `help.c` + `shell.c`)

```
infer batch on|off
infer batch config <size (1..32)> <timeout_us (100..100000)>
infer batch status

bench infer-stress N [iters]
```

`bench infer-stress` reports aggregate req/s, min/avg/max per-iteration latency, and the per-run counter deltas. Loads MNIST automatically.

### Lua (`kernel/src/lua_slm.c`)

- Safe (read-only): `slm.infer_batch_status()`.
- Admin: `slm.infer_batch_mode("on"|"off")`, `slm.infer_batch_config({size, timeout_us})`, `slm.infer_stress(N, iters)`.

### Docs

- `docs/lua.md` adds the four new bindings.
- `docs/shell.md` adds the four new shell entries.
- Framing matches #848: "an optional runtime mode for multi-tenant inference workloads."

## Test plan

- [x] `make test` — 11/11 batch tests pass (7 from #857 + 2 from #859 + 2 new)
- [x] `make kernel PLATFORM=RASPI5` — clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean

## New tests

- **Test 9 — admin FFI round-trip.** `set_mode(0/1)` round-trips through `get_mode`; `set_config(4, 1234)` reflected in `status`; null pointer returns -1.
- **Test 10 — stress workload.** `rust_infer_stress_run(4, 8)` spawns 4 workers × 8 iters, joins, asserts `success_count == 32, error_count == 0`. FFI rejects `n=0`, null output, `iters=0`.

## Notes

- The stress workload is the first call site in the OS that issues concurrent inference requests. Until now, every path (shell, Lua, `component_runtime.c`, bench) was serial. Without this workload, the batching feature has no path that exercises it end-to-end.
- The exact ratio of `batches_full` vs `batches_timeout` vs `singleton_dispatches` reported by a stress run depends on the current `infer batch` configuration — this is the input the #858 hardware-benchmark matrix consumes.

Refs #55, closes #860. Supersedes #889.

🤖 Generated with [Claude Code](https://claude.com/claude-code)