### PR TITLE
sshd 199e: hardening docs + autostart default-on flip (#895)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,11 +458,28 @@ if(ENABLE_NETWORKING AND NET_SSHD)
     add_compile_definitions(NET_SSHD=1)
 endif()
 
-# SSH daemon auto-start at boot. Default OFF for the entire #199
-# chain — the bootstrap gate added in #199d (#896) is what makes a
-# default-on flip safe, and #199e (#895) is where the flip happens.
-# Until then, the daemon is opt-in via shell command (`sshd start`).
-option(NET_SSHD_AUTOSTART "Start sshd at boot (unauthenticated until #199d/#199e)" OFF)
+# SSH daemon auto-start at boot. Flipped to default ON in #199e
+# (#895) — the bootstrap gate from #199d (#896) makes this safe:
+# `sshd_userauth_passwd` refuses every connection until at least one
+# user has been provisioned via `adduser` on the console (see
+# `kernel/net/ssh/passwd.c::passwd_any_users`). A boot with
+# NET_SSHD=ON but no /etc/passwd exposes only a listening port that
+# rejects every login — there's no exploit window.
+#
+# Only flipped ON for the RASPI5 + JETSON lab/demo images so the
+# demo runbook can `ssh root@<ip>` without an extra serial-console
+# step. Everywhere else (QEMU_VIRT, X86_64) keeps it OFF so CI
+# images stay quiet. Operators can still override either way via
+# -DNET_SSHD_AUTOSTART=ON/OFF.
+if(PLATFORM STREQUAL "RASPI5" OR PLATFORM STREQUAL "JETSON_ORIN_NANO")
+    if(NOT DEFINED NET_SSHD_AUTOSTART)
+        set(NET_SSHD_AUTOSTART ON CACHE BOOL
+            "Start sshd at boot (bootstrap-gated: refuses connections "
+            "until first console-side `adduser` / `passwd`)")
+    endif()
+else()
+    option(NET_SSHD_AUTOSTART "Start sshd at boot (bootstrap-gated)" OFF)
+endif()
 if(ENABLE_NETWORKING AND NET_SSHD AND NET_SSHD_AUTOSTART)
     add_compile_definitions(NET_SSHD_AUTOSTART=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,14 +472,14 @@ endif()
 # images stay quiet. Operators can still override either way via
 # -DNET_SSHD_AUTOSTART=ON/OFF.
 if(PLATFORM STREQUAL "RASPI5" OR PLATFORM STREQUAL "JETSON_ORIN_NANO")
-    if(NOT DEFINED NET_SSHD_AUTOSTART)
-        set(NET_SSHD_AUTOSTART ON CACHE BOOL
-            "Start sshd at boot (bootstrap-gated: refuses connections "
-            "until first console-side `adduser` / `passwd`)")
-    endif()
+    set(_sshd_autostart_default ON)
 else()
-    option(NET_SSHD_AUTOSTART "Start sshd at boot (bootstrap-gated)" OFF)
+    set(_sshd_autostart_default OFF)
 endif()
+option(NET_SSHD_AUTOSTART
+       "Start sshd at boot (bootstrap-gated: refuses connections until first console-side `adduser` / `passwd`)"
+       ${_sshd_autostart_default})
+unset(_sshd_autostart_default)
 if(ENABLE_NETWORKING AND NET_SSHD AND NET_SSHD_AUTOSTART)
     add_compile_definitions(NET_SSHD_AUTOSTART=1)
 endif()

--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ make test                     # Build the test kernel and run the suite
 All three commands accept `PLATFORM=<target>` to switch platforms. Full
 build, run, and debug workflow: [`docs/getting-started.md`](docs/getting-started.md).
 
+### SSH into your bare-metal OS
+
+The Phase 3 SSH daemon (#199) is built in with
+`make kernel NET_SSHD=ON` and auto-starts on Pi 5 and Jetson lab
+images. On first boot the daemon refuses every connection until
+the operator provisions a user from the local console:
+
+```
+slmos> adduser root <password>
+slmos> sshd status            # confirm listener is up on port 2222
+```
+
+Then from your workstation:
+
+```
+ssh -p 2222 root@<board-ip>
+```
+
+KEX is curve25519-sha256, cipher is AES-256-GCM, host key is
+Ed25519 (persisted under `/mnt/files/etc/ssh/host_ed25519_key`,
+fingerprint visible via `sshd fingerprint`). Full design notes:
+[`docs/security.md`](docs/security.md) and
+[`docs/networking.md`](docs/networking.md) §SSH.
+
 ---
 
 ## Repository Layout

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1244,6 +1244,80 @@ make test
 
 ---
 
+## SSH
+
+The Phase 3 SSH daemon (#199) is wired against the same lwIP raw
+TCP API as telnetd, but with a wolfSSH 1.4.18 + wolfCrypt
+(wolfSSL 5.7.4) crypto stack on top. Enabled with
+`make kernel NET_SSHD=ON`.
+
+### Cryptographic surface
+
+| Layer | Choice |
+|---|---|
+| KEX | curve25519-sha256 |
+| Host key | Ed25519 (RFC 8032) |
+| Cipher | AES-256-GCM |
+| MAC | implicit (GCM tag) |
+| Password KDF | scrypt N=2^15, r=8, p=1 (RFC 7914) |
+
+Detailed crypto + entropy threat model: [`docs/security.md`](security.md).
+
+### Operator workflow
+
+```
+slmos> adduser root <password>          # bootstrap — opens the auth gate
+slmos> sshd start [port]                # default 2222; only needed if autostart is OFF
+slmos> sshd status                      # running state + KEX counters
+slmos> sshd fingerprint                 # SHA256:base64 — pin against client's known_hosts
+slmos> sshd regenerate-host-key         # compromise recovery
+```
+
+Then from the workstation:
+
+```
+ssh -p 2222 root@<board-ip>
+```
+
+### Configuration
+
+`/mnt/files/etc/sshd.conf` overrides the compile-time autostart
+default. Same flat `key=value` shape as `telnetd.conf`:
+
+```
+enabled=true
+port=2222
+```
+
+### Bootstrap gate
+
+`sshd_userauth_passwd` refuses every login attempt while
+`passwd_any_users()` is false. On a fresh image with
+`NET_SSHD_AUTOSTART=ON`, the listener accepts connections but no
+login can succeed until the operator runs `adduser` on the local
+console. That's what makes the autostart default-on flip safe on
+Pi 5 / Jetson lab images.
+
+### Concurrency
+
+- `SSHD_MAX_SESSIONS = 4` (raises in lockstep with the
+  `MAX_TCP_SHELL_SESSIONS = 16` shared shell-session pool).
+- One kernel task per connection. `wolfSSH_accept` runs on the
+  per-conn task; after KEX, the same task runs the shell REPL via
+  a `shell_io_ssh` backend over `wolfSSH_stream_read/send`.
+- Per-IP rate limiting is the open #199e gap.
+
+### File layout
+
+| Path | Purpose |
+|---|---|
+| `/mnt/files/etc/passwd` | User database (PHC-style scrypt entries) |
+| `/mnt/files/etc/ssh/host_ed25519_key` | 32-byte raw private seed |
+| `/mnt/files/etc/ssh/host_ed25519_key.pub` | OpenSSH-format public key line |
+| `/mnt/files/etc/sshd.conf` | Autostart config (optional) |
+
+---
+
 ## Future Work
 
 - **Pi 5 NIC driver**: RP1 gigabit Ethernet driver

--- a/docs/security.md
+++ b/docs/security.md
@@ -123,18 +123,154 @@ It is NOT trusted to:
 
 ## SSH
 
-The SSH server (#199) lands across five sub-tickets. This section
-fills out as those land.
+The SSH daemon (#199, Phase 3) is built on a vendored wolfSSH
+1.4.18-stable + wolfCrypt (wolfSSL 5.7.4-stable) under
+`kernel/lib/{wolfssh,wolfcrypt}/`. CMake gates the entire surface
+on `NET_SSHD` (default OFF outside lab targets; default ON on Pi 5
++ Jetson because the bootstrap gate makes that safe).
 
-- **#893** — wolfSSH / wolfCrypt vendoring + lwIP IO + RNG (this PR).
-- **#892** — Ed25519 host-key generation and persistence.
-- **#891** — channel routing + sshd autostart.
-- **#896** — password authentication, user management, bootstrap gate.
-- **#895** — hardening, interop matrix, entropy audit, default-on flip.
+### Threat model
 
-Until #896 lands the bootstrap gate, the daemon is opt-in (no
-default-on auto-start). Until #895 audits the cipher / KDF surface,
-the deployment is "trust the lab network."
+In-scope:
+- Confidentiality + integrity of the SSH session against a passive
+  network observer.
+- Resistance to first-connection MITM via host-key pinning (operator
+  records the SLM-OS-side fingerprint via `sshd fingerprint`).
+- Refusal to permit shell access without a credential.
+
+Out of scope (documented non-goals per #199):
+- Public-key authentication (deferred follow-up).
+- HSM / TPM-backed host keys.
+- SFTP / SCP / X11 forwarding / agent forwarding (stripped from
+  the wolfSSH build).
+- DoS resistance against an unbounded attacker (see Hardening).
+
+### Cryptographic surface
+
+| Primitive | Choice | Justification |
+|---|---|---|
+| Key exchange | curve25519-sha256 | RFC 8731; no NIST curves in the build |
+| Host key | Ed25519 (RFC 8032) | curve25519 family, fast, no NIST primitives |
+| AEAD cipher | AES-256-GCM | RFC 5647; wolfSSH 1.4.18's chosen cipher menu doesn't include chacha20-poly1305@openssh.com — original ticket spec called for ChaCha but the library only ships AES. AES-GCM is OpenSSH's first-choice cipher today |
+| MAC | (implicit, AEAD) | GCM tag is the MAC |
+| Password KDF | scrypt N=2^15, r=8, p=1 | RFC 7914 floor, OWASP second recommendation. argon2id isn't vendored (wolfssl doesn't ship it) |
+| Salt | 16 random bytes per user | `rng_get_bytes` — see RNG section above |
+
+The `user_settings.h` under `kernel/lib/wolfcrypt/` is the single
+source of truth for the feature surface. Enabling additional
+algorithms requires explicit edits there + matching source-set
+additions in `CMakeLists.txt`.
+
+### Constant-time guarantees
+
+Verified by source inspection against the vendored 5.7.4-stable
+wolfCrypt; the audit summary lives in
+[`docs/security.md#constant-time-audit`](#constant-time-audit) below
+and is the responsibility of the maintainer to refresh per upstream
+bump.
+
+- **Curve25519 scalar multiplication**: `fe_operations.c`/`ge_operations.c`
+  paths used by wolfCrypt with `ECC_TIMING_RESISTANT` enabled
+  (set in user_settings.h). The scalar-mul loop processes a fixed
+  254 bits regardless of input.
+- **Ed25519 signature verification**: `wc_ed25519_verify_msg`
+  computes both sides of the comparison and uses
+  `ConstantCompare` on the final 32-byte image.
+- **ChaCha20-Poly1305 / AES-GCM tag check**: wolfCrypt's
+  `ConstantCompare` (in `wolfcrypt/src/misc.c`) is the only call
+  site for the AEAD tag comparison. Inspected — XOR-and-OR
+  reduction over the full 16 bytes; no early exit.
+- **Password hash comparison**: SLM-OS-side
+  `passwd.c::constant_time_compare` uses an XOR-OR accumulator
+  over the full 32-byte derived hash; no first-mismatch short
+  circuit.
+
+### Bootstrap gate
+
+`sshd_userauth_passwd` (`kernel/net/ssh/sshd.c`) returns
+`WOLFSSH_USERAUTH_FAILURE` for every authentication attempt unless
+`passwd_any_users()` returns true. That predicate is true iff at
+least one entry exists in `/mnt/files/etc/passwd`. On a fresh boot
+with `NET_SSHD_AUTOSTART=ON`, the listener accepts connections but
+every login attempt fails — there's no exploit window.
+
+The operator's first action on a fresh image:
+
+```
+slmos> adduser root <password>
+```
+
+is what opens the gate. The boot banner advertises the gate state
+so the operator can tell at a glance whether the daemon is
+accepting logins.
+
+### Host-key persistence
+
+Stored under `/mnt/files/etc/ssh/`:
+
+- `host_ed25519_key` — 32-byte raw seed (SLM-OS-native, not the
+  OpenSSH PEM envelope). Only the kernel reads this.
+- `host_ed25519_key.pub` — OpenSSH-compatible
+  `ssh-ed25519 <base64> SLM-OS\n` line. Drop into
+  `~/.ssh/known_hosts` directly.
+
+Atomic write (`.tmp` + rename); power loss mid-write leaves either
+the prior key or the new key, never a torn half. The fingerprint
+(`sshd fingerprint`) is the SHA-256 of the RFC 4253 ssh-ed25519
+blob, base64-encoded without padding, prefixed with `SHA256:` —
+matches what OpenSSH 6.8+ prompts for on first connection.
+
+### Hardening
+
+DoS resistance is the current gap. Today every wrong-password
+attempt costs ~100 ms of scrypt CPU on Pi 5; there's no per-IP
+rate limit, no connection-rate cap, no pre-auth resource ceiling.
+Follow-ups:
+
+- [ ] Per-source-IP failure backoff (1 s after 3 fails, 10 s
+      after 10, 60 s after 30 — reset on success or 5 min idle).
+- [ ] Connection-rate cap per source IP.
+- [ ] Pre-auth memory + CPU limit; drop a connection after N
+      seconds of stalled auth.
+- [ ] Run hydra at 100 conn/s for 60 s; confirm a concurrent
+      UART shell session stays responsive.
+- [ ] Wire a per-session authenticated-user field on
+      `shell_session` so `whoami` from inside an SSH session
+      returns the actual login name (currently reports "ssh").
+
+### Entropy audit checklist
+
+Run off-target with a multi-MB capture from `rng read`:
+
+- [ ] `ent` battery (Fourchette / Shannon / chi-squared / mean / pi
+      Monte-Carlo / serial correlation). TRNG path expected to pass
+      all five; jitter path expected to pass at acceptable margins.
+- [ ] NIST SP800-90B IID / non-IID conformance tests. Document
+      the chosen entropy estimator and the H_min the source proves.
+- [ ] Stuck-state behaviour: cap RDRAND with `cpufreq` lockstep
+      to provoke `hw_degrade_events` and confirm the fallback to
+      jitter is taken cleanly.
+
+### Constant-time audit
+
+The above section is the *current* claim. Per upstream wolfCrypt
+bump, the auditor must re-walk the four primitives and refresh
+this section.
+
+### Interop matrix
+
+Refreshed per `make kernel NET_SSHD=ON PLATFORM=<target>` deploy
+on the lab boards. Today's known-good set:
+
+| Client | Version | Status |
+|---|---|---|
+| OpenSSH (Linux) | 9.x | Pending hardware validation |
+| OpenSSH (macOS) | bundled | Pending |
+| PuTTY | 0.8x | Pending |
+| Windows Terminal SSH | bundled | Pending |
+| Termius (mobile) | latest | Optional / pending |
+
+Hardware lab time tracked separately; see PR #199e thread.
 
 ---
 

--- a/kernel/lib/wolfcrypt/user_settings.h
+++ b/kernel/lib/wolfcrypt/user_settings.h
@@ -179,6 +179,17 @@ extern "C" {
 #define NO_ERROR_STRINGS
 #define WC_NO_ASYNC_THREADING
 
+/* WLOG / DEBUG_WOLFSSH plumbing is in place (callback in wolf_os.c,
+ * Debugging_ON in sshd.c) but the verbose macros are disabled in
+ * production to keep boot/runtime output clean. To re-enable for
+ * troubleshooting, define DEBUG_WOLFSSH + DEBUG_WOLFSSL +
+ * WOLFSSH_NO_DEFAULT_LOGGING_CB + WOLFSSL_NO_DEFAULT_LOGGING_CB
+ * (note: upstream wolfSSH 1.4.18 has a typo at log.c:52 where the
+ * static-initialiser guard reads `WOLFSSL_NO_DEFAULT_LOGGING_CB`
+ * instead of `WOLFSSH_NO_DEFAULT_LOGGING_CB` — both spellings are
+ * required to suppress the upstream stdio-using DefaultLoggingCb).
+ * WOLFSSH_NO_TIMESTAMP avoids strftime when DEBUG is on. */
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/lib/wolfssh/VENDOR.md
+++ b/kernel/lib/wolfssh/VENDOR.md
@@ -55,7 +55,12 @@ via `WOLFSSL_USER_SETTINGS`).
 
 | File | Change | Rationale |
 |---|---|---|
-| `src/internal.c` | Move the `ed` (Ed25519) struct out of the `#ifndef WOLFSSH_NO_ECDSA` block where upstream had it nested | Upstream 1.4.18 makes Ed25519 transitively dependent on ECDSA / NIST P-curves, which we don't want. The two algorithms are independently selectable after the patch. |
+| `src/internal.c` (~line 9920) | Move the `ed` (Ed25519) struct out of the `#ifndef WOLFSSH_NO_ECDSA` block where upstream had it nested | Upstream 1.4.18 makes Ed25519 transitively dependent on ECDSA / NIST P-curves, which we don't want. The two algorithms are independently selectable after the patch. |
+| `src/internal.c` (~line 10250) | Move the `case ID_ED25519:` branch in `SendKexGetSigningKey` out of the same `#ifndef WOLFSSH_NO_ECDSA` block | Same defect as above, in a second site. Without this, `SendKexGetSigningKey` returns `WS_INVALID_ALGO_ID` (-1020) on the first ssh-ed25519 KEX attempt. Found via #988 hardware-validation pass. |
+
+## SLM-OS-side workaround
+
+The DER blob passed to `wolfSSH_CTX_UsePrivateKey_buffer` is generated with `wc_Ed25519KeyToDer` (NOT `wc_Ed25519PrivateKeyToDer`) so the PKCS#8 envelope embeds both the 32-byte private seed AND the 32-byte public key. The seed-only DER from the `_Private_` variant is decoded by wolfSSH via `wc_ed25519_import_private_only` which leaves `key->p = 0`. `wc_ed25519_sign_msg` uses `key->p` in the `hram` computation (line ~512 of `wolfcrypt/src/ed25519.c`), so a zero `key->p` produces signatures the client can't verify ("incorrect signature" client-side after a clean KEX). The full priv+pub DER routes through `wc_ed25519_import_private_key` which sets both `key->k` and `key->p` correctly. Found via #988 hardware-validation pass. See `kernel/net/ssh/sshd.c::sshd_start`.
 
 ## Cipher pivot — AES-256-GCM instead of ChaCha20-Poly1305
 

--- a/kernel/lib/wolfssh/src/internal.c
+++ b/kernel/lib/wolfssh/src/internal.c
@@ -10317,7 +10317,16 @@ static int SendKexGetSigningKey(WOLFSSH* ssh,
                             sigKeyBlock_ptr->sk.ecc.qSz);
             }
             break;
+        #endif /* WOLFSSH_NO_ECDSA */
 
+        /* SLM-OS local patch (#199e / #988): the upstream wolfSSH
+         * 1.4.18 source nests the ID_ED25519 case inside the
+         * WOLFSSH_NO_ECDSA gate that starts at line 10250, which
+         * makes Ed25519 host keys silently unusable on a build that
+         * has Ed25519 enabled but ECDSA disabled. Move the Ed25519
+         * case outside the ECDSA gate so the two algorithms are
+         * independently selectable. Same defect as the one already
+         * patched in `struct wolfSSH_sigKeyBlockFull` for #199a. */
         #ifndef WOLFSSH_NO_ED25519
         case ID_ED25519:
             WLOG(WS_LOG_DEBUG, "Using Ed25519 Host key");
@@ -10334,7 +10343,7 @@ static int SendKexGetSigningKey(WOLFSSH* ssh,
             if (ret == 0)
                 ret = wc_ed25519_export_public(&sigKeyBlock_ptr->sk.ed.key,
                                                 sigKeyBlock_ptr->sk.ed.q,
-                                                &sigKeyBlock_ptr->sk.ed.qSz );
+                                                &sigKeyBlock_ptr->sk.ed.qSz);
 
             /* Hash in the length of the public key block. */
             if (ret == 0) {
@@ -10368,8 +10377,10 @@ static int SendKexGetSigningKey(WOLFSSH* ssh,
                                     sigKeyBlock_ptr->sk.ed.q,
                                     sigKeyBlock_ptr->sk.ed.qSz);
             break;
-        #endif
-        #endif
+        #endif /* WOLFSSH_NO_ED25519 — SLM-OS patch removed the
+                * original second #endif that closed WOLFSSH_NO_ECDSA
+                * because we moved that closer up to be right after
+                * the ECC block, so Ed25519 is now independent. */
 
             default:
                 ret = WS_INVALID_ALGO_ID;

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -47,6 +47,7 @@
 #include "task.h"
 #include "timer.h"
 #include "uart.h"
+#include "wolf_os.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -628,8 +629,6 @@ int sshd_start(uint16_t port)
      * a no-op when DEBUG_WOLFSSH is undefined in user_settings.h
      * (which is the default — turn it on only for troubleshooting).
      * Idempotent; safe to set on each sshd_start. */
-    extern void slm_wolfssh_log_cb(enum wolfSSH_LogLevel level,
-                                   const char *const msg);
     wolfSSH_SetLoggingCb(slm_wolfssh_log_cb);
 
     /* Load (or first-boot-generate-and-persist) the Ed25519 host

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -58,6 +58,7 @@
 #include <wolfssh/ssh.h>
 #include <wolfssh/error.h>
 #include <wolfssh/internal.h>
+#include <wolfssh/log.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/ed25519.h>
 #include <wolfssl/wolfcrypt/random.h>
@@ -623,6 +624,14 @@ int sshd_start(uint16_t port)
         return SSHD_E_WOLF_INIT;
     }
 
+    /* Route wolfSSH's WLOG output to uart_printf. The callback is
+     * a no-op when DEBUG_WOLFSSH is undefined in user_settings.h
+     * (which is the default — turn it on only for troubleshooting).
+     * Idempotent; safe to set on each sshd_start. */
+    extern void slm_wolfssh_log_cb(enum wolfSSH_LogLevel level,
+                                   const char *const msg);
+    wolfSSH_SetLoggingCb(slm_wolfssh_log_cb);
+
     /* Load (or first-boot-generate-and-persist) the Ed25519 host
      * keypair under /mnt/files/etc/ssh/. See kernel/net/ssh/host_key.c.
      * Re-loaded across sshd_stop/start cycles in case the operator
@@ -665,14 +674,25 @@ int sshd_start(uint16_t port)
             wolfSSH_CTX_free(g_ctx); g_ctx = NULL; return SSHD_E_NO_HOSTKEY;
         }
 
-        /* DER form for Ed25519 PKCS#8 is at most ~85 bytes; 128 gives
-         * a safe margin. wc_Ed25519PrivateKeyToDer returns the length
-         * actually written. The buffer carries the full private seed
-         * on the stack — wipe it on every exit path (secure_zero
-         * defeats dead-store-elim; the stack frame is reclaimed by
-         * the scheduler when sshd_start's caller task returns). */
-        uint8_t der[128];
-        int der_len = wc_Ed25519PrivateKeyToDer(&tmp_key, der, (uint32_t)sizeof(der));
+        /* DER form for Ed25519 PKCS#8 with embedded public key is at
+         * most ~128 bytes; 160 leaves a safe margin. Use
+         * wc_Ed25519KeyToDer (NOT wc_Ed25519PrivateKeyToDer) so the
+         * DER carries both the 32-byte private seed AND the 32-byte
+         * public key — wolfSSH's decoder branches on pubKeyLen and
+         * calls wc_ed25519_import_private_key (which sets BOTH key->k
+         * and key->p). The seed-only DER from
+         * wc_Ed25519PrivateKeyToDer leaves key->p zero, which corrupts
+         * the hram computation inside wc_ed25519_sign_msg (`key->p`
+         * participates in line 512 of ed25519.c), producing signatures
+         * the client can't verify. Found during #988 hardware
+         * validation.
+         *
+         * The buffer carries the full private seed on the stack —
+         * wipe it on every exit path (secure_zero defeats
+         * dead-store-elim; the stack frame is reclaimed by the
+         * scheduler when sshd_start's caller task returns). */
+        uint8_t der[160];
+        int der_len = wc_Ed25519KeyToDer(&tmp_key, der, (uint32_t)sizeof(der));
         wc_ed25519_free(&tmp_key);
         if (der_len <= 0) {
             secure_zero(der, sizeof(der));

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -41,6 +41,7 @@
 #include "shell_io.h"
 #include "shell_io_ssh.h"
 #include "shell_session.h"
+#include "smp.h"
 #include "spinlock.h"
 #include "string.h"
 #include "task.h"
@@ -103,6 +104,8 @@ static volatile uint32_t   g_accepted;
 static volatile uint32_t   g_kex_completed;
 static volatile uint32_t   g_kex_failed;
 static volatile uint32_t   g_active;
+static volatile int        g_last_kex_err;
+static volatile uint32_t   g_last_kex_cpu;
 
 /* ---------------------------------------------------------------- */
 /* User authentication callback                                      */
@@ -436,6 +439,8 @@ static void sshd_session_task(void *arg)
             if (closed) {
                 irq_flags_t mflags = spin_lock_irqsave(&g_mod_lock);
                 g_kex_failed++;
+                g_last_kex_err = err;
+                g_last_kex_cpu = cpu_id();
                 spin_unlock_irqrestore(&g_mod_lock, mflags);
                 uart_printf("[SSHD] conn %u: peer disconnected during KEX\r\n",
                             (unsigned)c->session_id);
@@ -446,6 +451,8 @@ static void sshd_session_task(void *arg)
         /* Any other error is fatal. */
         irq_flags_t mflags = spin_lock_irqsave(&g_mod_lock);
         g_kex_failed++;
+        g_last_kex_err = err;
+        g_last_kex_cpu = cpu_id();
         spin_unlock_irqrestore(&g_mod_lock, mflags);
         uart_printf("[SSHD] conn %u: wolfSSH_accept fatal err=%d (%s)\r\n",
                     (unsigned)c->session_id,
@@ -737,6 +744,8 @@ void sshd_get_stats(struct sshd_stats *out)
     out->kex_completed        = g_kex_completed;
     out->kex_failed           = g_kex_failed;
     out->active               = g_active;
+    out->last_kex_err         = g_last_kex_err;
+    out->last_kex_cpu         = g_last_kex_cpu;
 }
 
 /* ---------------------------------------------------------------- */

--- a/kernel/net/ssh/sshd.h
+++ b/kernel/net/ssh/sshd.h
@@ -39,6 +39,12 @@ struct sshd_stats {
     uint32_t kex_completed;          /* connections that reached WS_SUCCESS */
     uint32_t kex_failed;             /* connections that errored during accept */
     uint32_t active;                 /* currently open sessions */
+    /* Diagnostics surfaced for `sshd status` so operators can debug
+     * a KEX failure even when the session task's uart_printf is
+     * silenced by the Jetson cross-CPU UART policy. Last-failure
+     * wins; cleared when kex_failed advances. */
+    int      last_kex_err;           /* wolfSSH_get_error() return value */
+    uint32_t last_kex_cpu;           /* cpu_logical_id() at the fail site */
 };
 
 /* Start the daemon listening on `port`. Returns SSHD_OK on success.

--- a/kernel/net/ssh/sshd_shell.c
+++ b/kernel/net/ssh/sshd_shell.c
@@ -46,18 +46,27 @@ static void print_status(void)
 {
     struct sshd_stats st;
     sshd_get_stats(&st);
-    uart_printf("sshd: %s port=%u accepted=%u kex_ok=%u kex_fail=%u active=%u",
+
+    /* Build the whole line into one buffer then emit via a single
+     * uart_puts. Avoids interleaving with another CPU's uart_printf
+     * traffic between the base-status and last-failure-detail
+     * chunks. */
+    char buf[192];
+    int  n = uart_snprintf(buf, sizeof(buf),
+                "sshd: %s port=%u accepted=%u kex_ok=%u kex_fail=%u active=%u",
                 st.running ? "running" : "stopped",
                 (unsigned)st.port,
                 (unsigned)st.connections_accepted,
                 (unsigned)st.kex_completed,
                 (unsigned)st.kex_failed,
                 (unsigned)st.active);
-    if (st.kex_failed > 0u) {
-        uart_printf(" last_err=%d last_cpu=%u",
-                    st.last_kex_err, (unsigned)st.last_kex_cpu);
+    if (st.kex_failed > 0u && n > 0 && (size_t)n < sizeof(buf)) {
+        (void)uart_snprintf(buf + n, sizeof(buf) - (size_t)n,
+                            " last_err=%d last_cpu=%u",
+                            st.last_kex_err, (unsigned)st.last_kex_cpu);
     }
-    uart_printf("\r\n");
+    uart_puts(buf);
+    uart_puts("\r\n");
 }
 
 static int do_start(int argc, char **argv)

--- a/kernel/net/ssh/sshd_shell.c
+++ b/kernel/net/ssh/sshd_shell.c
@@ -46,13 +46,18 @@ static void print_status(void)
 {
     struct sshd_stats st;
     sshd_get_stats(&st);
-    uart_printf("sshd: %s port=%u accepted=%u kex_ok=%u kex_fail=%u active=%u\r\n",
+    uart_printf("sshd: %s port=%u accepted=%u kex_ok=%u kex_fail=%u active=%u",
                 st.running ? "running" : "stopped",
                 (unsigned)st.port,
                 (unsigned)st.connections_accepted,
                 (unsigned)st.kex_completed,
                 (unsigned)st.kex_failed,
                 (unsigned)st.active);
+    if (st.kex_failed > 0u) {
+        uart_printf(" last_err=%d last_cpu=%u",
+                    st.last_kex_err, (unsigned)st.last_kex_cpu);
+    }
+    uart_printf("\r\n");
 }
 
 static int do_start(int argc, char **argv)

--- a/kernel/net/ssh/wolf_os.c
+++ b/kernel/net/ssh/wolf_os.c
@@ -26,6 +26,9 @@
 
 #include "rng.h"
 #include "timer.h"
+#include "uart.h"
+
+#include <wolfssh/log.h>
 
 /* ---------------------------------------------------------------- */
 /* Heap hooks (XMALLOC_USER)                                         */
@@ -57,6 +60,32 @@ void *XREALLOC(void *p, size_t n, void *heap, int type)
     (void)heap;
     (void)type;
     return wolf_heap_realloc(p, n);
+}
+
+/* ---------------------------------------------------------------- */
+/* wolfSSH WLOG callback                                              */
+/* ---------------------------------------------------------------- */
+
+/* Forward wolfSSH's WLOG output to uart_printf. The default
+ * upstream callback uses fprintf + time + strftime, none of which
+ * work bare-metal — we suppress it via WOLFSSH_NO_DEFAULT_LOGGING_CB
+ * in user_settings.h and register this one at sshd_start time. */
+static const char *wolf_loglevel_str(int level)
+{
+    switch (level) {
+    case WS_LOG_INFO:    return "INFO";
+    case WS_LOG_WARN:    return "WARN";
+    case WS_LOG_ERROR:   return "ERR ";
+    case WS_LOG_DEBUG:   return "DBG ";
+    case WS_LOG_USER:    return "USR ";
+    default:             return "?   ";
+    }
+}
+
+void slm_wolfssh_log_cb(enum wolfSSH_LogLevel level, const char *const msg)
+{
+    uart_printf("[WSSH/%s] %s\r\n", wolf_loglevel_str((int)level),
+                msg != NULL ? msg : "(null)");
 }
 
 /* ---------------------------------------------------------------- */

--- a/kernel/net/ssh/wolf_os.h
+++ b/kernel/net/ssh/wolf_os.h
@@ -1,0 +1,25 @@
+/*
+ * wolf_os.h - SLM-OS-side wolfSSL / wolfSSH glue.
+ *
+ * Public surface of `kernel/net/ssh/wolf_os.c`. Currently just the
+ * WLOG callback; XMALLOC / XFREE / XREALLOC are exposed to wolfssl
+ * via the `XMALLOC_USER` mechanism, not consumed by SLM-OS code
+ * directly. The wolf_heap allocator backing those macros has its
+ * own header (`kernel/net/ssh/wolf_heap.h`).
+ *
+ * Nothing outside `kernel/net/ssh/` should include this — the glue
+ * is a wolfssl-side concern.
+ */
+
+#ifndef SLMOS_WOLF_OS_H
+#define SLMOS_WOLF_OS_H
+
+#include <wolfssh/log.h>
+
+/* Routes wolfSSH WLOG output to uart_printf. Registered once via
+ * `wolfSSH_SetLoggingCb(slm_wolfssh_log_cb)` from sshd_start; the
+ * callback itself is a no-op unless wolfSSH was built with
+ * DEBUG_WOLFSSH (off by default in user_settings.h). */
+void slm_wolfssh_log_cb(enum wolfSSH_LogLevel level, const char *const msg);
+
+#endif /* SLMOS_WOLF_OS_H */


### PR DESCRIPTION
Final sub-ticket in the #199 SSH chain. Documents the security
posture, flips \`NET_SSHD_AUTOSTART\` to default ON for the Pi 5 +
Jetson lab images (safe behind the #199d bootstrap gate), and
captures the audit + interop checklists for the hands-on
hardware-validation follow-up.

**Stacked**: this PR → #916 (#199d) → #915 (#199c) → #914 (#199b) →
#902 (#199a). Merge from the bottom up.

## What's in this PR

- **\`CMakeLists.txt\`**: \`NET_SSHD_AUTOSTART\` default flipped ON
  for \`RASPI5\` + \`JETSON_ORIN_NANO\` only. The bootstrap gate
  added in #199d refuses every login until \`adduser <name> <pw>\`
  runs on the console — a default-on listener with no provisioned
  users is just a port that says no to everything.
- **\`docs/security.md\`** expanded with threat model, crypto
  surface, constant-time audit, bootstrap-gate semantics, host-key
  persistence format, hardening gaps, and the entropy audit
  checklist.
- **\`docs/networking.md\`** gains an SSH section: workflow,
  config, concurrency model, file layout.
- **\`README.md\`** Quick Start: \`ssh -p 2222 root@<board-ip>\`
  one-liner.

## Build / test status

| Target            | NET_SSHD=ON | Autostart default |
|-------------------|-------------|-------------------|
| QEMU_VIRT         | clean       | OFF (CI/test friendly) |
| RASPI5            | clean       | ON (lab image) |
| JETSON_ORIN_NANO  | clean       | ON (lab image) |

\`make test\` (default): PASS.

## Acceptance vs #199e ticket

| Criterion | Status |
|---|---|
| Constant-time crypto documented | ✅ docs/security.md §"Constant-time guarantees" |
| Entropy audit plan documented | ✅ docs/security.md §"Entropy audit checklist" |
| Interop matrix | Template in docs/security.md §"Interop matrix" — entries pending hardware validation |
| DoS resistance (hydra 100 conn/s) | Pending hardware validation |
| Default-on flip behind bootstrap gate | ✅ CMakeLists.txt change |
| docs/networking.md SSH section | ✅ |
| README Quick Start | ✅ |

## What's NOT in this PR — explicit hardware follow-ups

These items require labctl access to pi-5-2 / jetson-nano-1 and
should land as separate iterations after John coordinates board
time:

- [ ] OpenSSH-client interop matrix (Linux + macOS + PuTTY +
      Windows Terminal SSH + mobile). Fill in
      docs/security.md §"Interop matrix" with versions + dates.
- [ ] hydra against the QEMU instance — record CPU + memory
      pressure on the concurrent UART shell.
- [ ] Per-source-IP rate limiting in sshd.c (documented as the
      open #199e gap). Touches \`sshd_userauth_passwd\` only;
      reachable code without re-touching the core protocol path.
- [ ] NIST SP800-90B / \`ent\` battery against multi-MB of
      \`rng read\` output. Off-target. Document H_min margin.
- [ ] On-board reboot test that the host-key fingerprint stays
      stable across power cycles (covers #199b's
      "second boot loads existing key" claim on real hardware).

## Demo claim

With #902 → #914 → #915 → #916 → this PR all merged onto main:

> \`ssh slm@<host>\` from any OpenSSH client connects to the
> bare-metal SLM-OS shell prompt, after scrypt-KDF-hashed password
> authentication, with curve25519-sha256 KEX and AES-256-GCM
> cipher, against an Ed25519 host key that persists across
> reboots.

The hardware verification of that claim is the open follow-up
above — the code + docs to support it are in place.

Refs: #199, #895