### PR TITLE
hailo-re-driver: persist serial-tail in batch log on replay-step failure

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -73,6 +73,13 @@ class LoopConfig:
     reachable: rollback_mod.SHA_REACHABLE = field(
         default_factory=rollback_mod.git_reachable_from_main
     )
+    # How many trailing lines of the captured serial buffer to include
+    # in a batch log when replay-step fails. 30 covers the typical
+    # pre-shell window (kernel banner + driver inits + network init +
+    # shell start) without spamming the wrapper log on every transient.
+    # Bumping this in a future investigation is the easiest knob to
+    # turn for a single failing batch.
+    replay_error_stdout_tail_lines: int = 30
 
 
 def response_to_entry(
@@ -211,16 +218,16 @@ def _extend_corpus(
         # is undiagnosable — the captured 45 s of Pi 5 serial output
         # tells the operator whether the board hung pre-shell, emitted
         # a different prompt, kernel-panicked, or just booted slowly.
-        # 30 lines is enough to cover the typical pre-shell window
-        # (kernel banner + driver inits + network init + shell start)
-        # without spamming the batch log on every transient.
-        stdout_tail = _tail_lines(result.stdout, 30)
+        # Tail-length lives on LoopConfig so a single investigation can
+        # crank it up without editing source.
+        tail_n = cfg.replay_error_stdout_tail_lines
+        stdout_tail = _tail_lines(result.stdout, tail_n)
         return _StepOutcome(
             status="error",
             detail=(
                 f"replay-step failed: {result.message}\n"
                 f"stderr: {result.stderr}\n"
-                f"stdout tail (last 30 lines):\n{stdout_tail}"
+                f"stdout tail (last {tail_n} lines):\n{stdout_tail}"
             ),
         )
 

--- a/host-tools/hailo-re-driver/hailo_re_driver/loop.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/loop.py
@@ -206,9 +206,22 @@ def _extend_corpus(
             pass
 
     if isinstance(result, ReplayError):
+        # Surface the tail of the captured serial buffer in the batch
+        # log. Without it, "did not see shell prompt after flash+reboot"
+        # is undiagnosable — the captured 45 s of Pi 5 serial output
+        # tells the operator whether the board hung pre-shell, emitted
+        # a different prompt, kernel-panicked, or just booted slowly.
+        # 30 lines is enough to cover the typical pre-shell window
+        # (kernel banner + driver inits + network init + shell start)
+        # without spamming the batch log on every transient.
+        stdout_tail = _tail_lines(result.stdout, 30)
         return _StepOutcome(
             status="error",
-            detail=f"replay-step failed: {result.message}\nstderr: {result.stderr}",
+            detail=(
+                f"replay-step failed: {result.message}\n"
+                f"stderr: {result.stderr}\n"
+                f"stdout tail (last 30 lines):\n{stdout_tail}"
+            ),
         )
 
     if isinstance(result, ReplayDivergence):
@@ -338,6 +351,20 @@ def _ends_with_newline(path: Path) -> bool:
         except OSError:
             return True  # empty file — nothing to terminate
         return f.read(1) == b"\n"
+
+
+def _tail_lines(text: str, n: int) -> str:
+    """Return the last `n` lines of `text` (or all of it if shorter).
+    Trailing newline normalised away to avoid a doubled blank line when
+    the caller appends to a larger log entry. An empty input becomes
+    the sentinel "<empty>" so a future reader can tell "we did capture
+    but it was blank" apart from "we never tried to capture"."""
+    if not text:
+        return "<empty>"
+    lines = text.splitlines()
+    if len(lines) <= n:
+        return "\n".join(lines)
+    return "\n".join(lines[-n:])
 
 
 # Internal step outcome that carries forward into the top-level LoopOutcome.

--- a/host-tools/hailo-re-driver/tests/test_loop_mocked.py
+++ b/host-tools/hailo-re-driver/tests/test_loop_mocked.py
@@ -493,5 +493,99 @@ class WritePendingCorpusCleanupTests(unittest.TestCase):
                 pending_path.unlink(missing_ok=True)
 
 
+class TailLinesTests(unittest.TestCase):
+    """Pin behavioural details of the helper used to surface serial
+    output on replay-step failure. The exact tail count and the
+    empty-string sentinel are part of the operator-visible log format,
+    so worth pinning explicitly."""
+
+    def test_returns_all_lines_when_shorter_than_n(self) -> None:
+        out = loop_mod._tail_lines("alpha\nbeta\ngamma\n", 30)
+        self.assertEqual(out, "alpha\nbeta\ngamma")
+
+    def test_returns_last_n_when_longer(self) -> None:
+        text = "\n".join(f"line {i}" for i in range(100)) + "\n"
+        out = loop_mod._tail_lines(text, 5)
+        self.assertEqual(out, "line 95\nline 96\nline 97\nline 98\nline 99")
+
+    def test_empty_input_returns_sentinel(self) -> None:
+        # Distinguish "captured nothing" from "didn't capture" in the
+        # batch log; future readers shouldn't have to guess.
+        self.assertEqual(loop_mod._tail_lines("", 30), "<empty>")
+
+    def test_no_trailing_newline_in_output(self) -> None:
+        # The caller appends this into a multi-line detail string;
+        # leaving a trailing newline duplicates the blank-line gap.
+        out = loop_mod._tail_lines("a\nb\n", 30)
+        self.assertFalse(out.endswith("\n"), repr(out))
+
+
+class ReplayErrorDetailIncludesSerialTailTests(unittest.TestCase):
+    """Regression net for the Pi 5 boot-stall diagnostic. Without the
+    captured serial tail in the batch log, every \"did not see shell
+    prompt\" failure looks identical and is undiagnosable. The test
+    drives a single iteration with a SlmosRunner that returns a
+    boot-stall ReplayError and asserts the captured stdout's tail
+    shows up in the LoopOutcome detail."""
+
+    def test_replay_error_detail_includes_stdout_tail(self) -> None:
+        from hailo_re_driver.line_protocols import ExtendRequest
+        from hailo_re_driver.qemu_runner import ExtendEvent
+        from hailo_re_driver.slmos_runner import ReplayError
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = Path(d) / "c.jsonl"
+            from hailo_re_driver.corpus import Header
+            corpus_mod.init(corpus_path, Header(
+                format_version=1, hailort_version="4.23.0",
+                fw_version="4.23.0",
+                capture_host="qemu-x86_64",
+                slmos_base_sha="ef" * 20,
+                capture_started_at="2026-05-12T18:30:00Z",
+            ))
+
+            class _BootStallingSlmos:
+                def replay_step(self, corpus_path, seq, *,
+                                fresh_boot: bool = True):
+                    fake_serial = "\n".join(
+                        f"[ {i:>4}] boot line {i}" for i in range(50)
+                    ) + "\n"
+                    return ReplayError(
+                        kind="error",
+                        message="did not see shell prompt after flash+reboot "
+                                "(rc=0)",
+                        stdout=fake_serial,
+                        stderr="",
+                    )
+
+            extend_event = ExtendEvent(
+                kind="extend",
+                request=ExtendRequest(
+                    seq=1, bar=4, offset=0, size=4,
+                    reason="unknown_read",
+                ),
+                raw_line="HAILO_RE_CORPUS_EXTEND seq=1 bar=4 offset=0 "
+                         "size=4 reason=unknown_read",
+            )
+            qemu = _ScriptedQemuRunner([extend_event])
+
+            outcome = loop_mod.run_loop(
+                corpus_path, qemu, _BootStallingSlmos(),  # type: ignore[arg-type]
+                loop_mod.LoopConfig(max_iterations=1, reachable=lambda _s: True),
+            )
+
+            self.assertEqual(outcome.status, "error")
+            # The message line stays first so existing greps keep working.
+            self.assertIn(
+                "did not see shell prompt after flash+reboot",
+                outcome.detail,
+            )
+            # The last 30 lines of fake_serial must be visible.
+            self.assertIn("[   49] boot line 49", outcome.detail)
+            self.assertIn("[   20] boot line 20", outcome.detail)
+            # Earlier lines must NOT be (we only keep 30).
+            self.assertNotIn("[   19] boot line 19", outcome.detail)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_loop_mocked.py
+++ b/host-tools/hailo-re-driver/tests/test_loop_mocked.py
@@ -580,11 +580,76 @@ class ReplayErrorDetailIncludesSerialTailTests(unittest.TestCase):
                 "did not see shell prompt after flash+reboot",
                 outcome.detail,
             )
+            # The header advertises the configured tail length (default 30).
+            self.assertIn("stdout tail (last 30 lines):", outcome.detail)
             # The last 30 lines of fake_serial must be visible.
             self.assertIn("[   49] boot line 49", outcome.detail)
+            # Boundary check: line 20 IS preserved, line 19 is NOT — pins
+            # the exact cutoff at "last 30" so a silent drift to 29 or 31
+            # fails here as well as in the helper-unit test.
             self.assertIn("[   20] boot line 20", outcome.detail)
-            # Earlier lines must NOT be (we only keep 30).
             self.assertNotIn("[   19] boot line 19", outcome.detail)
+
+    def test_replay_error_detail_respects_loopconfig_tail_length(self) -> None:
+        """LoopConfig.replay_error_stdout_tail_lines is the operator-
+        facing knob for noisy investigations. A non-default value must
+        flow through to both the header label and the number of lines
+        preserved — otherwise the knob silently does nothing."""
+        from hailo_re_driver.line_protocols import ExtendRequest
+        from hailo_re_driver.qemu_runner import ExtendEvent
+        from hailo_re_driver.slmos_runner import ReplayError
+
+        with tempfile.TemporaryDirectory() as d:
+            corpus_path = Path(d) / "c.jsonl"
+            from hailo_re_driver.corpus import Header
+            corpus_mod.init(corpus_path, Header(
+                format_version=1, hailort_version="4.23.0",
+                fw_version="4.23.0",
+                capture_host="qemu-x86_64",
+                slmos_base_sha="ef" * 20,
+                capture_started_at="2026-05-12T18:30:00Z",
+            ))
+
+            class _BootStallingSlmos:
+                def replay_step(self, corpus_path, seq, *,
+                                fresh_boot: bool = True):
+                    fake_serial = "\n".join(
+                        f"[ {i:>4}] boot line {i}" for i in range(50)
+                    ) + "\n"
+                    return ReplayError(
+                        kind="error",
+                        message="did not see shell prompt after flash+reboot "
+                                "(rc=0)",
+                        stdout=fake_serial,
+                        stderr="",
+                    )
+
+            extend_event = ExtendEvent(
+                kind="extend",
+                request=ExtendRequest(
+                    seq=1, bar=4, offset=0, size=4,
+                    reason="unknown_read",
+                ),
+                raw_line="HAILO_RE_CORPUS_EXTEND seq=1 bar=4 offset=0 "
+                         "size=4 reason=unknown_read",
+            )
+            qemu = _ScriptedQemuRunner([extend_event])
+
+            outcome = loop_mod.run_loop(
+                corpus_path, qemu, _BootStallingSlmos(),  # type: ignore[arg-type]
+                loop_mod.LoopConfig(
+                    max_iterations=1,
+                    reachable=lambda _s: True,
+                    replay_error_stdout_tail_lines=5,
+                ),
+            )
+
+            self.assertEqual(outcome.status, "error")
+            self.assertIn("stdout tail (last 5 lines):", outcome.detail)
+            self.assertIn("[   49] boot line 49", outcome.detail)
+            self.assertIn("[   45] boot line 45", outcome.detail)
+            # Line 44 sits one slot above the 5-line window — must be gone.
+            self.assertNotIn("[   44] boot line 44", outcome.detail)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Last night's grind hit \`did not see shell prompt after flash+reboot (rc=0)\` in batch 4. The labctl trailer \`[148 lines, 45.0s, timeout]\` showed the Pi 5 *was* emitting serial output for the full 45 s — so the failure was \"booted but didn't reach the shell prompt in 45 s,\" not a hang.

The captured 148 lines were already in \`result.stdout\` returned by \`SlmosRunner.replay_step\`, but \`_extend_corpus\` only forwarded \`result.message\` and \`result.stderr\` to the batch log. The diagnostic was discarded.

## Fix

Append the last 30 lines of captured serial to the batch log on any \`ReplayError\`. 30 lines covers the typical pre-shell window (kernel banner, driver inits, network init, shell start) without spamming the wrapper log on every transient.

\`_tail_lines(text, n)\` helper added next to \`_ends_with_newline\` in \`loop.py\`. Empty input returns the sentinel \`<empty>\` so future readers can tell \"captured nothing\" apart from \"didn't capture.\"

## Composition with PR #846

PR #846 (refuse classification) is still open. Both PRs touch the same \`_extend_corpus\` ReplayError handler — they compose cleanly because the diagnostic-tail wiring lives in the \`ReplayError\` branch, and the refuse classification adds a *new* \`ReplayRefused\` branch beside it. No conflict expected at merge time.

## Test plan

- [x] Four \`_tail_lines\` unit tests: short input, long input, empty-input sentinel, no trailing newline.
- [x] One end-to-end test that drives the loop with a SlmosRunner returning a fake boot-stall ReplayError and asserts the last 30 lines of fake serial show up in \`LoopOutcome.detail\` while earlier lines do not.
- [x] \`python3 -m unittest discover tests\`: 64/64 PASS.
- [ ] Live grind re-relaunch: confirm next boot-stall transient logs the captured serial tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)