### PR TITLE
pmu: audit follow-up tests + shell fact-sheet (#60 a-d)

### DIFF
--- a/docs/fact-sheets/shell.md
+++ b/docs/fact-sheets/shell.md
@@ -24,7 +24,7 @@ Interactive shell, command surface, observability commands, multi-session.
 | Network commands (`net`, `ping`, `ifconfig`, `netstat`, `tcpsh`) | ✅ | ✅ | ✅ (USB CDC-ECM) | ✅ |
 | Lua (`lua`, `lua -e`, `lua <file>`) | ✅ | ✅ | ✅ | ✅ |
 | Scheduler (`sched`, `sched policy`, `sched stats`) | ✅ | ✅ | ✅ | ✅ |
-| Diagnostic (`dtb`, `timdiag`, `peek`, `macbdiag`) | ✅ | ✅ | ✅ | 🟡 (`timdiag` ARM-only) |
+| Diagnostic (`dtb`, `timdiag`, `peek`, `macbdiag`, `pmu`) | ✅ (`pmu` skips event values under TCG) | ✅ | ✅ | 🟡 (`timdiag` / `pmu` ARM-only — `pmu` x86 sibling tracked as #870) |
 | Kernel-replace admin (`kernel status/stage/activate/promote/rollback`) | 🟡 stub (no boot media) | ✅ tryboot-driven | 🟡 stub | 🟡 stub |
 | GPU/hw shell (`gpu`, `nvgpu phase-N`) | — | — | ✅ | ✅ |
 | Multi-session TCP shell (port 2323) | ✅ | ✅ | ✅ (USB CDC-ECM) | ✅ |

--- a/kernel/arch/arm64/pmu.c
+++ b/kernel/arch/arm64/pmu.c
@@ -300,11 +300,6 @@ bool pmu_is_ready(void)
     return pmu_ready_per_cpu[cpu];
 }
 
-/* Q16.16 fixed-point unit value (represents 1.0). pmu.c stays in
- * `-mgeneral-regs-only` land by keeping cache_pressure as Q16.16;
- * ai_state.c (FP-clean) divides by 65536.0f to get the float. */
-#define PMU_Q16_ONE (1u << 16)
-
 /*
  * Per-CPU cache_pressure cache, stored as Q16.16 fixed point so the
  * AI scheduler can pull a [0.0, 1.0] value without doing FP from pmu.c

--- a/kernel/include/pmu.h
+++ b/kernel/include/pmu.h
@@ -163,11 +163,17 @@ void pmu_sample_cache_pressure(void);
  * a plain per-CPU u32 cache that the writer updates with relaxed
  * stores. Returns 0.0 for an uninitialised slot.
  *
- * Returned as a fixed-point uint32_t scaled by 1<<16 to avoid pulling
- * FP into pmu.c (which is compiled with -mgeneral-regs-only like the
- * rest of the kernel; FP conversion lives in `ai_state.c`).
+ * Returned as a fixed-point uint32_t scaled by PMU_Q16_ONE to avoid
+ * pulling FP into pmu.c (which is compiled with -mgeneral-regs-only
+ * like the rest of the kernel; FP conversion lives in `ai_state.c`).
  */
 uint32_t pmu_get_cache_pressure_q16(uint32_t cpu);
+
+/* Q16.16 fixed-point unit value (represents 1.0 — the saturation
+ * cap for pmu_get_cache_pressure_q16). Exposed so callers and
+ * regression tests can reference the cap symbolically instead of
+ * inlining the literal. */
+#define PMU_Q16_ONE (1u << 16)
 
 #endif /* !PLATFORM_X86_64 */
 

--- a/kernel/tests/test_pmu.c
+++ b/kernel/tests/test_pmu.c
@@ -192,8 +192,8 @@ static void test_pmu_sample_cache_pressure_no_fault(void)
     pmu_sample_cache_pressure();  /* first call: prime the per-CPU state */
     pmu_sample_cache_pressure();  /* second call: takes the delta path */
     pmu_sample_cache_pressure();  /* third call: exercises EWMA blend */
-    TEST_ASSERT_MESSAGE(true,
-        "pmu_sample_cache_pressure must not fault under normal use");
+    /* Surviving all three calls IS the pass condition — no Unity assert
+     * is needed. A fault would crash the kernel before reaching here. */
 }
 
 static void test_pmu_get_cache_pressure_q16_bounded(void)
@@ -207,7 +207,7 @@ static void test_pmu_get_cache_pressure_q16_bounded(void)
      * would surface here as a value > 0x10000. */
     pmu_sample_cache_pressure();
     uint32_t cp = pmu_get_cache_pressure_q16(cpu_id());
-    TEST_ASSERT_MESSAGE(cp <= (1u << 16),
+    TEST_ASSERT_MESSAGE(cp <= PMU_Q16_ONE,
         "pmu_get_cache_pressure_q16 returned a value > 1.0 in Q16.16 — "
         "the EWMA saturation clamp regressed");
 }

--- a/kernel/tests/test_pmu.c
+++ b/kernel/tests/test_pmu.c
@@ -155,6 +155,63 @@ static void test_pmu_read_event_out_of_range_safe(void)
         "pmu_read_event with absurd idx must return 0");
 }
 
+/*
+ * #872 — pmu_sample_cache_pressure and pmu_get_cache_pressure_q16
+ * coverage. The sampler is called from scheduler_tick on every CPU,
+ * feeding the per-core slot the AI scheduler reads via
+ * pmu_get_cache_pressure_q16(cpu). These tests confirm the plumbing
+ * works (no fault, sensible return values, out-of-range bound check)
+ * without depending on a specific cache-miss rate — QEMU TCG returns
+ * zero L1D refills regardless, so the EWMA stays at 0 under emulation.
+ */
+static void test_pmu_get_cache_pressure_q16_out_of_range(void)
+{
+    /* Out-of-range CPU id must return 0, not fault. ai_state.c
+     * iterates over AI_STATE_NUM_CORES (6) which can exceed cpu_count
+     * on Pi 5 (4 cores); the guard ensures the resulting slot read
+     * never crashes regardless of how the caller bounds its iteration. */
+    TEST_ASSERT_MESSAGE(pmu_get_cache_pressure_q16(MAX_CPUS) == 0,
+        "pmu_get_cache_pressure_q16(MAX_CPUS) must return 0");
+    TEST_ASSERT_MESSAGE(pmu_get_cache_pressure_q16(UINT32_MAX) == 0,
+        "pmu_get_cache_pressure_q16(UINT32_MAX) must return 0");
+}
+
+static void test_pmu_sample_cache_pressure_no_fault(void)
+{
+    /* The sampler is called from scheduler_tick on every CPU. It
+     * must complete without faulting even when:
+     *   - The PMU is already enabled (the common path).
+     *   - It's called multiple times in quick succession (prime →
+     *     normal-update → normal-update).
+     * QEMU TCG returns zero L1D refills, so the EWMA stays at 0,
+     * but the underlying state machine (prime + delta tracking +
+     * EWMA blend) still exercises every code path.
+     *
+     * Surviving the calls IS the assertion — there's no PMCR_EL0
+     * trap or null-deref to surface a regression. */
+    pmu_sample_cache_pressure();  /* first call: prime the per-CPU state */
+    pmu_sample_cache_pressure();  /* second call: takes the delta path */
+    pmu_sample_cache_pressure();  /* third call: exercises EWMA blend */
+    TEST_ASSERT_MESSAGE(true,
+        "pmu_sample_cache_pressure must not fault under normal use");
+}
+
+static void test_pmu_get_cache_pressure_q16_bounded(void)
+{
+    /* After the sampler runs, the per-CPU cache returns a Q16.16
+     * fixed-point value in [0, PMU_Q16_ONE]. PMU_Q16_ONE is the
+     * sentinel for 1.0 (full saturation). Under QEMU TCG the value
+     * stays at 0 because L1D refills don't tick; on hardware it can
+     * be anywhere in the range. Either way, the value must never
+     * exceed the saturation cap — a regression in the EWMA clamp
+     * would surface here as a value > 0x10000. */
+    pmu_sample_cache_pressure();
+    uint32_t cp = pmu_get_cache_pressure_q16(cpu_id());
+    TEST_ASSERT_MESSAGE(cp <= (1u << 16),
+        "pmu_get_cache_pressure_q16 returned a value > 1.0 in Q16.16 — "
+        "the EWMA saturation clamp regressed");
+}
+
 int test_suite_pmu(void)
 {
     UnityBegin("test_pmu.c");
@@ -165,6 +222,10 @@ int test_suite_pmu(void)
     RUN_TEST(test_pmu_reset_clears_counters);
     RUN_TEST(test_pmu_read_all_snapshot_consistent);
     RUN_TEST(test_pmu_read_event_out_of_range_safe);
+    /* #872 — cache_pressure sampler + getter coverage. */
+    RUN_TEST(test_pmu_get_cache_pressure_q16_out_of_range);
+    RUN_TEST(test_pmu_sample_cache_pressure_no_fault);
+    RUN_TEST(test_pmu_get_cache_pressure_q16_bounded);
     return UnityEnd();
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7338,11 +7338,24 @@ pub extern "C" fn rust_inference_test() -> i32 {
         let zeroed_ok = buf.iter().all(|e| {
             e.count == 0 && e.total_ns == 0 && e.min_ns == 0 && e.max_ns == 0
         });
+        // #871: PMU sum fields must also reset to zero. A regression
+        // that forgot to extend op_profile_reset to clear the new
+        // atomics would surface here as a non-zero PMU column after
+        // reset, which would then leak into every snapshot.
+        let pmu_zeroed_ok = buf.iter().all(|e| {
+            e.cache_misses == 0
+                && e.l2_misses == 0
+                && e.instructions_retired == 0
+                && e.branch_mispredictions == 0
+                && e.cache_references == 0
+                && e.backend_stalls == 0
+                && e.cycles == 0
+        });
         // Slot 0 is MatMul (discriminant 0); slot 17 is Unknown
         // (discriminant 255). Both label assertions catch reorderings
         // of `op_type_to_index` / `index_to_op_type_u8`.
         let labels_ok = buf[0].op_type == 0 && buf[17].op_type == 255;
-        let passed = len_ok && zeroed_ok && labels_ok;
+        let passed = len_ok && zeroed_ok && pmu_zeroed_ok && labels_ok;
         print_test_result(b"profile: reset/snapshot baseline\0", passed);
         if !passed { failures += 1; }
     }


### PR DESCRIPTION
## Summary

Audit follow-up for the four PMU sub-tickets (#874 #875 #871 #872) merged earlier. Identified three gaps the original PRs missed:

- **#872 functions had no direct tests** — `pmu_sample_cache_pressure` and `pmu_get_cache_pressure_q16` are now consumed by the AI scheduler's `feature[2]` on every state-vector build, but a regression would only surface as misclassified placement decisions. Added 3 tests covering out-of-range bound, no-fault sampling across prime → delta → EWMA paths, and Q16.16 saturation clamp.
- **#871's PMU sum fields not asserted in the baseline reset/snapshot test** — extended `rust_inference_test` to assert all seven new PMU columns (`cache_misses`, `l2_misses`, `instructions_retired`, `branch_mispredictions`, `cache_references`, `backend_stalls`, `cycles`) zero after `op_profile_reset`.
- **docs/fact-sheets/shell.md missing `pmu`** — added to the Diagnostic row with TCG/x86 caveats (#870 referenced for the x86 sibling).

## Test plan

- [x] `make test` passes (QEMU ARM64) — all suites green after rebasing onto origin/main (which picked up #913 fixing the unrelated overlength test_lua.c string).
- [ ] Hardware verification not required — these are test-coverage and doc fixes; no kernel behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)