### PR TITLE
Dynamic batching 55d: hardware characterisation + benchmarks + docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -436,6 +436,28 @@ The inference engine (`runtime/src/inference/engine.rs`) executes operator graph
 | Gemm | General matrix multiplication (A x B + C) |
 | Flatten | Flatten to 2D (batch, features) |
 
+**Dynamic batched dispatch (runtime-toggleable mode, #55).** The
+engine exposes `run_inference_batched(model, batch_size, in, out)`
+alongside the single-sample `run_inference`. The
+`InferenceScheduler` (`runtime/src/sched/inference.rs`) collects
+concurrent inference requests into a bounded queue (up to
+`MAX_BATCH = 32`), then dispatches them through one
+`run_inference_batched` call once either the configured
+batch-size threshold is reached or a CNTPCT-driven flush timeout
+elapses since the first request landed. Per-request output buffers
+are populated and per-task completion mailboxes are signalled by
+the synchronous dispatcher (the submitter that tipped the threshold
+or won the timer race). A request carrying a `TaskDeadline` whose
+remaining slack is below the configured timeout bypasses the queue
+and dispatches as a singleton. Mode is OFF by default and
+toggleable at runtime via `infer batch on` (shell) or
+`slm.infer_batch_mode("on")` (Lua) — per the exploratory-OS
+framing (#848), batched dispatch is a swappable option, not a
+required behavior. The MNIST GPU fast path remains single-sample
+only; batched dispatches always take the CPU graph path.
+Characterised numbers live in `docs/benchmarks.md` under "Dynamic
+Batching".
+
 ### GPU Compute Framework
 
 The GPU backend (`runtime/src/inference/gpu.rs`) provides a framework for GPU-accelerated inference:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -441,22 +441,24 @@ engine exposes `run_inference_batched(model, batch_size, in, out)`
 alongside the single-sample `run_inference`. The
 `InferenceScheduler` (`runtime/src/sched/inference.rs`) collects
 concurrent inference requests into a bounded queue (up to
-`MAX_BATCH = 32`), then dispatches them through one
-`run_inference_batched` call once either the configured
-batch-size threshold is reached or a CNTPCT-driven flush timeout
-elapses since the first request landed. Per-request output buffers
-are populated and per-task completion mailboxes are signalled by
-the synchronous dispatcher (the submitter that tipped the threshold
-or won the timer race). A request carrying a `TaskDeadline` whose
-remaining slack is below the configured timeout bypasses the queue
-and dispatches as a singleton. Mode is OFF by default and
-toggleable at runtime via `infer batch on` (shell) or
-`slm.infer_batch_mode("on")` (Lua) — per the exploratory-OS
-framing (#848), batched dispatch is a swappable option, not a
-required behavior. The MNIST GPU fast path remains single-sample
-only; batched dispatches always take the CPU graph path.
-Characterised numbers live in `docs/benchmarks.md` under "Dynamic
-Batching".
+`MAX_BATCH`, defined in the scheduler module), then dispatches
+them through one `run_inference_batched` call once either the
+configured batch-size threshold is reached or a CNTPCT-driven
+flush timeout elapses since the first request landed. Per-request
+output buffers are populated and per-task completion mailboxes are
+signalled by the synchronous dispatcher (the submitter that tipped
+the threshold or won the timer race).
+
+Mode is OFF by default and toggleable at runtime via `infer batch on`
+(shell) or `slm.infer_batch_mode("on")` (Lua) — per the
+exploratory-OS framing (#848), batched dispatch is a swappable
+option, not a required behavior. A request carrying a
+`TaskDeadline` whose remaining slack is below the configured
+timeout bypasses the queue and dispatches as a singleton, so
+deadline-sensitive callers don't pay the timer wait. The MNIST
+GPU fast path remains single-sample only; batched dispatches always
+take the CPU graph path. Characterised numbers live in
+`docs/benchmarks.md` under "Dynamic Batching".
 
 ### GPU Compute Framework
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -523,6 +523,74 @@ The 2 MB block granularity means small models waste most of their allocated bloc
 
 ---
 
+## Dynamic Batching (Runtime-Toggleable Mode)
+
+SLM-OS's `InferenceScheduler` supports a runtime-toggleable batched dispatch mode (issue #55). Concurrent inference requests are collected into a bounded queue and, on either the size threshold or a configurable timer, dispatched in a single engine call. Per the exploratory-OS framing (#848), batching is a swappable option — default OFF — not a default behavior change.
+
+This section reports the **characterisation** of that mode on Pi 5 and Jetson, not a winner. The capstone story is "the engine supports a batched dispatch mode; here is its behavior at N = 1..16 on real hardware," not "batching wins."
+
+### Workload
+
+`bench infer-stress N [iters]` spawns N concurrent task workers, each running `iters` MNIST inferences against the dispatcher. Reported numbers below are from the shell command with the platform's standard `iters` setting (50 for N ≤ 8, 25 for N = 16 to cap wall-clock).
+
+Configuration for all batched runs: `batch_size = 8`, `timeout_us = 5000` (the shipping defaults). With batching ON the dispatcher routes through the queue + threshold/timer path; with OFF every request takes the existing singleton path.
+
+### Pi 5 (pi-5-2) — `bench infer-stress`, native boot, 4× Cortex-A76 @ 2.4 GHz
+
+| N | Mode | req/s | min µs | avg µs | max µs | batches_full | batches_timeout | singleton |
+|---|---|---|---|---|---|---|---|---|
+|  1 | OFF | 330 | 3009 |  3010 |  3028 | 0 | 0 |  50 |
+|  1 | ON  | 330 | 3009 |  3010 |  3011 | 0 | 0 |  50 |
+|  2 | OFF | 331 | 3010 |  5918 |  6030 | 0 | 0 | 100 |
+|  2 | ON  | 331 | 3011 |  5979 |  6025 | 0 | 0 | 100 |
+|  4 | OFF | 331 | 3010 | 11555 | 54224 | 0 | 0 | 200 |
+|  4 | ON  | 331 | 3010 | 11536 | 45188 | 0 | 0 | 200 |
+|  8 | OFF | 331 | 3009 | 11750 | 57226 | 0 | 0 | 400 |
+|  8 | ON  | 331 | 3010 | 11595 | 48199 | 0 | 0 | 400 |
+| 16 | OFF | 331 | 3010 | 11642 | 48197 | 0 | 0 | 400 |
+| 16 | ON  | 331 | 3010 | 11501 | 51213 | 0 | 0 | 400 |
+
+### Jetson Orin Nano (jetson-nano-1) — `bench infer-stress`, slmos-kexec, 6× Cortex-A78AE
+
+CPU-path matrix (the MNIST GPU fast path is single-sample only, so even ON paths take the CPU graph here; see "GPU fast path interaction" below):
+
+| N | Mode | req/s | min µs | avg µs | max µs (noise) | batches_full | batches_timeout | singleton |
+|---|---|---|---|---|---|---|---|---|
+|  1 | OFF | 239 | 4157 |  4176 |    4203 | 0 | 0 |  50 |
+|  1 | ON  | 239 | 4166 |  4177 |    4189 | 0 | 0 |  50 |
+|  2 | OFF | 239 | 4194 |  8317 |    8377 | 0 | 0 | 100 |
+|  2 | ON  | 239 | 4175 |  8312 |    8375 | 0 | 0 | 100 |
+|  4 | OFF | 102 | 4177 | 18961 |  654563 | 0 | 0 | 200 |
+|  4 | ON  | 102 | 4172 | 17998 |  444816 | 0 | 0 | 200 |
+|  8 | OFF |  79 | 4173 | 30594 | 1099540 | 0 | 0 | 400 |
+|  8 | ON  | 102 | 4172 | 30422 | 1308376 | 0 | 0 | 400 |
+| 16 | OFF | 143 | 4175 | 28189 | 1544941 | 0 | 0 | 400 |
+| 16 | ON  | 143 | 4175 | 28022 | 1517780 | 0 | 0 | 400 |
+
+Jetson max-latency outliers (the seconds-long tails) come from L4T-side scheduling noise after `slmos-kexec` — when the Linux→SLM-OS handoff inherits a busy GIC/timer state, individual worker iterations get descheduled for hundreds of milliseconds. The per-iter `min` (~4.2 ms) reflects the actual CPU-path cost; the `avg` widens with N because workers contend on the engine lock.
+
+GPU fast path interaction: at `N = 1` with `gpu use inference on` and a v6 channel handoff present, the engine routes through `run_mnist_gpu_fastpath`. With batching ON or `N > 1`, the GPU fast path is skipped because the GPU FFI asserts `input_len == 784`. Documented limitation; a batched MNIST GPU dispatch would amortise per-call setup over N samples and is candidate future work.
+
+### Interpretation — honest characterisation
+
+**Batched dispatch never fires on this workload.** The `batches_full` and `batches_timeout` columns are zero across every row of both matrices; every iteration on every run takes the singleton path. This is the honest result for MNIST + CPU graph and is explained by the dispatcher's three-way interaction with `EngineGuard` and the configured timer:
+
+1. The submitter that reserves the only slot in an empty queue sees `pending_count == 1` in `decide_role` and takes the **Solo fallback** (releases the slot and dispatches via the existing singleton path). Without this fallback, an isolated request would block for the full `batch_timeout_us` waiting for peers that never arrive — but here the shortcut means a queue of one always self-clears in microseconds.
+2. Concurrent workers serialise on `EngineGuard` (the engine lock that has always protected `run_inference`). With per-inference cost ≈ 3 ms on Pi 5 and ≈ 4.2 ms on Jetson, the window between *worker A releasing its slot and entering* `run_inference` and *worker B arriving at the queue* is ≈ microseconds — orders of magnitude shorter than the inference itself. Two workers virtually never coexist as `PENDING` at the same instant.
+3. The configured 5 ms timer flush can only fire when at least one waiter is sitting in the queue. Because of (1) and (2), no waiters accumulate.
+
+Together these mean batched dispatch is **structurally bounded by the engine lock** in the small-model + CPU regime. Throughput peaks at the single-thread engine rate (≈ 331 req/s Pi 5, ≈ 239 req/s Jetson) regardless of N; additional workers stack as latency, not throughput.
+
+**This is not a bug — it is the realistic characterisation that 55d was specifically asked to capture.** The dispatcher is correct (every QEMU regression test passes, the timer-flush path is exercised by a deterministic test in `rust_batch_inference_test`), and the infrastructure is in place. Workloads that would actually benefit are:
+
+- **Larger per-call setup that amortises across a batch.** Transformer attention layers, multi-MB Gemm operations, or quantised inference paths whose dequant/setup cost is per-call rather than per-element.
+- **Routing batched dispatches through a GPU fast path.** The current GPU MNIST handoff is `input_len == 784` only. A batched GPU dispatch would amortise channel set-up, doorbell, and PCI write overhead over N samples — the largest potential win.
+- **A lock-free or coarser-grained engine path** so multiple workers can land in `PENDING` together. `EngineGuard` is the bottleneck today; the parent issue notes that batching naturally reduces lock contention by holding the lock for one large call instead of N small ones — but only if the batch actually forms before the lock is acquired, which it doesn't with the current Solo fallback.
+
+The capstone report should reference this section as "the batched dispatch mode is implemented and characterised end-to-end; on the MNIST + CPU workload the engine lock dominates, so the option-space addition is the deliverable, not a throughput win." Per the exploratory-OS framing (#848), an unswapped option is still a valid contribution.
+
+---
+
 ## Test Suite Performance
 
 | Platform | Tests | Pass | Fail | Time |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -531,7 +531,7 @@ This section reports the **characterisation** of that mode on Pi 5 and Jetson, n
 
 ### Workload
 
-`bench infer-stress N [iters]` spawns N concurrent task workers, each running `iters` MNIST inferences against the dispatcher. Reported numbers below are from the shell command with the platform's standard `iters` setting (50 for N ≤ 8, 25 for N = 16 to cap wall-clock).
+[`bench infer-stress N [iters]`](shell.md#command-descriptions) spawns N concurrent task workers, each running `iters` MNIST inferences against the dispatcher. Reported numbers below are from the shell command with the platform's standard `iters` setting (50 for N ≤ 8, 25 for N = 16 to cap wall-clock).
 
 Configuration for all batched runs: `batch_size = 8`, `timeout_us = 5000` (the shipping defaults). With batching ON the dispatcher routes through the queue + threshold/timer path; with OFF every request takes the existing singleton path.
 
@@ -549,6 +549,8 @@ Configuration for all batched runs: `batch_size = 8`, `timeout_us = 5000` (the s
 |  8 | ON  | 331 | 3010 | 11595 | 48199 | 0 | 0 | 400 |
 | 16 | OFF | 331 | 3010 | 11642 | 48197 | 0 | 0 | 400 |
 | 16 | ON  | 331 | 3010 | 11501 | 51213 | 0 | 0 | 400 |
+
+Pi 5 max-latency outliers at N ≥ 4 (~50 ms) reflect the default cooperative-preempt scheduling (10 ms quantum), not dispatcher contention: a worker that loses CPU just after `submit_inference_sync` returns can wait several quanta before its next iteration runs. The per-iter `min` (~3.0 ms) is the true single-inference cost; `avg` widens with N because workers serialise on `EngineGuard`.
 
 ### Jetson Orin Nano (jetson-nano-1) — `bench infer-stress`, slmos-kexec, 6× Cortex-A78AE
 


### PR DESCRIPTION
## Summary

Lands the #55d deliverable: hardware-captured throughput matrix on **pi-5-2** and **jetson-nano-1** for the dynamic-batching dispatcher (#862 / #908 / #917), plus the architecture-section paragraph framing batched dispatch as a runtime-toggleable mode.

Rebased onto main after #862 + #908 + #917 squash-merged; replaces closed PR #903.

## Hardware runs

20 stress configurations captured via `bench infer-stress`:

- **Pi 5 (4× Cortex-A76 @ 2.4 GHz, native boot):** ~331 req/s across every (N, mode), 3.0 ms / iter at N=1.
- **Jetson Orin Nano (6× Cortex-A78AE, slmos-kexec from Linux):** ~239 req/s at N≤2, 4.18 ms / iter at N=1; widened max-latency tails past N=4 from L4T scheduling noise.

## Headline finding (honest characterisation)

**`batches_full` and `batches_timeout` are zero in every row.** Every iteration on every run took the singleton path. This is the **structurally expected** result for MNIST + CPU graph and is exactly what #848 asked us to capture ("option-space addition, not a throughput win").

The `docs/benchmarks.md` text explains the mechanism end-to-end:

1. **Solo fallback** fires whenever a submitter sees `pending_count == 1` (the design choice from #857 that prevents isolated callers from blocking on the timer when no peers will arrive).
2. **Engine-lock serialisation** dominates. Per-inference cost (~3 ms Pi 5, ~4.2 ms Jetson) is microseconds × 1000 longer than the `reserve_slot → decide_role` window; two workers virtually never coexist in `PENDING`.
3. **Timer flush** can only fire when waiters accumulate, which (1) and (2) prevent jointly.

Throughput is therefore capped at the single-thread engine rate regardless of N. Additional workers stack as latency, not throughput.

## What we shipped

- Correct dispatcher: every QEMU regression test (11/11 batch tests across #862, #908, #917) passes.
- Timer-flush path exercised by a deterministic test (`inject_pending_slot_for_test`-based) — proves the path works even though concurrent workloads on MNIST+CPU don't exercise it.
- Documentation that names the workloads that *would* benefit:
  - Transformer-style heavier-setup ops (attention, multi-MB Gemm).
  - Batched GPU dispatch (the MNIST GPU fast path is N=1-only today).
  - Lock-free or coarser-grained engine path so batches can actually form before the lock is taken.

## Doc changes

- `docs/benchmarks.md` adds the "Dynamic Batching (Runtime-Toggleable Mode)" section with both matrices and the interpretation paragraph.
- `docs/architecture.md` "CPU Inference Engine" subsection gains a paragraph describing batched dispatch as a swappable runtime mode and pointing to the benchmarks section.
- `docs/lua.md` and `docs/shell.md` already updated in #917 — verified correct in this PR.

## Test plan

- [x] Pi 5 hardware runs captured via labctl `serial_capture` (coordinated through John before claiming pi-5-2)
- [x] Jetson hardware runs captured via labctl `serial_capture` after Linux→SLM-OS kexec (coordinated through John before claiming jetson-nano-1)
- [x] Both platforms cross-built clean throughout
- [x] No new code changes — docs-only; existing tests still pass

Refs #55, closes #858. Supersedes #903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)