### PR TITLE
sched: bench sched-policy --workload harness (refs #882)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2090,6 +2090,7 @@ if(ENABLE_AI_SCHEDULER)
         kernel/sched/ai/ai_weights_mlp.c
         kernel/sched/ai/ai_weights_ppo.c
         kernel/sched/ai/ai_test_helpers.c
+        kernel/sched/ai/workloads.c
         $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/ai/fp_context.S>
         $<$<STREQUAL:${PLATFORM},X86_64>:kernel/sched/ai/fp_context.S>
     )

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -273,6 +273,55 @@ The AI scheduler adds ~40 µs overhead per scheduling decision on Pi 5 hardware.
 - Systems where optimal CPU placement matters more than scheduling overhead
 - Evaluation of learned scheduling policies against heuristic baselines
 
+### Scheduling-quality workload harness (#882, sub-ticket of #61)
+
+The `bench sched-policy` verb also accepts a workload mode that
+drives a representative task mix through `scheduler_add_task` so
+policies can be compared on real scheduling **quality** — deadline
+miss rate, completion-time percentiles, per-CPU balance, and
+throughput — not only inference-only decision latency. The
+inference-only mode (legacy `bench sched-policy` with no flags)
+still runs and remains backward compatible.
+
+```
+slmos> bench sched-policy --workload mixed --all
+slmos> bench sched-policy --workload deadline-heavy --policy ai_mlp
+slmos> bench sched-policy --list-workloads
+```
+
+Workloads are static templates defined in
+`kernel/sched/ai/workloads.c`:
+
+| Workload            | Tasks | Templates | Purpose                                                     |
+|---------------------|-------|-----------|-------------------------------------------------------------|
+| `mixed`             | 24    | 3         | Representative cross-section — short tight-deadline + long no-deadline tasks. Closest shape to the synthetic-baseline training set. |
+| `deadline-heavy`    | 24    | 3         | Every task carries a tight relative deadline; surfaces deadline-pressure policy differences. |
+| `latency-sensitive` | 24    | 2         | Very short tasks with very tight deadlines; CPU-balance matters most. |
+| `cpu-bound`         | 16    | 2         | Long tasks, no deadlines; surfaces work-balance differences without deadline pressure. |
+
+Output format — one row per policy, columns `Done / DL-tasks /
+DL-miss% / p50 us / p99 us / max us / CPU-cov / Tasks/s`. `CPU-cov`
+is the coefficient of variation of completed-task counts across
+CPUs (lower = more balanced). `Tasks/s` reports steady-state
+throughput. Per the [exploratory-OS framing][i848], the table is
+characterization data; no winning policy is declared in the output.
+
+[i848]: https://github.com/SLM-OS/SLM-Operating-System/issues/848
+
+The harness wraps the existing pluggable-policy interface — switching
+policies between rows via `sched_set_policy`, dispatching tasks
+through `scheduler_add_task` so the active policy's `assign_cpu`
+callback is exercised, then restoring the prior policy on the way
+out. Worker tasks run at `TASK_PRIORITY_HIGH` so they preempt the
+shell's busy-wait on cooperative-preempt platforms.
+
+Real hardware comparison tables for Pi 5 (4 CPUs) and Jetson Orin
+Nano (6 CPUs) — across all four registered policies, on both the
+synthetic-trained baseline weights and the SLM-OS-fine-tuned weights
+— land in #884 (61d) after the trace-capture (#880) and fine-tune
+(#879) sub-tickets complete. The harness lands here so that work has
+a stable target shape.
+
 ### XGBoost cascade workflow
 
 The XGBoost cascade is loaded at runtime — there is no kernel-image

--- a/kernel/sched/ai/workloads.c
+++ b/kernel/sched/ai/workloads.c
@@ -162,7 +162,15 @@ static struct bench_wl_slot wl_slots[BENCH_WORKLOAD_MAX_TASKS] __attribute__((al
 /* Re-entry guard. `bench_workload_run` mutates the module-static
  * `wl_slots` array; a concurrent second caller (Lua, IPC, future
  * non-shell entry point) would silently corrupt records. Mirrors the
- * `in_split` pattern documented in kernel/CLAUDE.md §"Buddy Allocator". */
+ * `in_split` pattern documented in kernel/CLAUDE.md §"Buddy Allocator".
+ *
+ * Best-effort fail-loud, NOT a cross-CPU lock — on Pi 5 / Jetson the
+ * `volatile bool` write isn't guaranteed visible to a concurrent reader
+ * on another CPU without cache maintenance. The documented precondition
+ * (shell task on CPU 0, single-threaded) makes this a non-issue in
+ * practice. A future Lua/IPC binding that legitimately needs concurrent
+ * access must add an external spinlock around the whole run rather than
+ * lean on this guard. */
 static volatile bool bench_workload_in_flight = false;
 
 static void workload_busy_wait_us(uint32_t us)

--- a/kernel/sched/ai/workloads.c
+++ b/kernel/sched/ai/workloads.c
@@ -36,6 +36,7 @@
 #include "smp.h"
 #include "cache.h"
 #include "timer.h"
+#include "string.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -115,10 +116,9 @@ const struct bench_workload *bench_workload_find(const char *name)
 {
     if (!name) return 0;
     for (uint32_t i = 0; i < sizeof(bench_workloads_table)/sizeof(bench_workloads_table[0]); i++) {
-        const char *a = name;
-        const char *b = bench_workloads_table[i].name;
-        while (*a && *b && *a == *b) { a++; b++; }
-        if (*a == 0 && *b == 0) return &bench_workloads_table[i];
+        if (strcmp(name, bench_workloads_table[i].name) == 0) {
+            return &bench_workloads_table[i];
+        }
     }
     return 0;
 }
@@ -140,15 +140,20 @@ const struct bench_workload *bench_workload_get(uint32_t idx)
  * different slots can't false-share. The records array is module
  * static so the worker can find its slot from `arg`. Only one
  * `bench_workload_run` may be in flight at a time (the shell is
- * single-threaded). */
+ * single-threaded).
+ *
+ * The driver's input (`dispatch_ns`, `runtime_us`, `deadline_ns`)
+ * lives in the same struct as the worker's output so a single
+ * cache_clean_range on the slot covers everything the worker reads
+ * before scheduler_add_task hands it off — without this, on Pi 5 a
+ * worker dispatched to a non-CPU-0 core would read stale zeros for
+ * `runtime_us` and busy-wait for zero cycles (incoherent per-core
+ * L2; see kernel/CLAUDE.md §"Cache Maintenance"). */
 struct __attribute__((aligned(64))) bench_wl_slot {
     struct bench_wl_record rec;
     uint8_t  _pad[64 - sizeof(struct bench_wl_record)];
 };
 static struct bench_wl_slot wl_slots[BENCH_WORKLOAD_MAX_TASKS] __attribute__((aligned(64)));
-static uint64_t wl_dispatch_ns[BENCH_WORKLOAD_MAX_TASKS];
-static uint32_t wl_runtime_us[BENCH_WORKLOAD_MAX_TASKS];
-static uint32_t wl_active_count;
 
 static void workload_busy_wait_us(uint32_t us)
 {
@@ -170,13 +175,19 @@ static void workload_task_body(void *arg)
         return;
     }
 
-    /* Busy-spin for the template's runtime. */
-    workload_busy_wait_us(wl_runtime_us[slot]);
+    /* Invalidate this slot so we read the driver's just-cleaned
+     * dispatch_ns / runtime_us / deadline_ns rather than any stale
+     * local L1 contents on Pi 5 / Jetson. */
+    cache_invalidate_range(&wl_slots[slot], sizeof(wl_slots[slot]));
 
-    uint64_t end_ns = slm_get_time_ns();
-    uint64_t dispatch_ns = wl_dispatch_ns[slot];
+    uint32_t runtime_us = wl_slots[slot].rec.runtime_us;
+    uint64_t dispatch_ns = wl_slots[slot].rec.dispatch_ns;
     uint64_t deadline_ns = wl_slots[slot].rec.deadline_ns;
 
+    /* Busy-spin for the template's runtime. */
+    workload_busy_wait_us(runtime_us);
+
+    uint64_t end_ns = slm_get_time_ns();
     wl_slots[slot].rec.completion_ns = end_ns;
     wl_slots[slot].rec.latency_us =
         (uint32_t)((end_ns - dispatch_ns) / 1000ULL);
@@ -188,13 +199,6 @@ static void workload_task_body(void *arg)
 }
 
 /* ---- Quantile + stddev helpers (integer-only) ---- */
-
-static int u64_cmp(const void *a, const void *b)
-{
-    uint64_t aa = *(const uint64_t *)a;
-    uint64_t bb = *(const uint64_t *)b;
-    return (aa > bb) - (aa < bb);
-}
 
 /* Simple insertion sort — N <= 32 so O(N^2) is fine. */
 static void sort_u64(uint64_t *arr, uint32_t n)
@@ -208,7 +212,6 @@ static void sort_u64(uint64_t *arr, uint32_t n)
         }
         arr[j] = key;
     }
-    (void)u64_cmp;  /* future use if we switch to qsort */
 }
 
 /* Quantile interpolation: returns arr[ceil(q*n) - 1] for sorted arr.
@@ -285,21 +288,24 @@ int bench_workload_run(const struct sched_policy_ops *policy,
 
     if (sched_set_policy(policy) < 0) return -1;
 
-    /* Clear records + scratch arrays. */
+    /* Clear records. The dispatch loop below fills in dispatch_ns /
+     * runtime_us / deadline_ns per slot and then cache_cleans the
+     * slot before scheduler_add_task hands the worker off. */
     for (uint32_t i = 0; i < BENCH_WORKLOAD_MAX_TASKS; i++) {
-        wl_slots[i].rec.completion_ns = 0;
+        wl_slots[i].rec.dispatch_ns = 0;
+        wl_slots[i].rec.runtime_us = 0;
         wl_slots[i].rec.deadline_ns = 0;
+        wl_slots[i].rec.completion_ns = 0;
         wl_slots[i].rec.latency_us = 0;
         wl_slots[i].rec.ran_on_cpu = 0xFF;
         wl_slots[i].rec.deadline_met = 0;
         wl_slots[i].rec.done = 0;
-        wl_dispatch_ns[i] = 0;
-        wl_runtime_us[i] = 0;
     }
     cache_clean_range(wl_slots, sizeof(wl_slots));
-    wl_active_count = wl->n_tasks_total;
 
-    for (uint32_t i = 0; i < MAX_CPUS; i++) out->cpu_completions[i] = 0;
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        out->cpu_completions[i] = 0;
+    }
 
     uint64_t bench_start_ns = slm_get_time_ns();
 
@@ -308,16 +314,16 @@ int bench_workload_run(const struct sched_policy_ops *policy,
     struct task *created[BENCH_WORKLOAD_MAX_TASKS] = { 0 };
     for (uint32_t i = 0; i < wl->n_tasks_total; i++) {
         const struct bench_wl_template *tpl = &wl->templates[i % wl->n_templates];
-        wl_runtime_us[i] = tpl->est_runtime_us;
 
         uint64_t now_ns = slm_get_time_ns();
-        wl_dispatch_ns[i] = now_ns;
-
+        wl_slots[i].rec.dispatch_ns = now_ns;
+        wl_slots[i].rec.runtime_us = tpl->est_runtime_us;
         if (tpl->deadline_slack_us > 0) {
             wl_slots[i].rec.deadline_ns =
                 now_ns + (uint64_t)tpl->deadline_slack_us * 1000ULL;
         }
-        /* Clean slot before worker reads its template fields. */
+        /* Push slot to PoC so the worker (which may run on a
+         * different CPU with an incoherent L2) sees these fields. */
         cache_clean_range(&wl_slots[i], sizeof(wl_slots[i]));
 
         struct task *t = task_create_with_priority(
@@ -382,8 +388,9 @@ int bench_workload_run(const struct sched_policy_ops *policy,
             out->cpu_completions[wl_slots[i].rec.ran_on_cpu]++;
         }
         latencies[lat_count++] = (uint64_t)wl_slots[i].rec.latency_us;
-        if ((uint64_t)wl_slots[i].rec.latency_us > out->completion_max_us)
+        if ((uint64_t)wl_slots[i].rec.latency_us > out->completion_max_us) {
             out->completion_max_us = wl_slots[i].rec.latency_us;
+        }
         if (wl_slots[i].rec.deadline_ns != 0) {
             out->deadline_tasks++;
             if (!wl_slots[i].rec.deadline_met) out->deadline_misses++;

--- a/kernel/sched/ai/workloads.c
+++ b/kernel/sched/ai/workloads.c
@@ -1,0 +1,429 @@
+/*
+ * workloads.c — Real-workload comparison harness (#882, sub-ticket of #61).
+ *
+ * Drives a representative task mix through `scheduler_add_task` so
+ * different scheduler policies can be compared on real scheduling
+ * quality, not only inference-only decision latency. See workloads.h
+ * for the public API.
+ *
+ * Design notes
+ * ------------
+ * The driver runs in the shell task on CPU 0. Worker tasks are
+ * created at TASK_PRIORITY_HIGH so they preempt the shell's
+ * busy-wait on cooperative-preempt platforms. Each worker spins on
+ * `timer_get_count()` for its template's `est_runtime_us` and then
+ * records (completion_ns, cpu, deadline_met) into a per-task slot
+ * in a BSS records array. The driver loops `slm_get_time_ns()` until
+ * all slots show `done==1` or the per-run timeout expires.
+ *
+ * Cross-CPU coherency: each worker writes only its own slot, then
+ * calls cache_clean on it; the driver invalidates the array before
+ * reading. On NC-memory platforms the records still live in BSS for
+ * simplicity — every record is on its own 64-byte cacheline and the
+ * "writer-side clean + reader-side invalidate" pattern is exactly
+ * the one called out in kernel/CLAUDE.md §"Cache Maintenance (Pi 5
+ * / No SMPEN)". This is the same approach `bench stealing` uses on
+ * cacheable BSS platforms; we follow it uniformly so the harness has
+ * one code path.
+ */
+
+#if defined(CONFIG_AI_SCHEDULER)
+
+#include "workloads.h"
+#include "task.h"
+#include "sched.h"
+#include "sched_policy.h"
+#include "smp.h"
+#include "cache.h"
+#include "timer.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* slm_get_time_ns prototype lives in kernel/include/util.h on most
+ * platforms; declare locally to keep the include surface narrow. */
+extern uint64_t slm_get_time_ns(void);
+
+/* ---- Workload templates ---- */
+
+/* "mixed" — representative cross-section. Two short tight-deadline
+ * tasks for every long no-deadline task. Closest to the
+ * `slm_sim/workloads/system.py` shape the synthetic-baseline weights
+ * were trained on, so it's the natural smoke test for differentiating
+ * policies before the ai-real fine-tune lands. */
+static const struct bench_wl_template wl_mixed_tpls[] = {
+    { .est_runtime_us =  300, .deadline_slack_us = 2000, .priority = 5 },
+    { .est_runtime_us =  500, .deadline_slack_us = 4000, .priority = 4 },
+    { .est_runtime_us = 1500, .deadline_slack_us =    0, .priority = 3 },
+};
+
+/* "deadline-heavy" — every task carries a tight relative deadline.
+ * Heuristic should miss more deadlines than ai_mlp/ai_ppo if the
+ * trained policies' deadline-pressure heuristics generalize. */
+static const struct bench_wl_template wl_deadline_tpls[] = {
+    { .est_runtime_us =  400, .deadline_slack_us = 1500, .priority = 6 },
+    { .est_runtime_us =  600, .deadline_slack_us = 2000, .priority = 6 },
+    { .est_runtime_us =  250, .deadline_slack_us = 1000, .priority = 7 },
+};
+
+/* "latency-sensitive" — very short tasks with very tight deadlines,
+ * arriving in close succession. CPU-balance matters most here. */
+static const struct bench_wl_template wl_latency_tpls[] = {
+    { .est_runtime_us = 150, .deadline_slack_us =  800, .priority = 6 },
+    { .est_runtime_us = 200, .deadline_slack_us = 1000, .priority = 7 },
+};
+
+/* "cpu-bound" — long tasks, no deadlines. Surfaces work-balance
+ * differences without deadline pressure. */
+static const struct bench_wl_template wl_cpu_bound_tpls[] = {
+    { .est_runtime_us = 4000, .deadline_slack_us = 0, .priority = 4 },
+    { .est_runtime_us = 2000, .deadline_slack_us = 0, .priority = 5 },
+};
+
+static const struct bench_workload bench_workloads_table[] = {
+    {
+        .name = "mixed",
+        .templates = wl_mixed_tpls,
+        .n_templates = sizeof(wl_mixed_tpls) / sizeof(wl_mixed_tpls[0]),
+        .n_tasks_total = 24,
+        .arrival_spacing_us = 300,
+    },
+    {
+        .name = "deadline-heavy",
+        .templates = wl_deadline_tpls,
+        .n_templates = sizeof(wl_deadline_tpls) / sizeof(wl_deadline_tpls[0]),
+        .n_tasks_total = 24,
+        .arrival_spacing_us = 200,
+    },
+    {
+        .name = "latency-sensitive",
+        .templates = wl_latency_tpls,
+        .n_templates = sizeof(wl_latency_tpls) / sizeof(wl_latency_tpls[0]),
+        .n_tasks_total = 24,
+        .arrival_spacing_us = 150,
+    },
+    {
+        .name = "cpu-bound",
+        .templates = wl_cpu_bound_tpls,
+        .n_templates = sizeof(wl_cpu_bound_tpls) / sizeof(wl_cpu_bound_tpls[0]),
+        .n_tasks_total = 16,
+        .arrival_spacing_us = 0,
+    },
+};
+
+const struct bench_workload *bench_workload_find(const char *name)
+{
+    if (!name) return 0;
+    for (uint32_t i = 0; i < sizeof(bench_workloads_table)/sizeof(bench_workloads_table[0]); i++) {
+        const char *a = name;
+        const char *b = bench_workloads_table[i].name;
+        while (*a && *b && *a == *b) { a++; b++; }
+        if (*a == 0 && *b == 0) return &bench_workloads_table[i];
+    }
+    return 0;
+}
+
+uint32_t bench_workload_count(void)
+{
+    return (uint32_t)(sizeof(bench_workloads_table)/sizeof(bench_workloads_table[0]));
+}
+
+const struct bench_workload *bench_workload_get(uint32_t idx)
+{
+    if (idx >= sizeof(bench_workloads_table)/sizeof(bench_workloads_table[0])) return 0;
+    return &bench_workloads_table[idx];
+}
+
+/* ---- Worker bookkeeping ---- */
+
+/* Each slot on its own 64-byte cacheline so adjacent workers writing
+ * different slots can't false-share. The records array is module
+ * static so the worker can find its slot from `arg`. Only one
+ * `bench_workload_run` may be in flight at a time (the shell is
+ * single-threaded). */
+struct __attribute__((aligned(64))) bench_wl_slot {
+    struct bench_wl_record rec;
+    uint8_t  _pad[64 - sizeof(struct bench_wl_record)];
+};
+static struct bench_wl_slot wl_slots[BENCH_WORKLOAD_MAX_TASKS] __attribute__((aligned(64)));
+static uint64_t wl_dispatch_ns[BENCH_WORKLOAD_MAX_TASKS];
+static uint32_t wl_runtime_us[BENCH_WORKLOAD_MAX_TASKS];
+static uint32_t wl_active_count;
+
+static void workload_busy_wait_us(uint32_t us)
+{
+    if (us == 0) return;
+    uint64_t freq = timer_get_frequency();
+    uint64_t target_cycles = ((uint64_t)us * freq) / 1000000ULL;
+    uint64_t start = timer_get_count();
+    while ((timer_get_count() - start) < target_cycles) {
+        __asm__ volatile("" ::: "memory");
+    }
+}
+
+static void workload_task_body(void *arg)
+{
+    uint32_t slot = (uint32_t)(uintptr_t)arg;
+    if (slot >= BENCH_WORKLOAD_MAX_TASKS) {
+        /* Defensive — caller never passes this, but a bad cast
+         * would corrupt our records array. */
+        return;
+    }
+
+    /* Busy-spin for the template's runtime. */
+    workload_busy_wait_us(wl_runtime_us[slot]);
+
+    uint64_t end_ns = slm_get_time_ns();
+    uint64_t dispatch_ns = wl_dispatch_ns[slot];
+    uint64_t deadline_ns = wl_slots[slot].rec.deadline_ns;
+
+    wl_slots[slot].rec.completion_ns = end_ns;
+    wl_slots[slot].rec.latency_us =
+        (uint32_t)((end_ns - dispatch_ns) / 1000ULL);
+    wl_slots[slot].rec.ran_on_cpu = (uint8_t)cpu_id();
+    wl_slots[slot].rec.deadline_met =
+        (deadline_ns == 0 || end_ns <= deadline_ns) ? 1u : 0u;
+    wl_slots[slot].rec.done = 1;
+    cache_clean_range(&wl_slots[slot], sizeof(wl_slots[slot]));
+}
+
+/* ---- Quantile + stddev helpers (integer-only) ---- */
+
+static int u64_cmp(const void *a, const void *b)
+{
+    uint64_t aa = *(const uint64_t *)a;
+    uint64_t bb = *(const uint64_t *)b;
+    return (aa > bb) - (aa < bb);
+}
+
+/* Simple insertion sort — N <= 32 so O(N^2) is fine. */
+static void sort_u64(uint64_t *arr, uint32_t n)
+{
+    for (uint32_t i = 1; i < n; i++) {
+        uint64_t key = arr[i];
+        uint32_t j = i;
+        while (j > 0 && arr[j - 1] > key) {
+            arr[j] = arr[j - 1];
+            j--;
+        }
+        arr[j] = key;
+    }
+    (void)u64_cmp;  /* future use if we switch to qsort */
+}
+
+/* Quantile interpolation: returns arr[ceil(q*n) - 1] for sorted arr.
+ * q is in milli-units (e.g. 500 = p50). n must be >= 1. */
+static uint64_t quantile_milli(const uint64_t *sorted, uint32_t n, uint32_t q_milli)
+{
+    if (n == 0) return 0;
+    uint64_t idx = ((uint64_t)q_milli * (uint64_t)n + 999u) / 1000u;
+    if (idx == 0) idx = 1;
+    if (idx > n) idx = n;
+    return sorted[idx - 1];
+}
+
+/* Coefficient of variation × 1000 across the non-zero entries of `counts`.
+ * COV = stddev / mean. Smaller = more even distribution.
+ * Integer-only — avoids floating-point in kernel context.
+ *
+ * To compute stddev without sqrt, we use the formula
+ *   variance = E[x^2] - (E[x])^2
+ *   stddev = sqrt(variance)
+ *   cov_milli = (stddev * 1000) / mean
+ * For integer sqrt we use a 16-iteration Newton step.
+ */
+static uint32_t isqrt_u64(uint64_t n)
+{
+    if (n == 0) return 0;
+    /* Initial estimate: high bit / 2. */
+    uint64_t x = n;
+    uint64_t r = 1;
+    while (x > 0) { r <<= 1; x >>= 2; }
+    /* Newton iterations: r' = (r + n/r) / 2. 16 is plenty for u64. */
+    for (int i = 0; i < 16; i++) {
+        if (r == 0) break;
+        r = (r + n / r) / 2;
+    }
+    return (uint32_t)r;
+}
+
+static uint32_t compute_cov_milli(const uint32_t *counts, uint32_t n_cpus)
+{
+    uint64_t sum = 0;
+    uint32_t k = 0;
+    for (uint32_t i = 0; i < n_cpus; i++) {
+        if (counts[i] > 0) { sum += counts[i]; k++; }
+    }
+    if (k < 2 || sum == 0) return 0;
+    uint64_t mean = sum / k;
+    if (mean == 0) return 0;
+    uint64_t sq_sum = 0;
+    for (uint32_t i = 0; i < n_cpus; i++) {
+        if (counts[i] > 0) {
+            int64_t d = (int64_t)counts[i] - (int64_t)mean;
+            sq_sum += (uint64_t)(d * d);
+        }
+    }
+    uint64_t variance = sq_sum / k;
+    uint32_t sd = isqrt_u64(variance);
+    /* COV * 1000 = sd / mean * 1000 */
+    return (uint32_t)(((uint64_t)sd * 1000ULL) / mean);
+}
+
+/* ---- Main entry point ---- */
+
+int bench_workload_run(const struct sched_policy_ops *policy,
+                       const struct bench_workload *wl,
+                       struct bench_workload_result *out)
+{
+    if (!policy || !wl || !out) return -1;
+    if (wl->n_tasks_total == 0 || wl->n_tasks_total > BENCH_WORKLOAD_MAX_TASKS) return -1;
+    if (wl->n_templates == 0) return -1;
+
+    /* Snapshot active policy so we can restore on the way out. */
+    const struct sched_policy_ops *prev = sched_find_policy(sched_get_policy());
+
+    if (sched_set_policy(policy) < 0) return -1;
+
+    /* Clear records + scratch arrays. */
+    for (uint32_t i = 0; i < BENCH_WORKLOAD_MAX_TASKS; i++) {
+        wl_slots[i].rec.completion_ns = 0;
+        wl_slots[i].rec.deadline_ns = 0;
+        wl_slots[i].rec.latency_us = 0;
+        wl_slots[i].rec.ran_on_cpu = 0xFF;
+        wl_slots[i].rec.deadline_met = 0;
+        wl_slots[i].rec.done = 0;
+        wl_dispatch_ns[i] = 0;
+        wl_runtime_us[i] = 0;
+    }
+    cache_clean_range(wl_slots, sizeof(wl_slots));
+    wl_active_count = wl->n_tasks_total;
+
+    for (uint32_t i = 0; i < MAX_CPUS; i++) out->cpu_completions[i] = 0;
+
+    uint64_t bench_start_ns = slm_get_time_ns();
+
+    /* Dispatch loop. */
+    uint32_t dispatched = 0;
+    struct task *created[BENCH_WORKLOAD_MAX_TASKS] = { 0 };
+    for (uint32_t i = 0; i < wl->n_tasks_total; i++) {
+        const struct bench_wl_template *tpl = &wl->templates[i % wl->n_templates];
+        wl_runtime_us[i] = tpl->est_runtime_us;
+
+        uint64_t now_ns = slm_get_time_ns();
+        wl_dispatch_ns[i] = now_ns;
+
+        if (tpl->deadline_slack_us > 0) {
+            wl_slots[i].rec.deadline_ns =
+                now_ns + (uint64_t)tpl->deadline_slack_us * 1000ULL;
+        }
+        /* Clean slot before worker reads its template fields. */
+        cache_clean_range(&wl_slots[i], sizeof(wl_slots[i]));
+
+        struct task *t = task_create_with_priority(
+            "wl_bench", workload_task_body,
+            (void *)(uintptr_t)i, tpl->priority);
+        if (!t) break;  /* Task table exhausted — report whatever we got. */
+        created[i] = t;
+
+        if (tpl->deadline_slack_us > 0) {
+            task_set_deadline(t, wl_slots[i].rec.deadline_ns);
+        }
+        scheduler_add_task(t);
+        dispatched++;
+
+        if (wl->arrival_spacing_us > 0 && i + 1 < wl->n_tasks_total) {
+            workload_busy_wait_us(wl->arrival_spacing_us);
+        }
+    }
+
+    /* Wait for completion. Generous timeout = 4x expected workload
+     * duration + 1s floor. Expected duration estimated from sum of
+     * runtime templates, assuming perfect parallelism on cpu_count
+     * cores (which the policies should approach). */
+    uint64_t expected_us = 0;
+    for (uint32_t i = 0; i < wl->n_tasks_total; i++) {
+        expected_us += wl->templates[i % wl->n_templates].est_runtime_us;
+    }
+    expected_us /= (cpu_count > 0 ? cpu_count : 1u);
+    uint64_t timeout_ns = (uint64_t)expected_us * 4000ULL + 1000000000ULL;
+
+    for (;;) {
+        cache_invalidate_range(wl_slots, sizeof(wl_slots));
+        uint32_t done = 0;
+        for (uint32_t i = 0; i < dispatched; i++) {
+            if (wl_slots[i].rec.done) done++;
+        }
+        if (done >= dispatched) break;
+        uint64_t elapsed = slm_get_time_ns() - bench_start_ns;
+        if (elapsed > timeout_ns) break;
+        /* Brief busy-wait then re-check. yield() would also work but
+         * a busy-wait keeps the timing simpler and doesn't return
+         * control to the scheduler in a way that could re-queue this
+         * task. */
+        workload_busy_wait_us(200);
+    }
+
+    uint64_t bench_end_ns = slm_get_time_ns();
+    cache_invalidate_range(wl_slots, sizeof(wl_slots));
+
+    /* Tally. */
+    out->tasks_dispatched = dispatched;
+    out->tasks_completed = 0;
+    out->deadline_tasks = 0;
+    out->deadline_misses = 0;
+    out->completion_max_us = 0;
+    uint64_t latencies[BENCH_WORKLOAD_MAX_TASKS];
+    uint32_t lat_count = 0;
+    for (uint32_t i = 0; i < dispatched; i++) {
+        if (!wl_slots[i].rec.done) continue;
+        out->tasks_completed++;
+        if (wl_slots[i].rec.ran_on_cpu < MAX_CPUS) {
+            out->cpu_completions[wl_slots[i].rec.ran_on_cpu]++;
+        }
+        latencies[lat_count++] = (uint64_t)wl_slots[i].rec.latency_us;
+        if ((uint64_t)wl_slots[i].rec.latency_us > out->completion_max_us)
+            out->completion_max_us = wl_slots[i].rec.latency_us;
+        if (wl_slots[i].rec.deadline_ns != 0) {
+            out->deadline_tasks++;
+            if (!wl_slots[i].rec.deadline_met) out->deadline_misses++;
+        }
+    }
+    if (lat_count > 0) {
+        sort_u64(latencies, lat_count);
+        out->completion_p50_us = quantile_milli(latencies, lat_count, 500);
+        out->completion_p99_us = quantile_milli(latencies, lat_count, 990);
+    } else {
+        out->completion_p50_us = 0;
+        out->completion_p99_us = 0;
+    }
+    out->cpu_balance_milli_cov = compute_cov_milli(out->cpu_completions, MAX_CPUS);
+    out->duration_ns = bench_end_ns - bench_start_ns;
+    if (out->duration_ns > 0) {
+        /* tasks per 1000 seconds, i.e. milli-tasks/sec for two-decimal
+         * display: ((completed * 1e9 * 1000) / duration_ns) → milli */
+        out->throughput_milli =
+            ((uint64_t)out->tasks_completed * 1000000000ULL * 1000ULL)
+            / out->duration_ns;
+    } else {
+        out->throughput_milli = 0;
+    }
+
+    /* Reap finished task structs so the next run starts with a clean
+     * table. Any task that didn't finish (timed-out) is forcibly
+     * terminated then destroyed to keep the table clean — see kernel
+     * CLAUDE.md "Leaky tests that block CPU 1" for why this matters. */
+    for (uint32_t i = 0; i < dispatched; i++) {
+        if (!created[i]) continue;
+        if (!wl_slots[i].rec.done) {
+            scheduler_terminate_task(created[i]);
+        }
+        task_destroy(created[i]);
+    }
+
+    if (prev) (void)sched_set_policy(prev);
+
+    return 0;
+}
+
+#endif /* CONFIG_AI_SCHEDULER */

--- a/kernel/sched/ai/workloads.c
+++ b/kernel/sched/ai/workloads.c
@@ -37,6 +37,8 @@
 #include "cache.h"
 #include "timer.h"
 #include "string.h"
+#include "preempt_point.h"
+#include "debug.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -44,6 +46,8 @@
 /* slm_get_time_ns prototype lives in kernel/include/util.h on most
  * platforms; declare locally to keep the include surface narrow. */
 extern uint64_t slm_get_time_ns(void);
+
+#define BENCH_WL_ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 /* ---- Workload templates ---- */
 
@@ -85,28 +89,28 @@ static const struct bench_workload bench_workloads_table[] = {
     {
         .name = "mixed",
         .templates = wl_mixed_tpls,
-        .n_templates = sizeof(wl_mixed_tpls) / sizeof(wl_mixed_tpls[0]),
+        .n_templates = BENCH_WL_ARRAY_SIZE(wl_mixed_tpls),
         .n_tasks_total = 24,
         .arrival_spacing_us = 300,
     },
     {
         .name = "deadline-heavy",
         .templates = wl_deadline_tpls,
-        .n_templates = sizeof(wl_deadline_tpls) / sizeof(wl_deadline_tpls[0]),
+        .n_templates = BENCH_WL_ARRAY_SIZE(wl_deadline_tpls),
         .n_tasks_total = 24,
         .arrival_spacing_us = 200,
     },
     {
         .name = "latency-sensitive",
         .templates = wl_latency_tpls,
-        .n_templates = sizeof(wl_latency_tpls) / sizeof(wl_latency_tpls[0]),
+        .n_templates = BENCH_WL_ARRAY_SIZE(wl_latency_tpls),
         .n_tasks_total = 24,
         .arrival_spacing_us = 150,
     },
     {
         .name = "cpu-bound",
         .templates = wl_cpu_bound_tpls,
-        .n_templates = sizeof(wl_cpu_bound_tpls) / sizeof(wl_cpu_bound_tpls[0]),
+        .n_templates = BENCH_WL_ARRAY_SIZE(wl_cpu_bound_tpls),
         .n_tasks_total = 16,
         .arrival_spacing_us = 0,
     },
@@ -115,7 +119,7 @@ static const struct bench_workload bench_workloads_table[] = {
 const struct bench_workload *bench_workload_find(const char *name)
 {
     if (!name) return 0;
-    for (uint32_t i = 0; i < sizeof(bench_workloads_table)/sizeof(bench_workloads_table[0]); i++) {
+    for (uint32_t i = 0; i < BENCH_WL_ARRAY_SIZE(bench_workloads_table); i++) {
         if (strcmp(name, bench_workloads_table[i].name) == 0) {
             return &bench_workloads_table[i];
         }
@@ -125,12 +129,12 @@ const struct bench_workload *bench_workload_find(const char *name)
 
 uint32_t bench_workload_count(void)
 {
-    return (uint32_t)(sizeof(bench_workloads_table)/sizeof(bench_workloads_table[0]));
+    return (uint32_t)BENCH_WL_ARRAY_SIZE(bench_workloads_table);
 }
 
 const struct bench_workload *bench_workload_get(uint32_t idx)
 {
-    if (idx >= sizeof(bench_workloads_table)/sizeof(bench_workloads_table[0])) return 0;
+    if (idx >= BENCH_WL_ARRAY_SIZE(bench_workloads_table)) return 0;
     return &bench_workloads_table[idx];
 }
 
@@ -155,6 +159,12 @@ struct __attribute__((aligned(64))) bench_wl_slot {
 };
 static struct bench_wl_slot wl_slots[BENCH_WORKLOAD_MAX_TASKS] __attribute__((aligned(64)));
 
+/* Re-entry guard. `bench_workload_run` mutates the module-static
+ * `wl_slots` array; a concurrent second caller (Lua, IPC, future
+ * non-shell entry point) would silently corrupt records. Mirrors the
+ * `in_split` pattern documented in kernel/CLAUDE.md §"Buddy Allocator". */
+static volatile bool bench_workload_in_flight = false;
+
 static void workload_busy_wait_us(uint32_t us)
 {
     if (us == 0) return;
@@ -163,6 +173,13 @@ static void workload_busy_wait_us(uint32_t us)
     uint64_t start = timer_get_count();
     while ((timer_get_count() - start) < target_cycles) {
         __asm__ volatile("" ::: "memory");
+        /* Cheap when the local quantum hasn't expired; falls into
+         * schedule() when ≥10 ms has elapsed (COOP_PREEMPT builds).
+         * Required by the kernel/CLAUDE.md §"Preemption Model"
+         * policy because the longest workload template's busy-wait
+         * (cpu-bound = 4000 us) can otherwise monopolize a CPU.
+         * Call site is lock-free per the preempt_point.h contract. */
+        slm_preempt_point();
     }
 }
 
@@ -283,10 +300,18 @@ int bench_workload_run(const struct sched_policy_ops *policy,
     if (wl->n_tasks_total == 0 || wl->n_tasks_total > BENCH_WORKLOAD_MAX_TASKS) return -1;
     if (wl->n_templates == 0) return -1;
 
+    if (bench_workload_in_flight) {
+        panic("bench_workload_run: reentrant invocation (wl_slots is single-owner)");
+    }
+    bench_workload_in_flight = true;
+
     /* Snapshot active policy so we can restore on the way out. */
     const struct sched_policy_ops *prev = sched_find_policy(sched_get_policy());
 
-    if (sched_set_policy(policy) < 0) return -1;
+    if (sched_set_policy(policy) < 0) {
+        bench_workload_in_flight = false;
+        return -1;
+    }
 
     /* Clear records. The dispatch loop below fills in dispatch_ns /
      * runtime_us / deadline_ns per slot and then cache_cleans the
@@ -315,26 +340,29 @@ int bench_workload_run(const struct sched_policy_ops *policy,
     for (uint32_t i = 0; i < wl->n_tasks_total; i++) {
         const struct bench_wl_template *tpl = &wl->templates[i % wl->n_templates];
 
-        uint64_t now_ns = slm_get_time_ns();
-        wl_slots[i].rec.dispatch_ns = now_ns;
-        wl_slots[i].rec.runtime_us = tpl->est_runtime_us;
-        if (tpl->deadline_slack_us > 0) {
-            wl_slots[i].rec.deadline_ns =
-                now_ns + (uint64_t)tpl->deadline_slack_us * 1000ULL;
-        }
-        /* Push slot to PoC so the worker (which may run on a
-         * different CPU with an incoherent L2) sees these fields. */
-        cache_clean_range(&wl_slots[i], sizeof(wl_slots[i]));
-
+        /* Create the worker first — task_create_with_priority does not
+         * queue it, so the worker can't run until scheduler_add_task
+         * below. Allocator + zeroing can take a non-trivial slice on
+         * Pi 5, so capture dispatch_ns AFTER creation to honor the
+         * header's "at scheduler_add_task time" contract. */
         struct task *t = task_create_with_priority(
             "wl_bench", workload_task_body,
             (void *)(uintptr_t)i, tpl->priority);
         if (!t) break;  /* Task table exhausted — report whatever we got. */
         created[i] = t;
 
+        uint64_t now_ns = slm_get_time_ns();
+        wl_slots[i].rec.dispatch_ns = now_ns;
+        wl_slots[i].rec.runtime_us = tpl->est_runtime_us;
         if (tpl->deadline_slack_us > 0) {
+            wl_slots[i].rec.deadline_ns =
+                now_ns + (uint64_t)tpl->deadline_slack_us * 1000ULL;
             task_set_deadline(t, wl_slots[i].rec.deadline_ns);
         }
+        /* Push slot to PoC so the worker (which may run on a
+         * different CPU with an incoherent L2) sees these fields. */
+        cache_clean_range(&wl_slots[i], sizeof(wl_slots[i]));
+
         scheduler_add_task(t);
         dispatched++;
 
@@ -430,6 +458,7 @@ int bench_workload_run(const struct sched_policy_ops *policy,
 
     if (prev) (void)sched_set_policy(prev);
 
+    bench_workload_in_flight = false;
     return 0;
 }
 

--- a/kernel/sched/ai/workloads.h
+++ b/kernel/sched/ai/workloads.h
@@ -1,0 +1,112 @@
+/*
+ * workloads.h — Real-workload comparison harness for AI scheduler policies (#882).
+ *
+ * Drives a representative task mix through `scheduler_add_task` so that
+ * pluggable policies (heuristic, ai_mlp, ai_ppo, ai_xgb) can be compared
+ * on scheduling **quality** (deadline-miss rate, completion-time
+ * percentiles, CPU-balance) rather than only inference-only decision
+ * latency. The shell entry point lives in `shell_sys.c` under
+ * `bench sched-policy --workload <name>`.
+ *
+ * The harness is gated behind CONFIG_AI_SCHEDULER because three of the
+ * four comparison policies require the AI runtime. The heuristic-only
+ * row remains available when running the harness on AI_SCHED builds.
+ *
+ * Per the exploratory-OS framing (#848) the harness reports
+ * characterization data; no winning policy is declared.
+ */
+
+#ifndef KERNEL_SCHED_AI_WORKLOADS_H
+#define KERNEL_SCHED_AI_WORKLOADS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "config.h"
+
+/* Maximum tasks dispatched per workload run. Bounded so the records
+ * array fits comfortably under the per-task slot budget in NC memory
+ * and so a missed completion never strands more than this many task
+ * slots in the global task table. */
+#define BENCH_WORKLOAD_MAX_TASKS  32u
+
+/* Task template — describes one entry in a workload's repeating
+ * pattern. `est_runtime_us` is the target busy-loop duration the
+ * task body will spin for; `deadline_slack_us` is the deadline
+ * relative to dispatch time (0 = no deadline); `priority` maps to
+ * the TASK_PRIORITY_* constants in `task.h`. */
+struct bench_wl_template {
+    uint32_t est_runtime_us;
+    uint32_t deadline_slack_us;
+    uint8_t  priority;
+    uint8_t  _pad[3];
+};
+
+/* Workload definition. Templates are applied round-robin to
+ * `n_tasks_total` dispatch slots; `arrival_spacing_us` is the
+ * busy-wait gap between successive dispatches (0 = burst). */
+struct bench_workload {
+    const char *name;
+    const struct bench_wl_template *templates;
+    uint32_t n_templates;
+    uint32_t n_tasks_total;
+    uint32_t arrival_spacing_us;
+};
+
+/* Per-task result record, populated by the worker on completion. */
+struct bench_wl_record {
+    uint64_t completion_ns;   /* end_ns relative to bench start; 0 = not done */
+    uint64_t deadline_ns;     /* absolute deadline copied from task->deadline_ns */
+    uint32_t latency_us;      /* end_ns - dispatch_ns */
+    uint8_t  ran_on_cpu;
+    uint8_t  deadline_met;    /* 1 if completion_ns <= deadline, else 0 */
+    uint8_t  done;            /* 1 once worker has finished and written its slot */
+    uint8_t  _pad;
+};
+
+/* Aggregate result of one (policy × workload) bench run. */
+struct bench_workload_result {
+    uint32_t tasks_dispatched;
+    uint32_t tasks_completed;
+    uint32_t deadline_tasks;     /* tasks that had a deadline */
+    uint32_t deadline_misses;
+    uint64_t completion_p50_us;
+    uint64_t completion_p99_us;
+    uint64_t completion_max_us;
+    uint32_t cpu_completions[MAX_CPUS];
+    /* CPU-balance metric — coefficient of variation × 1000, lower is
+     * more balanced. Computed across CPUs that received >0 tasks.
+     * Stored as integer milli-units to avoid printing fp from kernel. */
+    uint32_t cpu_balance_milli_cov;
+    uint64_t duration_ns;
+    uint64_t throughput_milli; /* tasks per 1000 seconds = milli-tasks/s; printable as X.XXX */
+};
+
+/* Look up a workload by name. Returns NULL if no match. */
+const struct bench_workload *bench_workload_find(const char *name);
+
+/* Enumerate workloads (for `--all`-style iteration / help text). */
+uint32_t bench_workload_count(void);
+const struct bench_workload *bench_workload_get(uint32_t idx);
+
+/*
+ * Run one (policy × workload) bench cycle.
+ *
+ * Switches to `policy` for the duration of the run, dispatches the
+ * workload's task mix through `scheduler_add_task` (so the active
+ * policy's `assign_cpu` is exercised), waits for completion with a
+ * generous timeout, then restores the previous policy. The aggregate
+ * metrics are written to *out.
+ *
+ * Returns 0 on success, -1 on setup error (invalid policy / workload /
+ * task table exhaustion before any dispatches).
+ *
+ * Must be called from the shell task (CPU 0). Worker tasks are
+ * dispatched at TASK_PRIORITY_HIGH so they preempt the bench loop's
+ * busy-wait on real platforms.
+ */
+struct sched_policy_ops;
+int bench_workload_run(const struct sched_policy_ops *policy,
+                       const struct bench_workload *wl,
+                       struct bench_workload_result *out);
+
+#endif /* KERNEL_SCHED_AI_WORKLOADS_H */

--- a/kernel/sched/ai/workloads.h
+++ b/kernel/sched/ai/workloads.h
@@ -52,15 +52,27 @@ struct bench_workload {
     uint32_t arrival_spacing_us;
 };
 
-/* Per-task result record, populated by the worker on completion. */
+/* Per-task slot: combines the worker's input (runtime_us +
+ * dispatch_ns, written by the driver before scheduler_add_task) and
+ * the worker's output (completion_ns, ran_on_cpu, deadline_met,
+ * done). Both halves live in one struct so a single
+ * cache_clean_range(&wl_slots[i], sizeof(wl_slots[i])) on the driver
+ * side covers everything the worker reads from this slot — important
+ * on Pi 5 / Jetson where per-core L2 caches are incoherent (no SMPEN).
+ * See kernel/CLAUDE.md §"Cache Maintenance (Pi 5 / No SMPEN)". */
 struct bench_wl_record {
-    uint64_t completion_ns;   /* end_ns relative to bench start; 0 = not done */
-    uint64_t deadline_ns;     /* absolute deadline copied from task->deadline_ns */
-    uint32_t latency_us;      /* end_ns - dispatch_ns */
+    /* --- Driver-written input (read by worker) --- */
+    uint64_t dispatch_ns;     /* slm_get_time_ns() at scheduler_add_task time */
+    uint32_t runtime_us;      /* template's est_runtime_us — worker busy-waits this long */
+    uint32_t _pad_input;
+    uint64_t deadline_ns;     /* absolute deadline copied from task->deadline_ns; 0 = none */
+    /* --- Worker-written output (read by driver after task exits) --- */
+    uint64_t completion_ns;   /* end_ns; 0 = not yet done */
+    uint32_t latency_us;      /* completion_ns - dispatch_ns */
     uint8_t  ran_on_cpu;
     uint8_t  deadline_met;    /* 1 if completion_ns <= deadline, else 0 */
     uint8_t  done;            /* 1 once worker has finished and written its slot */
-    uint8_t  _pad;
+    uint8_t  _pad_output;
 };
 
 /* Aggregate result of one (policy × workload) bench run. */

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1161,6 +1161,160 @@ static void bench_sched_policy(void)
                          hailo_h, 1000);
     }
 }
+
+/* --- Scheduling-quality workload comparison (#882, sub-ticket of #61) ---
+ *
+ * `bench sched-policy --workload <name> [--policy <p>|--all]` exercises
+ * a representative task mix through `scheduler_add_task` so different
+ * policies can be compared on real scheduling quality (deadline-miss
+ * rate, completion-time p50/p99, CPU-balance, throughput) rather than
+ * only inference-only decision latency.
+ *
+ * Workload definitions + the run loop live in
+ * `kernel/sched/ai/workloads.c`; this layer is the shell-side parser
+ * and pretty-printer.
+ *
+ * Per the exploratory-OS framing (#848) the harness reports
+ * characterization data; no winning policy is declared.
+ */
+#include "workloads.h"
+
+static void bench_sched_workload_print_header(const struct bench_workload *wl)
+{
+    shell_printf("\r\nWorkload: %s  (%u tasks, %u-template mix, "
+                 "%u us spacing, %u CPUs)\r\n",
+                 wl->name, (unsigned)wl->n_tasks_total,
+                 (unsigned)wl->n_templates,
+                 (unsigned)wl->arrival_spacing_us,
+                 (unsigned)cpu_count);
+    shell_puts("Policy        | Done    | DL-tasks | DL-miss% | p50 us | "
+               "p99 us | max us | CPU-cov | Tasks/s\r\n");
+    shell_puts("--------------+---------+----------+----------+--------+"
+               "--------+--------+---------+--------\r\n");
+}
+
+static void bench_sched_workload_print_row(const char *policy_name,
+                                           const struct bench_workload_result *r)
+{
+    /* Deadline-miss percent (one decimal) with safe divide. */
+    uint32_t dl_pct_x10 = 0;
+    if (r->deadline_tasks > 0) {
+        dl_pct_x10 = (uint32_t)(((uint64_t)r->deadline_misses * 1000ULL)
+                                 / (uint64_t)r->deadline_tasks);
+    }
+    /* Throughput milli-units → "N.NNN" decimal. */
+    uint64_t tp_int = r->throughput_milli / 1000ULL;
+    uint64_t tp_frac = r->throughput_milli % 1000ULL;
+    shell_printf(
+        "%-13s | %3u/%-3u | %8u | %4u.%u%%   | %6lu | %6lu | %6lu | %3u.%03u | %lu.%03lu\r\n",
+        policy_name,
+        (unsigned)r->tasks_completed,
+        (unsigned)r->tasks_dispatched,
+        (unsigned)r->deadline_tasks,
+        (unsigned)(dl_pct_x10 / 10u),
+        (unsigned)(dl_pct_x10 % 10u),
+        (unsigned long)r->completion_p50_us,
+        (unsigned long)r->completion_p99_us,
+        (unsigned long)r->completion_max_us,
+        (unsigned)(r->cpu_balance_milli_cov / 1000u),
+        (unsigned)(r->cpu_balance_milli_cov % 1000u),
+        (unsigned long)tp_int, (unsigned long)tp_frac);
+}
+
+static int bench_sched_workload_one(const struct sched_policy_ops *policy,
+                                    const struct bench_workload *wl)
+{
+    struct bench_workload_result r;
+    int rc = bench_workload_run(policy, wl, &r);
+    if (rc < 0) {
+        shell_printf("%-13s | (setup error)\r\n", policy->name);
+        return rc;
+    }
+    bench_sched_workload_print_row(policy->name, &r);
+    return 0;
+}
+
+static void bench_sched_workload_dispatch(const struct bench_workload *wl,
+                                          const char *policy_filter,
+                                          bool all_policies)
+{
+    bench_sched_workload_print_header(wl);
+
+    if (all_policies) {
+        int count = sched_policy_count();
+        for (int i = 0; i < count; i++) {
+            const struct sched_policy_ops *p = sched_policy_get(i);
+            if (!p) continue;
+            /* Skip ai_hailo when no HEF is loaded — without a model it
+             * falls back to heuristic on every assign_cpu and produces
+             * a row that's indistinguishable from heuristic. */
+            if (p->name && p->name[0] == 'a' && p->name[1] == 'i' &&
+                p->name[2] == '_' && p->name[3] == 'h') {
+                extern inference_model_handle_t ai_policy_hailo_get_model_handle(void);
+                if (ai_policy_hailo_get_model_handle() == INF_INVALID_HANDLE) continue;
+            }
+            (void)bench_sched_workload_one(p, wl);
+        }
+    } else if (policy_filter) {
+        const struct sched_policy_ops *p = sched_find_policy(policy_filter);
+        if (!p) {
+            shell_printf("Unknown policy: %s (try heuristic, ai_mlp, ai_ppo, ai_xgb)\r\n",
+                         policy_filter);
+            return;
+        }
+        (void)bench_sched_workload_one(p, wl);
+    } else {
+        const struct sched_policy_ops *p = sched_find_policy(sched_get_policy());
+        if (p) (void)bench_sched_workload_one(p, wl);
+    }
+
+    shell_puts("\r\nNote: characterization-only output per #848; no "
+               "winning policy declared.\r\n");
+}
+
+/* Returns 0 if we handled a workload mode (caller should not run the
+ * legacy inference-only path); 1 if no --workload was passed. */
+static int bench_sched_policy_cli(int argc, char *argv[])
+{
+    const char *workload_name = 0;
+    const char *policy_filter = 0;
+    bool all_policies = false;
+
+    for (int i = 2; i < argc; i++) {
+        if (strcmp(argv[i], "--workload") == 0 && i + 1 < argc) {
+            workload_name = argv[++i];
+        } else if (strcmp(argv[i], "--policy") == 0 && i + 1 < argc) {
+            policy_filter = argv[++i];
+        } else if (strcmp(argv[i], "--all") == 0) {
+            all_policies = true;
+        } else if (strcmp(argv[i], "--list-workloads") == 0) {
+            shell_puts("Workloads:\r\n");
+            for (uint32_t k = 0; k < bench_workload_count(); k++) {
+                const struct bench_workload *wl = bench_workload_get(k);
+                shell_printf("  %-18s  %u tasks, %u templates\r\n",
+                             wl->name, (unsigned)wl->n_tasks_total,
+                             (unsigned)wl->n_templates);
+            }
+            return 0;
+        } else {
+            shell_printf("Unknown sched-policy flag: %s\r\n", argv[i]);
+            shell_puts("Usage: bench sched-policy [--workload <name> "
+                       "[--policy <p>|--all]] [--list-workloads]\r\n");
+            return 0;
+        }
+    }
+
+    if (!workload_name) return 1;
+
+    const struct bench_workload *wl = bench_workload_find(workload_name);
+    if (!wl) {
+        shell_printf("Unknown workload: %s\r\n", workload_name);
+        shell_puts("Try `bench sched-policy --list-workloads`.\r\n");
+        return 0;
+    }
+    bench_sched_workload_dispatch(wl, policy_filter, all_policies);
+    return 0;
+}
 #endif /* CONFIG_AI_SCHEDULER */
 
 /* --- Scheduler stats snapshot --- */
@@ -1815,7 +1969,12 @@ int cmd_bench(int argc, char *argv[])
         }
 #if defined(CONFIG_AI_SCHEDULER)
     } else if (strcmp(argv[1], "sched-policy") == 0) {
-        bench_sched_policy();
+        /* Workload-driven scheduling-quality mode runs when --workload
+         * is present; otherwise fall through to the legacy inference-
+         * only latency benchmark for backward compatibility. */
+        if (bench_sched_policy_cli(argc, argv) != 0) {
+            bench_sched_policy();
+        }
 #endif
     } else if (strcmp(argv[1], "all") == 0) {
         shell_puts("SLM-OS Performance Benchmarks\r\n");

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1248,10 +1248,11 @@ static void bench_sched_workload_dispatch(const struct bench_workload *wl,
             /* Skip ai_hailo when no HEF is loaded — without a model it
              * falls back to heuristic on every assign_cpu and produces
              * a row that's indistinguishable from heuristic. */
-            if (p->name && p->name[0] == 'a' && p->name[1] == 'i' &&
-                p->name[2] == '_' && p->name[3] == 'h') {
+            if (p->name && strcmp(p->name, "ai_hailo") == 0) {
                 extern inference_model_handle_t ai_policy_hailo_get_model_handle(void);
-                if (ai_policy_hailo_get_model_handle() == INF_INVALID_HANDLE) continue;
+                if (ai_policy_hailo_get_model_handle() == INF_INVALID_HANDLE) {
+                    continue;
+                }
             }
             (void)bench_sched_workload_one(p, wl);
         }

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1079,6 +1079,7 @@ static void bench_ipc_latency(void)
 #if defined(CONFIG_AI_SCHEDULER)
 #include "inference_device.h"
 #include "ai_types.h"
+#include "../sched/ai/ai_policy_hailo.h"
 
 static void bench_policy_one(const char *dev_name,
                              enum inference_dtype dtype,
@@ -1247,10 +1248,13 @@ static void bench_sched_workload_dispatch(const struct bench_workload *wl,
             if (!p) continue;
             /* Skip ai_hailo when no HEF is loaded — without a model it
              * falls back to heuristic on every assign_cpu and produces
-             * a row that's indistinguishable from heuristic. */
+             * a row that's indistinguishable from heuristic. Print a
+             * notice so a future bench operator doesn't wonder why a
+             * four-policy comparison shows three rows. */
             if (p->name && strcmp(p->name, "ai_hailo") == 0) {
-                extern inference_model_handle_t ai_policy_hailo_get_model_handle(void);
                 if (ai_policy_hailo_get_model_handle() == INF_INVALID_HANDLE) {
+                    shell_puts("ai_hailo      | (skipped — no HEF loaded; "
+                               "`hailo load <hef>` first)\r\n");
                     continue;
                 }
             }

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -4928,6 +4928,13 @@ static void test_bench_workload_find_known_names(void)
 
     TEST_ASSERT_NULL(bench_workload_find("does-not-exist"));
     TEST_ASSERT_NULL(bench_workload_find(NULL));
+
+    /* Pin a representative template value so a future edit that
+     * accidentally changes a workload's runtime by an order of
+     * magnitude surfaces here rather than in silent table drift. */
+    TEST_ASSERT_TRUE(mixed->templates[0].est_runtime_us > 0);
+    TEST_ASSERT_TRUE(mixed->templates[0].est_runtime_us < 10000);
+    TEST_ASSERT_TRUE(mixed->arrival_spacing_us < 10000);
 }
 
 static void test_bench_workload_get_enumerates_all(void)
@@ -4995,7 +5002,9 @@ static void test_bench_workload_run_heuristic_mixed(void)
     /* Sum of per-CPU completions == total completions (no records
      * leak past the cpu_completions[] array). */
     uint32_t cpu_sum = 0;
-    for (uint32_t i = 0; i < MAX_CPUS; i++) cpu_sum += r.cpu_completions[i];
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        cpu_sum += r.cpu_completions[i];
+    }
     TEST_ASSERT_EQUAL_UINT32(r.tasks_completed, cpu_sum);
 }
 #endif /* ENABLE_BOOT_TESTS */

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -4897,6 +4897,112 @@ static void test_task_pinned_to_cpu0(void)
 }
 
 /* ============================================================================
+ * Real-workload comparison harness tests (#882, sub-ticket of #61)
+ *
+ * The harness lives in `kernel/sched/ai/workloads.c` and is exercised
+ * from the shell via `bench sched-policy --workload <name>`. These
+ * tests pin the public API (workload lookup, result struct shape) so a
+ * future refactor can't silently change the table the docs cite.
+ * ============================================================================ */
+
+#ifdef CONFIG_AI_SCHEDULER
+#include "../sched/ai/workloads.h"
+
+/* Integer-only smoke: lookup table is what `bench sched-policy
+ * --list-workloads` advertises and what the sibling-repo training
+ * pipeline expects to read back. */
+static void test_bench_workload_find_known_names(void)
+{
+    TEST_ASSERT_EQUAL_UINT32(4, bench_workload_count());
+
+    const struct bench_workload *mixed = bench_workload_find("mixed");
+    TEST_ASSERT_NOT_NULL(mixed);
+    TEST_ASSERT_NOT_NULL(mixed->templates);
+    TEST_ASSERT_TRUE(mixed->n_templates >= 1);
+    TEST_ASSERT_TRUE(mixed->n_tasks_total > 0);
+    TEST_ASSERT_TRUE(mixed->n_tasks_total <= BENCH_WORKLOAD_MAX_TASKS);
+
+    TEST_ASSERT_NOT_NULL(bench_workload_find("deadline-heavy"));
+    TEST_ASSERT_NOT_NULL(bench_workload_find("latency-sensitive"));
+    TEST_ASSERT_NOT_NULL(bench_workload_find("cpu-bound"));
+
+    TEST_ASSERT_NULL(bench_workload_find("does-not-exist"));
+    TEST_ASSERT_NULL(bench_workload_find(NULL));
+}
+
+static void test_bench_workload_get_enumerates_all(void)
+{
+    /* Every index < count must return a populated workload; every
+     * index >= count must return NULL. This keeps `--list-workloads`
+     * honest against a future entry being added without bumping the
+     * count or vice versa. */
+    uint32_t n = bench_workload_count();
+    for (uint32_t i = 0; i < n; i++) {
+        const struct bench_workload *wl = bench_workload_get(i);
+        TEST_ASSERT_NOT_NULL(wl);
+        TEST_ASSERT_NOT_NULL(wl->name);
+        TEST_ASSERT_NOT_NULL(wl->templates);
+        TEST_ASSERT_TRUE(wl->n_templates >= 1);
+        TEST_ASSERT_TRUE(wl->n_tasks_total > 0);
+    }
+    TEST_ASSERT_NULL(bench_workload_get(n));
+    TEST_ASSERT_NULL(bench_workload_get(n + 100));
+}
+
+static void test_bench_workload_run_rejects_bad_args(void)
+{
+    struct bench_workload_result r;
+    const struct sched_policy_ops *heur = sched_find_policy("heuristic");
+    const struct bench_workload *mixed = bench_workload_find("mixed");
+    TEST_ASSERT_NOT_NULL(heur);
+    TEST_ASSERT_NOT_NULL(mixed);
+
+    TEST_ASSERT_EQUAL_INT(-1, bench_workload_run(NULL, mixed, &r));
+    TEST_ASSERT_EQUAL_INT(-1, bench_workload_run(heur, NULL, &r));
+    TEST_ASSERT_EQUAL_INT(-1, bench_workload_run(heur, mixed, NULL));
+}
+
+#if defined(ENABLE_BOOT_TESTS)
+/* End-to-end: heuristic policy + mixed workload. We don't assert any
+ * specific scheduling-quality threshold (QEMU timing is jittery and
+ * the harness is characterization-only per #848). Instead we pin the
+ * invariants that downstream tooling depends on: dispatch != 0,
+ * `tasks_completed <= tasks_dispatched`, percentile fields populated
+ * when any task completed, throughput nonzero when any task
+ * completed. */
+static void test_bench_workload_run_heuristic_mixed(void)
+{
+    const struct sched_policy_ops *heur = sched_find_policy("heuristic");
+    const struct bench_workload *mixed = bench_workload_find("mixed");
+    TEST_ASSERT_NOT_NULL(heur);
+    TEST_ASSERT_NOT_NULL(mixed);
+
+    struct bench_workload_result r = { 0 };
+    int rc = bench_workload_run(heur, mixed, &r);
+    TEST_ASSERT_EQUAL_INT(0, rc);
+
+    TEST_ASSERT_TRUE(r.tasks_dispatched > 0);
+    TEST_ASSERT_TRUE(r.tasks_dispatched <= mixed->n_tasks_total);
+    TEST_ASSERT_TRUE(r.tasks_completed <= r.tasks_dispatched);
+    TEST_ASSERT_TRUE(r.deadline_misses <= r.deadline_tasks);
+    TEST_ASSERT_TRUE(r.duration_ns > 0);
+    if (r.tasks_completed > 0) {
+        TEST_ASSERT_TRUE(r.completion_p50_us <= r.completion_p99_us);
+        TEST_ASSERT_TRUE(r.completion_p99_us <= r.completion_max_us);
+        TEST_ASSERT_TRUE(r.throughput_milli > 0);
+    }
+
+    /* Sum of per-CPU completions == total completions (no records
+     * leak past the cpu_completions[] array). */
+    uint32_t cpu_sum = 0;
+    for (uint32_t i = 0; i < MAX_CPUS; i++) cpu_sum += r.cpu_completions[i];
+    TEST_ASSERT_EQUAL_UINT32(r.tasks_completed, cpu_sum);
+}
+#endif /* ENABLE_BOOT_TESTS */
+
+#endif /* CONFIG_AI_SCHEDULER */
+
+/* ============================================================================
  * Test Suite Entry Point
  * ============================================================================ */
 
@@ -5164,6 +5270,14 @@ int test_suite_scheduler(void)
     RUN_TEST(test_sched_cmd_policy_list);
     RUN_TEST(test_sched_cmd_stats);
     RUN_TEST(test_sched_cmd_invalid);
+
+    /* #882 — real-workload comparison harness (kernel/sched/ai/workloads.c). */
+    RUN_TEST(test_bench_workload_find_known_names);
+    RUN_TEST(test_bench_workload_get_enumerates_all);
+    RUN_TEST(test_bench_workload_run_rejects_bad_args);
+#if defined(ENABLE_BOOT_TESTS)
+    RUN_TEST(test_bench_workload_run_heuristic_mixed);
+#endif
 #endif
 
     return UnityEnd();


### PR DESCRIPTION
## Summary

Closes [#882](https://github.com/SLM-OS/SLM-Operating-System/issues/882) (sub-ticket of [#61](https://github.com/SLM-OS/SLM-Operating-System/issues/61)). Adds the real-workload comparison harness that drives a representative task mix through `scheduler_add_task` and reports per-policy scheduling quality (deadline-miss%, completion-time p50/p99/max, per-CPU balance, throughput) — not only inference-only decision latency.

The inference-only mode (legacy `bench sched-policy` with no flags) is unchanged and still works.

## What changed

- **New CLI:** `bench sched-policy --workload <name> [--policy <p>|--all] [--list-workloads]`
- **New module:** `kernel/sched/ai/workloads.{c,h}` — workload templates + run loop
- **Four shipped workloads:** `mixed`, `deadline-heavy`, `latency-sensitive`, `cpu-bound`
- **Cross-policy iteration:** `--all` iterates every registered policy (heuristic, ai_mlp, ai_ppo, ai_xgb, ai_hailo) and skips ai_hailo cleanly when no HEF is loaded
- **Tests:** 4 new in `kernel/tests/test_scheduler.c`, all pass on QEMU
- **Docs:** new section in `docs/benchmarks.md`

Per the [exploratory-OS framing (#848)](https://github.com/SLM-OS/SLM-Operating-System/issues/848) the harness reports characterization data only — no winning policy is declared in the output.

## Why now

#58 (XGBoost) has merged, so `ai_xgb` is in the registry. Without it the harness would have needed a retrofit pass for the fourth policy.

## Test plan

- [x] `make test AI_SCHED=ON` — clean except the same 8 pre-existing failures as main
- [x] `make kernel PLATFORM=RASPI5 AI_SCHED=ON` — clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO AI_SCHED=ON` — pre-existing "Kernel image too large" on main (same with and without this branch; per [#886](https://github.com/SLM-OS/SLM-Operating-System/pull/886) commit message)
- [x] `bench_workload_find` / `bench_workload_get` / `bench_workload_run` API coverage in QEMU
- [ ] Hardware run on pi-5-2 + jetson-nano-1 — deferred to [#884 (61d)](https://github.com/SLM-OS/SLM-Operating-System/issues/884) once trace capture + fine-tune land, so the full synthetic-vs-real comparison matrix can be filled in one coordinated pass. Coordination with @johnjezl before flashing either board.

## Out of scope (per #882's "Out of scope")

- SLM-OS-side trace collection → [#880](https://github.com/SLM-OS/SLM-Operating-System/issues/880) (61b)
- Sibling-repo fine-tune → [#879](https://github.com/SLM-OS/SLM-Operating-System/issues/879) (61c)
- Documentation of retrained-weight comparison → [#884](https://github.com/SLM-OS/SLM-Operating-System/issues/884) (61d)
- Replacing inference-only mode — backward compatible

Refs #61 (parent), #882 (this sub-ticket), #848 (framing), #58 (xgb dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)