### PR TITLE
msg_router #67 audit: pin publish_nowait contract + refresh fact sheet

### DIFF
--- a/docs/fact-sheets/ipc.md
+++ b/docs/fact-sheets/ipc.md
@@ -7,12 +7,20 @@ Message routing, pub/sub, shared buffers, priority-inheritance mutexes.
 | Sub-capability | QEMU (ARM64) | Pi 5 | Jetson | x86-64 |
 |---|---|---|---|---|
 | Message router | Topic-based pub/sub | Same | Same | Same |
-| Publisher API | `msg_router_publish(topic, msg, size)` | Same | Same | Same |
-| Subscriber API | `msg_subscribe(topic, cb)` / `msg_unsubscribe` | Same | Same | Same |
-| Topic name limit | Fixed size in struct | Same | Same | Same |
-| Message shape | Pointer + size; no serialization | Same | Same | Same |
-| Ack model | Per-message ack with timeout | Same | Same | Same |
-| Ack timeout source | `pit_ticks` | `timer_get_count()` CNTPCT | Same | LAPIC timer |
+| Publisher API (default, ack-wait) | `msg_router_publish(topic, data)` | Same | Same | Same |
+| Publisher API (priority, ack-wait) | `msg_router_publish_priority(topic, data, prio)` | Same | Same | Same |
+| Publisher API (fire-and-forget) | `msg_router_publish_nowait(topic, data)` | Same | Same | Same |
+| Subscriber API | `msg_router_subscribe(topic, component_idx)` / `msg_router_unsubscribe_all(idx)` | Same | Same | Same |
+| Receive / ack API | `msg_router_receive(idx, topic_out)` + `msg_router_ack(idx)` | Same | Same | Same |
+| Topic name limit | `TOPIC_NAME_LEN = 16` incl. NUL; oversized rejected (#69) | Same | Same | Same |
+| Wildcard subscriptions | Pattern ending in `*` matches topic prefix (`/sensors/*`) | Same | Same | Same |
+| Per-subscription delivery | Exact + wildcard match deliver **once per subscription** (DDS / ROS 2 / ZeroMQ contract) | Same | Same | Same |
+| Cross-mailbox priority ordering | `receive()` returns highest-priority ready mailbox under lock-held scan | Same | Same | Same |
+| LAST_RECEIVED ack-targeting | `ack` clears exactly the mailbox the most recent `receive` returned, even under cross-CPU activity | Same | Same | Same |
+| Single-slot mailbox limitation | Back-to-back nowait deliver to same mailbox overwrites first message (#869 — post-capstone) | Same | Same | Same |
+| Message shape | Pointer + NUL-terminated bytes (`MAX_MSG_LEN = 60`) | Same | Same | Same |
+| Ack model | Per-message ack with 5 s CNTPCT timeout (no-ack-wait variant available) | Same | Same | Same |
+| Ack timeout source | `timer_get_count()` CNTPCT | Same | Same | LAPIC timer |
 | Shared buffers | Ring buffers with producer/consumer pointers | Same | Same | Same |
 | Shared buffer cache maintenance | — | DC CVAC/CIVAC required | Same | — |
 | Priority-inheritance mutex | ✅ (mutex.h) | Same | Same | Same |
@@ -20,6 +28,22 @@ Message routing, pub/sub, shared buffers, priority-inheritance mutexes.
 | Shell surface | `msg send <topic> <payload>`, `msg list`, `msg subscribe <topic>` | Same | Same | Same |
 | Lua bindings | `slm.msg_publish`, `slm.msg_subscribe`, `slm.msg_unsubscribe` | Same | Same | Same |
 | Multi-state Lua msg fan-out | Shared `LUA_MSG_SUB_IDX` sentinel | Same | Same | Same |
+
+### Concurrency stress tests (#67)
+
+The router's concurrency contracts above are pinned by automated tests
+that run on every `make test`:
+
+| Test | Suite | What it pins |
+|---|---|---|
+| `test_msg_router_cross_cpu` | `test_integration.c` | Cross-CPU pub/recv/ack round-trip without router-internal deadlock (#66) |
+| `test_msg_router_multi_subscriber` | `test_integration.c` | 2 subs on 2 CPUs both receive every message from a 3rd-CPU publisher; `delivered == 2` per publish (#864 / #67a) |
+| `test_msg_router_priority_concurrent` | `test_integration.c` | High-prio + low-prio publishers don't starve each other under sustained load; cross-mailbox prio scan picks high-prio first (#864 / #67a) |
+| `test_wildcard_exact_overlap_delivers_twice` | `test_msg_router.c` | Exact + wildcard overlap delivers twice (one per subscription) (#863 / #67b) |
+| `test_wildcard_only_delivers_once` | `test_msg_router.c` | Wildcard-only match delivers once (#863 / #67b) |
+| `test_msg_router_ack_targets_last_received` | `test_msg_router.c` | `ack` clears the right mailbox when a newer message landed in a different mailbox between receive and ack (#867 / #67c) |
+| `test_msg_router_ack_targets_last_received_cross_cpu` | `test_integration.c` | Same as above but the second publish happens on a different CPU than receive/ack (#867 / #67c) |
+| `test_publish_nowait_basic_contract` | `test_msg_router.c` | `publish_nowait` returns immediately with fan-out count, rejects NULL / oversized topics, overwrites unacked mailbox in place |
 
 ## Skipped / Blocked
 
@@ -35,4 +59,4 @@ Message routing, pub/sub, shared buffers, priority-inheritance mutexes.
 - `docs/m7-message-router.md` (design doc)
 - `docs/component-development.md` §"Message router hookup"
 
-*Last updated: 18 April 2026*
+*Last updated: 15 May 2026 (#67 concurrency-test audit)*

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -389,6 +389,86 @@ static void test_msg_router_ack_targets_last_received(void)
     msg_router_unsubscribe_all(5);
 }
 
+/*
+ * Coverage for msg_router_publish_nowait's own contracts (#67 audit follow-up).
+ *
+ * `publish_nowait` was previously only exercised as a *vehicle* in the 67b
+ * and 67c tests above. Those tests pin contracts (per-subscription delivery,
+ * LAST_RECEIVED ack-targeting) that depend on publish_nowait's fan-out
+ * behaviour but don't assert publish_nowait's own contracts directly:
+ *
+ *   1. **Returns immediately** with the mailbox fan-out count — no 5 s
+ *      ack-wait like msg_router_publish.
+ *   2. **Returns 0 for NULL topic_name.**
+ *   3. **Returns 0 for oversized topic_name** (rejects truncation per #69).
+ *   4. **Returns 0 when no subscribers match** (no targets to deliver to).
+ *   5. **Overwrites unconditionally** — a second nowait deliver to the same
+ *      mailbox while the first is still unacked replaces the data, ready
+ *      stays set. The subscriber sees only the second message; the first
+ *      is lost. This is the documented single-slot mailbox behaviour
+ *      (tracked for queued-mailbox redesign as #869). The test asserts the
+ *      contract as it stands today so a future fix that changes semantics
+ *      forces an explicit test update rather than a silent regression.
+ */
+static void test_publish_nowait_basic_contract(void)
+{
+    msg_router_init();
+
+    /* Contract (2): NULL topic returns 0. */
+    TEST_ASSERT_EQUAL_INT(0,
+        msg_router_publish_nowait(NULL, (const uint8_t *)"x"));
+
+    /* Contract (3): oversized topic (>= TOPIC_NAME_LEN) returns 0.
+     * "/sensors/temperature" is 20 bytes; TOPIC_NAME_LEN is 16. */
+    TEST_ASSERT_EQUAL_INT(0, msg_router_publish_nowait(
+        (const uint8_t *)"/sensors/temperature", (const uint8_t *)"x"));
+
+    /* Contract (4): no subscribers → 0, and returns immediately
+     * (we measure the timer to confirm no ack-wait). */
+    uint64_t freq = timer_get_frequency();
+    uint64_t t0 = timer_get_count();
+    int delivered = msg_router_publish_nowait(
+        (const uint8_t *)"/nw/empty", (const uint8_t *)"x");
+    uint64_t elapsed = timer_get_count() - t0;
+    TEST_ASSERT_EQUAL_INT(0, delivered);
+    TEST_ASSERT_LESS_THAN(freq, elapsed);  /* << 1 second */
+
+    /* Contract (1): subscribed topic → returns fan-out count immediately. */
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe("/nw/one", 9));
+    t0 = timer_get_count();
+    delivered = msg_router_publish_nowait(
+        (const uint8_t *)"/nw/one", (const uint8_t *)"hi");
+    elapsed = timer_get_count() - t0;
+    TEST_ASSERT_EQUAL_INT(1, delivered);
+    TEST_ASSERT_LESS_THAN(freq, elapsed);
+
+    /* Contract (5): second nowait deliver to the same unacked mailbox
+     * overwrites the first. The subscriber receives only the second
+     * payload — first is lost. This pins the documented limitation
+     * tracked as #869; if a queued-mailbox redesign lands, this test
+     * is the canary that forces the test to be updated together with
+     * the doc/runtime change. */
+    delivered = msg_router_publish_nowait(
+        (const uint8_t *)"/nw/one", (const uint8_t *)"two");
+    TEST_ASSERT_EQUAL_INT(1, delivered);
+
+    uint8_t topic_buf[16];
+    const uint8_t *msg = msg_router_receive(9, topic_buf);
+    TEST_ASSERT_NOT_NULL(msg);
+    TEST_ASSERT_EQUAL_STRING("/nw/one", (const char *)topic_buf);
+    /* Single-slot mailbox: only the second message survives — the
+     * first ("hi") was overwritten in place by the second ("two"). */
+    TEST_ASSERT_EQUAL_STRING("two", (const char *)msg);
+    msg_router_ack(9);
+
+    /* Mailbox now empty — a second receive returns NULL (confirms
+     * the overwrite collapsed two publishes into one mailbox slot,
+     * not two slots). */
+    TEST_ASSERT_NULL(msg_router_receive(9, topic_buf));
+
+    msg_router_unsubscribe_all(9);
+}
+
 int test_suite_msg_router(void)
 {
     UNITY_BEGIN();
@@ -402,6 +482,7 @@ int test_suite_msg_router(void)
     RUN_TEST(test_wildcard_exact_overlap_delivers_twice);
     RUN_TEST(test_wildcard_only_delivers_once);
     RUN_TEST(test_msg_router_ack_targets_last_received);
+    RUN_TEST(test_publish_nowait_basic_contract);
     RUN_TEST(test_publish_times_out_without_ack);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Audit follow-up to the #67 message-router concurrency test work
(#864 / #863 / #867 / #868 already merged on main). Two gaps
surfaced when reviewing whether all changes have comprehensive
tests + up-to-date documentation:

1. **`msg_router_publish_nowait` has no dedicated test.** It was used
   as a *vehicle* in 67b and 67c (`publish_nowait` then
   `receive`/`ack` to pin per-subscription delivery and LAST_RECEIVED
   targeting), but its own contracts — immediate return, NULL /
   oversized topic rejection, mailbox overwrite — were never asserted.

2. **`docs/fact-sheets/ipc.md` is stale.** Wrong signature for
   `msg_router_publish` (`(topic, msg, size)` ← incorrect, real is
   `(topic, data)`); no mention of `publish_priority`,
   `publish_nowait`, the per-subscription delivery contract, the
   cross-mailbox priority ordering, the LAST_RECEIVED ack-targeting,
   or the single-slot mailbox limitation.

## Changes

- **`test_publish_nowait_basic_contract`** (new test in
  `kernel/tests/test_msg_router.c`) pins:
  - Returns immediately with fan-out count (verified via CNTPCT vs
    `timer_get_frequency`).
  - Returns 0 for NULL `topic_name`.
  - Returns 0 for oversized `topic_name` (≥ `TOPIC_NAME_LEN`).
  - Returns 0 when no subscribers match.
  - Overwrites unacked mailbox in place — pins the documented
    single-slot mailbox limitation (#869) so a future queued-mailbox
    redesign has to update the test, not silently regress callers.

- **`docs/fact-sheets/ipc.md`**: rewrote the Matrix table with
  corrected signatures and the four concurrency guarantees pinned
  by #67. Added a new "Concurrency stress tests (#67)" subsection
  that maps each guarantee to its pinning test. Refreshed
  "Last updated" stamp.

No behavior change in `runtime/src/msg_router.rs`.

## Test plan

- [x] `make test` — full suite green; new test PASS.
- [x] `make kernel PLATFORM=RASPI5` — clean build.
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean build.
- [ ] Hardware verification — not required for this audit PR; the new
      `publish_nowait` test runs single-threaded on the same code path
      already verified on pi-5-2 via the 67b / 67c tests.

Refs #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)