### PR TITLE
tests+docs: dynamic-batching shell/Lua coverage + ffi.md section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -991,6 +991,10 @@ set(TEST_SOURCES
     # as test_slm_shell.c — the slm_runner library only links on ARM64
     # because rust_slm_session_open / rust_slm_prompt are ARM64-only.
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_slm_runner.c>
+    # Dynamic-batching shell verb tests (#55 / PR #917). ARM64-only —
+    # the underlying rust_infer_batch_* / rust_infer_stress_run FFI
+    # is gated like the rest of the inference stack.
+    $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_infer_shell.c>
     # SLM GPU dispatch counter FFI tests (PR #831). Cross-platform —
     # `slm_runtime_dispatch_stats` / `_reset` are defined for every
     # platform (Jetson has the real impl, others share the stub at

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -401,6 +401,104 @@ typedef struct {
 
 The `rust_infer_stats()` function fills the caller-provided struct with cumulative statistics from the inference engine. Latency values are tracked per-inference and reported in microseconds. The `rust_infer_bench()` function runs the specified number of iterations on the given model and prints a summary (min/avg/max latency) to the UART console.
 
+### Dynamic Batching FFI (called from C)
+
+Issue #55 / PRs #862 + #908 + #917. The `InferenceScheduler`
+(`runtime/src/sched/inference.rs`) exposes a runtime-toggleable
+batched-dispatch mode to the C kernel via the entrypoints below.
+Mode is OFF by default; flip it on via the shell (`infer batch on`)
+or Lua (`slm.infer_batch_mode("on")`). All entrypoints are safe to
+call from any task context.
+
+```c
+/* Toggle batched dispatch. `on != 0` enables, `0` disables. */
+void rust_infer_batch_set_mode(int32_t on);
+
+/* Returns 1 when batched dispatch is enabled, 0 otherwise. */
+int32_t rust_infer_batch_get_mode(void);
+
+/* Configure batch-size threshold + flush timeout.
+ * Bounds: 1 <= batch_size <= MAX_BATCH (32),
+ *         100 us <= timeout_us <= 100_000 us.
+ * Out-of-range values clamp to the nearest bound (upper bound on
+ * timeout_us is enforced in the FFI; lower bound + batch_size clamp
+ * happen inside `sched::set_batch_size` / `set_batch_timeout_us`).
+ * Returns 0 on success. */
+int32_t rust_infer_batch_set_config(uint32_t batch_size, uint32_t timeout_us);
+
+/* Snapshot the dispatcher state into `*out`. Returns 0 on success,
+ * -1 if `out` is null. */
+int32_t rust_infer_batch_status(RustBatchStatus *out);
+
+/* Run the concurrent stress workload. Spawns `n_workers` task workers
+ * (1..32), each running `iters_per_worker` (1..100_000) MNIST
+ * inferences against the dispatcher. Joins, then writes the
+ * aggregated result into `*out`. MNIST must be loaded first
+ * (`rust_model_load_builtin_mnist`).
+ *
+ * Returns 0 on success, negative on error:
+ *   -1  out is null, or n_workers / iters_per_worker out of range
+ *   -2  MNIST not loaded
+ *   -3  a stress run is already in flight
+ *   -4  task spawn failure (zero workers spawned)
+ *   -5  join deadline exceeded (workers didn't finish in time)
+ *
+ * Safety: caller must run in task context (not ISR) with the
+ * scheduler initialised. A timed-out run's stragglers are isolated
+ * from the next run by an internal generation counter — they
+ * continue to completion but never increment the next run's
+ * counters or `STRESS_WORKERS_DONE`. */
+int32_t rust_infer_stress_run(uint32_t n_workers,
+                              uint32_t iters_per_worker,
+                              RustStressResult *out);
+```
+
+#### RustBatchStatus Structure
+
+```c
+typedef struct {
+    uint32_t enabled;              // 1 if batched dispatch is on, 0 otherwise
+    uint32_t batch_size;           // Configured threshold (clamped to [1, MAX_BATCH])
+    uint32_t timeout_us;           // Configured partial-batch flush timeout
+    uint32_t queue_depth;          // Current pending queue depth
+    uint64_t total_submitted;      // Requests submitted since last reset
+    uint64_t completed;            // Successful completions
+    uint64_t failed;               // Engine errors
+    uint64_t batches_dispatched;   // Total batched dispatches (size + timeout)
+    uint64_t batches_full;         // Batches triggered by size threshold
+    uint64_t batches_timeout;      // Batches triggered by partial-batch timer
+    uint64_t bypassed_deadline;    // Requests that bypassed the queue (tight deadline)
+    uint64_t singleton_dispatches; // Requests that fell through to the singleton path
+} RustBatchStatus;
+```
+
+#### RustStressResult Structure
+
+```c
+typedef struct {
+    uint32_t n_workers;            // Workers actually spawned (may be < requested
+                                   // if task table was exhausted; the shell and
+                                   // Lua bindings surface this explicitly)
+    uint32_t iters_per_worker;     // Iterations per worker requested by caller
+    uint64_t success_count;        // Successful inferences across all workers
+    uint64_t error_count;          // Failed inferences across all workers
+    uint64_t wall_ns;              // Wall-clock duration of the stress run
+    uint64_t total_lat_ns;         // Sum of per-iteration latencies
+    uint64_t min_lat_ns;           // Minimum observed per-iteration latency
+    uint64_t max_lat_ns;           // Maximum observed per-iteration latency
+    /* Counter deltas captured between pre-run and post-run snapshots. */
+    uint64_t batches_dispatched;
+    uint64_t batches_full;
+    uint64_t batches_timeout;
+    uint64_t bypassed_deadline;
+    uint64_t singleton_dispatches;
+} RustStressResult;
+```
+
+Field layout is part of the FFI contract — extending either struct
+requires updating both `runtime/src/lib.rs` and
+`kernel/include/slm_ffi.h` in lockstep.
+
 ### GPU Compute (called from C)
 
 The GPU compute layer provides capability detection and status reporting for GPU-accelerated inference. Implemented in Rust (`runtime/src/inference/gpu.rs`) with C FFI wrappers in `kernel/src/slm_ffi.c`.

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -196,6 +196,10 @@ int test_harness_run_all(void)
     total_failures += test_suite_slm_load();
     total_failures += test_suite_slm_shell();
     total_failures += test_suite_slm_runner();
+    /* Dynamic-batching shell verbs (#55 / PR #917): `infer batch ...`
+     * + `bench infer-stress` argument validation. Rust side is
+     * covered by rust_batch_inference_test. */
+    total_failures += test_suite_infer_shell();
     total_failures += test_suite_scheduler();
     total_failures += test_suite_component();
     total_failures += test_suite_vmm();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -53,6 +53,11 @@ int test_suite_slm_shell(void);
  * /slm/token → /slm/done streaming) */
 int test_suite_slm_runner(void);
 
+/* Dynamic-batching shell verb tests (#55 / PR #917 — covers
+ * `infer batch ...` and `bench infer-stress` argument validation
+ * + `infer batch on/off/config` FFI round-trip) */
+int test_suite_infer_shell(void);
+
 /* SLM GPU dispatch counter FFI tests (PR #831 — pins the contract
  * of `slm_runtime_dispatch_stats` / `_reset`: post-reset zeros,
  * out-of-range op_kind safety, NULL-tolerance, op-kind coverage) */

--- a/kernel/tests/test_infer_shell.c
+++ b/kernel/tests/test_infer_shell.c
@@ -73,12 +73,13 @@ static void test_infer_shell_batch_unknown_subcommand(void)
 
 /*
  * `infer batch on` and `infer batch off` round-trip through
- * `rust_infer_batch_get_mode`. Restore to OFF at the end so we
- * don't leak state into other tests.
+ * `rust_infer_batch_get_mode`. Capture the entry-time mode and
+ * restore it at the end so the test doesn't leak state.
  */
 static void test_infer_shell_batch_on_off_round_trip(void)
 {
-    /* Force a known starting state. */
+    int32_t pre_mode = rust_infer_batch_get_mode();
+
     rust_infer_batch_set_mode(0);
     TEST_ASSERT_EQUAL_INT32(0, rust_infer_batch_get_mode());
 
@@ -89,6 +90,8 @@ static void test_infer_shell_batch_on_off_round_trip(void)
     ret = shell_execute("infer batch off");
     TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT32(0, rust_infer_batch_get_mode());
+
+    rust_infer_batch_set_mode(pre_mode);
 }
 
 /*
@@ -143,11 +146,15 @@ static void test_infer_shell_batch_config_out_of_range(void)
 }
 
 /*
- * `infer batch config 4 1234` is in range → applied. Restore to
- * defaults at the end.
+ * `infer batch config 4 1234` is in range → applied. Capture the
+ * entry-time config and restore it at the end so the test doesn't
+ * leak state.
  */
 static void test_infer_shell_batch_config_in_range_applies(void)
 {
+    RustBatchStatus pre;
+    rust_infer_batch_status(&pre);
+
     int ret = shell_execute("infer batch config 4 1234");
     TEST_ASSERT_EQUAL_INT(0, ret);
 
@@ -156,9 +163,7 @@ static void test_infer_shell_batch_config_in_range_applies(void)
     TEST_ASSERT_EQUAL_UINT32(4u, s.batch_size);
     TEST_ASSERT_EQUAL_UINT32(1234u, s.timeout_us);
 
-    /* Restore defaults (matches `DEFAULT_BATCH_SIZE` / default
-     * `BATCH_TIMEOUT_US` in runtime/src/sched/inference.rs). */
-    rust_infer_batch_set_config(8, 5000);
+    rust_infer_batch_set_config(pre.batch_size, pre.timeout_us);
 }
 
 /*

--- a/kernel/tests/test_infer_shell.c
+++ b/kernel/tests/test_infer_shell.c
@@ -1,0 +1,263 @@
+/*
+ * Inference Shell Verb Tests (#55 / PR #917).
+ *
+ * Exercises the argument-validation surface of:
+ *
+ *   - `infer batch ...` (kernel/src/shell_sys.c::cmd_infer)
+ *   - `bench infer-stress ...` (kernel/src/shell_sys.c::cmd_bench)
+ *
+ * Both verbs forward to the Rust dynamic-batching FFI
+ * (`rust_infer_batch_*` and `rust_infer_stress_run`). The Rust side
+ * is covered end-to-end by `rust_batch_inference_test` (Tests 1-11
+ * in runtime/src/lib.rs); the cases here pin the C-side parse +
+ * range-check + dispatch paths that run synchronously before the
+ * FFI call so a regression shows up in CI instead of only at
+ * runtime.
+ *
+ * Tests that would require the scheduler to actually spawn worker
+ * tasks (the success path of `bench infer-stress N`) live in
+ * `rust_batch_inference_test` Test 11; this file deliberately
+ * stays on the early-return branches.
+ */
+
+#include "unity.h"
+#include "../include/shell.h"
+#include "../include/shell_internal.h"
+#include "../include/slm_ffi.h"
+#include "../include/string.h"
+
+/* ============================================================================
+ * `infer batch ...` dispatch + argument validation
+ * ========================================================================= */
+
+/*
+ * `infer` with no subcommand → 1 (usage printed). Covers the
+ * `argc < 3 || strcmp(argv[1], "batch") != 0` early-return.
+ */
+static void test_infer_shell_no_subcommand_prints_usage(void)
+{
+    int ret = shell_execute("infer");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `infer batch` with no sub-subcommand → 1. The collapsed argc<3
+ * guard in cmd_infer (S6 from PR #917 review) covers both
+ * "missing batch verb" and "missing on/off/config/status" with
+ * a single early-return.
+ */
+static void test_infer_shell_batch_no_action(void)
+{
+    int ret = shell_execute("infer batch");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `infer wrong-verb on` → 1 (only `batch` is recognised).
+ */
+static void test_infer_shell_unknown_verb(void)
+{
+    int ret = shell_execute("infer wrong-verb on");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `infer batch garbage` → 1 (unknown sub-subcommand falls through
+ * to the trailing "unknown subcommand" line).
+ */
+static void test_infer_shell_batch_unknown_subcommand(void)
+{
+    int ret = shell_execute("infer batch garbage");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `infer batch on` and `infer batch off` round-trip through
+ * `rust_infer_batch_get_mode`. Restore to OFF at the end so we
+ * don't leak state into other tests.
+ */
+static void test_infer_shell_batch_on_off_round_trip(void)
+{
+    /* Force a known starting state. */
+    rust_infer_batch_set_mode(0);
+    TEST_ASSERT_EQUAL_INT32(0, rust_infer_batch_get_mode());
+
+    int ret = shell_execute("infer batch on");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_INT32(1, rust_infer_batch_get_mode());
+
+    ret = shell_execute("infer batch off");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_INT32(0, rust_infer_batch_get_mode());
+}
+
+/*
+ * `infer batch config <size> <us>` argument validation. Each
+ * negative case must NOT mutate the configuration (we sample with
+ * `rust_infer_batch_status` before and after to verify).
+ */
+static void test_infer_shell_batch_config_missing_args(void)
+{
+    RustBatchStatus pre;
+    rust_infer_batch_status(&pre);
+
+    /* No size, no timeout. */
+    int ret = shell_execute("infer batch config");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+
+    /* Size only, no timeout. */
+    ret = shell_execute("infer batch config 4");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+
+    RustBatchStatus post;
+    rust_infer_batch_status(&post);
+    TEST_ASSERT_EQUAL_UINT32(pre.batch_size, post.batch_size);
+    TEST_ASSERT_EQUAL_UINT32(pre.timeout_us, post.timeout_us);
+}
+
+static void test_infer_shell_batch_config_out_of_range(void)
+{
+    RustBatchStatus pre;
+    rust_infer_batch_status(&pre);
+
+    /* size = 0 → rejected. */
+    int ret = shell_execute("infer batch config 0 5000");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+
+    /* size = 33 → above MAX_BATCH (32). */
+    ret = shell_execute("infer batch config 33 5000");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+
+    /* timeout < 100 us — pinned by the shell-side guard. */
+    ret = shell_execute("infer batch config 4 50");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+
+    /* timeout > 100_000 us. */
+    ret = shell_execute("infer batch config 4 200000");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+
+    RustBatchStatus post;
+    rust_infer_batch_status(&post);
+    TEST_ASSERT_EQUAL_UINT32(pre.batch_size, post.batch_size);
+    TEST_ASSERT_EQUAL_UINT32(pre.timeout_us, post.timeout_us);
+}
+
+/*
+ * `infer batch config 4 1234` is in range → applied. Restore to
+ * defaults at the end.
+ */
+static void test_infer_shell_batch_config_in_range_applies(void)
+{
+    int ret = shell_execute("infer batch config 4 1234");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    RustBatchStatus s;
+    rust_infer_batch_status(&s);
+    TEST_ASSERT_EQUAL_UINT32(4u, s.batch_size);
+    TEST_ASSERT_EQUAL_UINT32(1234u, s.timeout_us);
+
+    /* Restore defaults (matches `DEFAULT_BATCH_SIZE` / default
+     * `BATCH_TIMEOUT_US` in runtime/src/sched/inference.rs). */
+    rust_infer_batch_set_config(8, 5000);
+}
+
+/*
+ * `infer batch status` → 0. We can't capture UART output here, but
+ * a return of 0 proves the verb ran the FFI path through to
+ * completion without faulting.
+ */
+static void test_infer_shell_batch_status_returns_ok(void)
+{
+    int ret = shell_execute("infer batch status");
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+/* ============================================================================
+ * `bench infer-stress ...` argument validation
+ * ========================================================================= */
+
+/*
+ * `bench infer-stress` with no N → 1 (usage). The success path
+ * (`bench infer-stress 4 8`) requires a running scheduler and is
+ * covered by `rust_batch_inference_test` Test 11.
+ */
+static void test_bench_infer_stress_no_workers(void)
+{
+    int ret = shell_execute("bench infer-stress");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `bench infer-stress 0` → 1 (N must be 1..32).
+ */
+static void test_bench_infer_stress_zero_workers(void)
+{
+    int ret = shell_execute("bench infer-stress 0");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `bench infer-stress 33` → 1 (N > 32).
+ */
+static void test_bench_infer_stress_oversize_workers(void)
+{
+    int ret = shell_execute("bench infer-stress 33");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `bench infer-stress 4 abc` → 1. Pins the S5 fix from PR #917:
+ * the iters arg used to silently default to 50 when parse failed;
+ * now it returns 1 with a usage line.
+ */
+static void test_bench_infer_stress_bogus_iters(void)
+{
+    int ret = shell_execute("bench infer-stress 4 abc");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `bench infer-stress 4 0` → 1 (iters must be > 0).
+ */
+static void test_bench_infer_stress_zero_iters(void)
+{
+    int ret = shell_execute("bench infer-stress 4 0");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/*
+ * `bench infer-stress 4 100001` → 1 (iters above the upper bound).
+ */
+static void test_bench_infer_stress_oversize_iters(void)
+{
+    int ret = shell_execute("bench infer-stress 4 100001");
+    TEST_ASSERT_EQUAL_INT(1, ret);
+}
+
+/* ============================================================================
+ * Suite Runner
+ * ========================================================================= */
+
+int test_suite_infer_shell(void)
+{
+    UnityBegin("Inference Shell Verb Tests");
+
+    RUN_TEST(test_infer_shell_no_subcommand_prints_usage);
+    RUN_TEST(test_infer_shell_batch_no_action);
+    RUN_TEST(test_infer_shell_unknown_verb);
+    RUN_TEST(test_infer_shell_batch_unknown_subcommand);
+    RUN_TEST(test_infer_shell_batch_on_off_round_trip);
+    RUN_TEST(test_infer_shell_batch_config_missing_args);
+    RUN_TEST(test_infer_shell_batch_config_out_of_range);
+    RUN_TEST(test_infer_shell_batch_config_in_range_applies);
+    RUN_TEST(test_infer_shell_batch_status_returns_ok);
+
+    RUN_TEST(test_bench_infer_stress_no_workers);
+    RUN_TEST(test_bench_infer_stress_zero_workers);
+    RUN_TEST(test_bench_infer_stress_oversize_workers);
+    RUN_TEST(test_bench_infer_stress_bogus_iters);
+    RUN_TEST(test_bench_infer_stress_zero_iters);
+    RUN_TEST(test_bench_infer_stress_oversize_iters);
+
+    return (int)UnityEnd();
+}

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -1360,6 +1360,127 @@ static void test_slm_infer_stats(void)
 }
 
 /*
+ * Test: slm.infer_batch_status (safe surface) returns a table with
+ * the documented fields. Exercises the C-side table marshalling.
+ */
+static void test_slm_infer_batch_status_shape(void)
+{
+    lua_State *L = test_lua_open_safe();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "local s = slm.infer_batch_status()\n"
+        "assert(type(s) == 'table', 'should return table')\n"
+        "assert(type(s.enabled) == 'boolean', 'enabled bool')\n"
+        "assert(type(s.batch_size) == 'number', 'batch_size num')\n"
+        "assert(type(s.timeout_us) == 'number', 'timeout_us num')\n"
+        "assert(type(s.queue_depth) == 'number', 'queue_depth num')\n"
+        "assert(type(s.batches_dispatched) == 'number')\n"
+        "assert(type(s.batches_full) == 'number')\n"
+        "assert(type(s.batches_timeout) == 'number')\n"
+        "assert(type(s.bypassed_deadline) == 'number')\n"
+        "assert(type(s.singleton_dispatches) == 'number')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    test_lua_close(L);
+}
+
+/*
+ * Test: slm.infer_batch_mode round-trips through the dispatcher.
+ * Admin-only surface. Restores OFF at the end.
+ */
+static void test_slm_infer_batch_mode_round_trip(void)
+{
+    lua_State *L = test_lua_open_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    /* Force a known starting state. */
+    rust_infer_batch_set_mode(0);
+
+    const char *code =
+        "local on = slm.infer_batch_mode('on')\n"
+        "assert(on == true, 'on should be true')\n"
+        "assert(slm.infer_batch_status().enabled == true)\n"
+        "local off = slm.infer_batch_mode('off')\n"
+        "assert(off == false, 'off should be false')\n"
+        "assert(slm.infer_batch_status().enabled == false)\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    test_lua_close(L);
+}
+
+/*
+ * Test: slm.infer_batch_mode rejects non-"on"/"off" arguments via
+ * luaL_error. lua_slm_dostring returns non-zero on Lua error.
+ */
+static void test_slm_infer_batch_mode_bad_arg(void)
+{
+    lua_State *L = test_lua_open_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code = "slm.infer_batch_mode('garbage')\n";
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_NOT_EQUAL(0, result);
+    test_lua_close(L);
+}
+
+/*
+ * Test: slm.infer_batch_config applies in-range values, returns the
+ * applied table, and rejects out-of-range values via luaL_error
+ * (pins the S7 fix from PR #917 review). Restores defaults at end.
+ */
+static void test_slm_infer_batch_config(void)
+{
+    lua_State *L = test_lua_open_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "local r = slm.infer_batch_config({size=4, timeout_us=1234})\n"
+        "assert(r.size == 4, 'size applied')\n"
+        "assert(r.timeout_us == 1234, 'timeout applied')\n"
+        /* size out of range → luaL_error → pcall returns false */
+        "local ok = pcall(slm.infer_batch_config, {size=99})\n"
+        "assert(not ok, 'oversize should error')\n"
+        "local ok2 = pcall(slm.infer_batch_config, {timeout_us=200000})\n"
+        "assert(not ok2, 'oversize timeout should error')\n"
+        "local ok3 = pcall(slm.infer_batch_config, {size=-1})\n"
+        "assert(not ok3, 'negative size should error')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    test_lua_close(L);
+    /* Restore defaults. */
+    rust_infer_batch_set_config(8, 5000);
+}
+
+/*
+ * Test: slm.infer_stress rejects out-of-range N and iters via
+ * luaL_error. Success-path coverage (which would spawn worker
+ * tasks) lives in `rust_batch_inference_test` Test 11.
+ */
+static void test_slm_infer_stress_arg_validation(void)
+{
+    lua_State *L = test_lua_open_admin();
+    TEST_ASSERT_NOT_NULL(L);
+
+    const char *code =
+        "local ok = pcall(slm.infer_stress, 0)\n"
+        "assert(not ok, 'N=0 should error')\n"
+        "local ok2 = pcall(slm.infer_stress, 33)\n"
+        "assert(not ok2, 'N>32 should error')\n"
+        "local ok3 = pcall(slm.infer_stress, 4, 0)\n"
+        "assert(not ok3, 'iters=0 should error')\n"
+        "local ok4 = pcall(slm.infer_stress, 4, 200000)\n"
+        "assert(not ok4, 'iters too large should error')\n";
+
+    int result = lua_slm_dostring(L, code);
+    TEST_ASSERT_EQUAL_INT(0, result);
+    test_lua_close(L);
+}
+
+/*
  * Test: slm.gpu_status always returns a table with .available boolean.
  */
 static void test_slm_gpu_status(void)
@@ -3996,6 +4117,12 @@ int test_suite_lua(void)
     RUN_TEST(test_slm_model_load_bad_paths);
     RUN_TEST(test_slm_model_load_non_onnx);
     RUN_TEST(test_slm_infer_stats);
+    /* #55 / PR #917 dynamic-batching Lua bindings */
+    RUN_TEST(test_slm_infer_batch_status_shape);
+    RUN_TEST(test_slm_infer_batch_mode_round_trip);
+    RUN_TEST(test_slm_infer_batch_mode_bad_arg);
+    RUN_TEST(test_slm_infer_batch_config);
+    RUN_TEST(test_slm_infer_stress_arg_validation);
     RUN_TEST(test_slm_gpu_status);
     RUN_TEST(test_slm_ai_sched_stats);
     RUN_TEST(test_slm_eviction_bindings);

--- a/kernel/tests/test_lua.c
+++ b/kernel/tests/test_lua.c
@@ -1388,14 +1388,15 @@ static void test_slm_infer_batch_status_shape(void)
 
 /*
  * Test: slm.infer_batch_mode round-trips through the dispatcher.
- * Admin-only surface. Restores OFF at the end.
+ * Admin-only surface. Captures the entry-time mode and restores it
+ * at the end so the test doesn't leak state.
  */
 static void test_slm_infer_batch_mode_round_trip(void)
 {
     lua_State *L = test_lua_open_admin();
     TEST_ASSERT_NOT_NULL(L);
 
-    /* Force a known starting state. */
+    int32_t pre_mode = rust_infer_batch_get_mode();
     rust_infer_batch_set_mode(0);
 
     const char *code =
@@ -1409,6 +1410,7 @@ static void test_slm_infer_batch_mode_round_trip(void)
     int result = lua_slm_dostring(L, code);
     TEST_ASSERT_EQUAL_INT(0, result);
     test_lua_close(L);
+    rust_infer_batch_set_mode(pre_mode);
 }
 
 /*
@@ -1429,12 +1431,16 @@ static void test_slm_infer_batch_mode_bad_arg(void)
 /*
  * Test: slm.infer_batch_config applies in-range values, returns the
  * applied table, and rejects out-of-range values via luaL_error
- * (pins the S7 fix from PR #917 review). Restores defaults at end.
+ * (pins the S7 fix from PR #917 review). Captures the entry-time
+ * config and restores it at the end so the test doesn't leak state.
  */
 static void test_slm_infer_batch_config(void)
 {
     lua_State *L = test_lua_open_admin();
     TEST_ASSERT_NOT_NULL(L);
+
+    RustBatchStatus pre;
+    rust_infer_batch_status(&pre);
 
     const char *code =
         "local r = slm.infer_batch_config({size=4, timeout_us=1234})\n"
@@ -1451,8 +1457,7 @@ static void test_slm_infer_batch_config(void)
     int result = lua_slm_dostring(L, code);
     TEST_ASSERT_EQUAL_INT(0, result);
     test_lua_close(L);
-    /* Restore defaults. */
-    rust_infer_batch_set_config(8, 5000);
+    rust_infer_batch_set_config(pre.batch_size, pre.timeout_us);
 }
 
 /*


### PR DESCRIPTION
## Summary

Post-merge audit of the dynamic-batching stack (#862 / #908 / #917 / #927) found three gaps the four merged PRs didn't cover. This PR closes them.

## Gaps addressed

1. **`docs/ffi.md` missing the dynamic-batching FFI section.** The structs (`RustBatchStatus`, `RustStressResult`) and the five entrypoints (`rust_infer_batch_set_mode`, `_get_mode`, `_set_config`, `_status`, `rust_infer_stress_run`) were declared in `slm_ffi.h` + Rust but had no entry in the canonical FFI reference. New section covers struct layout, return-code contract, safety invariants, and the generation-counter straggler-isolation behaviour added in PR #917's review fix.

2. **No `kernel/tests/` coverage for `cmd_infer` or `bench infer-stress`.** New `kernel/tests/test_infer_shell.c` (ARM64-only, modelled on `test_slm_shell.c`) pins the argument-validation surface with 15 Unity cases via `shell_execute()`:
   - Dispatcher fall-through (no verb, wrong verb, garbage subcommand)
   - `infer batch on`/`off` round-trip through `rust_infer_batch_get_mode`
   - `infer batch config` validation (missing args, size 0 / >32, timeout <100 / >100_000, in-range applies)
   - `infer batch status` smoke test
   - `bench infer-stress` validation (no N, N=0, N>32, bogus iters arg pinning the S5 fix from PR #917 review, iters=0, iters too large)

3. **No `test_lua.c` coverage for the new Lua bindings.** Five new cases:
   - `slm.infer_batch_status()` table shape (safe surface)
   - `slm.infer_batch_mode("on"/"off")` round-trip + bad-arg `luaL_error`
   - `slm.infer_batch_config({...})` — pins the S7 range-check fix (negative size, oversize size, oversize timeout)
   - `slm.infer_stress(N, iters)` arg validation via `pcall`

## Test plan

- [x] `make test` — passes; 20 new tests added (15 in `test_infer_shell`, 5 in `test_lua`), 0 failures.
- [x] Verified per-test PASS lines in `build/test-output.log`.
- [x] No production code changed — only docs + tests + harness wiring.

## Files

```
 CMakeLists.txt                   |   4 +
 docs/ffi.md                      |  98 ++++++++++++++++
 kernel/tests/test_harness.c      |   4 +
 kernel/tests/test_harness.h      |   5 +
 kernel/tests/test_infer_shell.c  | 254 +++++++++++++++++++++++++++++++++++++++ (new)
 kernel/tests/test_lua.c          | 113 +++++++++++++++++
```

Refs #55. Follow-up to #862, #908, #917, #927.

🤖 Generated with [Claude Code](https://claude.com/claude-code)