### PR TITLE
sched: AI decision-trace ring + sched aitrace verbs (closes #880)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2095,6 +2095,7 @@ if(ENABLE_AI_SCHEDULER)
         kernel/sched/ai/ai_weights_ppo.c
         kernel/sched/ai/ai_test_helpers.c
         kernel/sched/ai/workloads.c
+        kernel/sched/ai/sched_trace_ai.c
         $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/sched/ai/fp_context.S>
         $<$<STREQUAL:${PLATFORM},X86_64>:kernel/sched/ai/fp_context.S>
     )

--- a/docs/sched-trace-format.md
+++ b/docs/sched-trace-format.md
@@ -67,6 +67,17 @@ function operates on (extracted via `ai_extract_state`).
 
 Total: 16 + 16 + 4×4 + 432 = 480 bytes. ✓
 
+`action_core` is the **pre-S5-override** value — the CPU the active
+policy's `assign_cpu` returned, BEFORE `scheduler_add_task`'s proactive
+load-balance override (see `kernel/sched/sched.c` near
+`scheduler_add_task`) potentially redirects the task elsewhere. The
+trace is meant for training the policy that made the choice, so
+recording the policy's actual output (not the post-override target)
+is what the ingester wants. The override outcome is recoverable
+indirectly from the next decision's state vector and from the
+matching COMPLETION's `ran_on_cpu`. Do not try to use `action_core`
+as ground truth for "where the task ultimately ran".
+
 The state vector layout matches the sibling-repo simulator's
 observation space:
 

--- a/docs/sched-trace-format.md
+++ b/docs/sched-trace-format.md
@@ -1,0 +1,177 @@
+# AI Scheduler Decision-Trace Format (#880)
+
+The AI scheduler decision-trace ring buffer captures `(state, action)`
+tuples (plus per-task completion outcomes) so the sibling-repo training
+pipeline can fine-tune MLP/PPO policies on real SLM-OS scheduling
+behaviour rather than only the simulated workloads in
+`~/projects/slm-os-scheduler-ai/slm_sim/workloads/`.
+
+This document pins the on-disk byte layout. **Any change to field
+offsets requires bumping `version` in the file header.** The sibling-
+repo ingester (`data/slmos_traces.py`, added in #879 / 61c) parses
+the bytes per this spec.
+
+Distinct from the cross-CPU dispatch tracer documented in
+`docs/scheduler.md` §"Trace" (`sched_trace.h`) — that one records
+16-byte context-switch events for ASCII timelines; this one records
+480-byte AI-decision frames.
+
+## Endianness
+
+All multi-byte fields are little-endian on disk. SLM-OS targets are
+all LE platforms (ARM64 LE, x86-64). The ingester reads as LE
+unconditionally.
+
+## File header (32 bytes, fixed)
+
+| Offset | Size | Type    | Field                       | Description                                                  |
+|-------:|-----:|---------|-----------------------------|--------------------------------------------------------------|
+|  0     | 4    | u32     | `magic`                     | `0x53544C53` (ASCII `'S' 'L' 'T' 'S'`)                       |
+|  4     | 2    | u16     | `version`                   | Currently `1`. Bumped on any layout change.                  |
+|  6     | 2    | u16     | `record_size`               | Always `480`. Sanity-check; ingester aborts on mismatch.     |
+|  8     | 4    | u32     | `record_count`              | Number of records that follow.                               |
+| 12     | 4    | u32     | `state_dim`                 | AI state-vector dimension. Currently `108`.                  |
+| 16     | 8    | u64     | `total_events_since_start`  | Monotonic counter at dump time (≥ `record_count`).           |
+| 24     | 8    | u64     | `dropped_events`            | Records that wrapped before dump. `total - record_count`.    |
+
+## Record (480 bytes, fixed)
+
+Every record is `480` bytes regardless of `kind`. The two variants
+share a union; the unused part is zero-padded. Fixed-size records
+let the ingester `mmap` and seek by index.
+
+### Common header (16 bytes)
+
+| Offset | Size | Type   | Field          | Description                                           |
+|-------:|-----:|--------|----------------|-------------------------------------------------------|
+|  0     | 1    | u8     | `kind`         | `1` = DECISION, `2` = COMPLETION.                     |
+|  1     | 1    | u8     | `cpu_recorded` | CPU id (`cpu_id()`) that wrote this record.           |
+|  2     | 2    | u16    | `_hdr_pad`     | Zero. Reserved for future flags.                      |
+|  4     | 4    | u32    | `task_id`      | `struct task::id`. Joins DECISION and COMPLETION pairs. |
+|  8     | 8    | u64    | `timestamp_ns` | `slm_get_time_ns()` at record time.                   |
+
+### DECISION variant (kind = 1)
+
+Written from `scheduler_add_task` right after `active_policy->assign_cpu`
+returns. The state vector is the same one the policy's inference
+function operates on (extracted via `ai_extract_state`).
+
+| Offset | Size | Type    | Field             | Description                                          |
+|-------:|-----:|---------|-------------------|------------------------------------------------------|
+| 16     | 16   | char[16]| `policy_name`     | Null-padded ASCII; policy that made the decision.    |
+| 32     | 4    | i32     | `action_core`     | CPU id `assign_cpu` returned. Pre-S5-override.       |
+| 36     | 4    | i32     | `action_priority` | `task->effective_priority` at decision time.         |
+| 40     | 4    | i32     | `action_preempt`  | Reserved (currently always `0`).                     |
+| 44     | 4    | u32     | `_decision_pad`   | Zero.                                                |
+| 48     | 432  | f32[108]| `state`           | 108-dim FP32 state vector (`ai_extract_state` output)|
+
+Total: 16 + 16 + 4×4 + 432 = 480 bytes. ✓
+
+The state vector layout matches the sibling-repo simulator's
+observation space:
+
+- `state[0..35]`   — per-core features (6 cores × 6 features)
+- `state[36..99]`  — per-task features (8 tasks × 8 features)
+- `state[100..107]`— global features
+
+See `kernel/sched/ai/ai_state.c::ai_extract_state` for the canonical
+field ordering. The sibling-repo `slm_sim/observation.py` describes
+the same layout for its synthetic data.
+
+### COMPLETION variant (kind = 2)
+
+Written from `task_exit`. Links back to its matching DECISION via
+`task_id` (each task has at most one DECISION + one COMPLETION
+within a single trace window).
+
+| Offset | Size | Type    | Field                    | Description                                           |
+|-------:|-----:|---------|--------------------------|-------------------------------------------------------|
+| 16     | 8    | u64     | `dispatch_ns`            | `timestamp_ns` of the matching DECISION (0 if unknown)|
+| 24     | 8    | u64     | `completion_ns`          | `slm_get_time_ns()` at `task_exit`.                   |
+| 32     | 8    | u64     | `deadline_ns`            | `task->deadline_ns` at exit (0 = no deadline).        |
+| 40     | 4    | u32     | `latency_to_complete_us` | `(completion_ns - dispatch_ns) / 1000`, or 0.         |
+| 44     | 1    | u8      | `ran_on_cpu`             | `task->assigned_cpu` at exit.                         |
+| 45     | 1    | u8      | `deadline_met`           | 1 iff `completion_ns <= deadline_ns` (or no deadline).|
+| 46     | 2    | u8[2]   | `_completion_pad`        | Zero.                                                 |
+| 48     | 432  | u8[432] | `_tail_pad`              | Zero.                                                 |
+
+Total: 16 + 32 + 432 = 480 bytes. ✓
+
+The `dispatch_ns` field is `0` in v1 — the kernel doesn't currently
+track per-task dispatch timestamps separately from the existing
+trace ring. The ingester can correlate DECISION ↔ COMPLETION by
+`task_id` if precise latency is needed. A future version may
+populate this field directly.
+
+## Ordering and merging
+
+Records are written into per-CPU ring buffers. The dump streams
+each per-CPU ring in oldest-to-newest order, concatenated by CPU id
+(`cpu_recorded` ascending). Within a CPU, records are in monotonic
+`timestamp_ns` order; across CPUs, the ingester merge-sorts on
+`timestamp_ns` if a strict global order is needed.
+
+`dropped_events > 0` indicates the ring wrapped during capture. The
+oldest events are the ones that were overwritten, so the surviving
+records skew toward the end of the capture window.
+
+## Capture overhead
+
+Targets ≤5% overhead per `scheduler_add_task` (per #880 acceptance).
+At AI MLP decision-latency of ~42 µs on Pi 5, the budget is ~2 µs
+per decision — comfortably above the trace-write cost (one
+`ai_extract_state` call + memcpy + `cache_clean_range`).
+
+Measure with `bench sched-policy --workload mixed --all` (#882) with
+`sched aitrace stop` vs `sched aitrace start` — the table's `Tasks/s`
+and `p50` columns are the relevant comparison points.
+
+## Shell control
+
+```
+sched aitrace start              # clear ring, start capturing
+sched aitrace stop               # stop capturing, print stats
+sched aitrace stats              # show fill / dropped counters
+sched aitrace clear              # drop all records (safe while ON)
+sched aitrace dump <path>        # stream the trace into a file
+```
+
+For example:
+
+```
+slmos> sched aitrace start
+slmos> bench sched-policy --workload mixed --all
+slmos> sched aitrace stop
+slmos> sched aitrace dump /mnt/files/sched_trace.bin
+```
+
+## Lua control
+
+```lua
+slm.sched_aitrace_start()
+slm.sched_aitrace_stop()
+slm.sched_aitrace_clear()
+local stats = slm.sched_aitrace_stats()  -- table: enabled, used, total, dropped, dump_size
+local ok = slm.sched_aitrace_dump("/mnt/files/sched_trace.bin")
+```
+
+## Sibling-repo ingester (#879)
+
+Located at `~/projects/slm-os-scheduler-ai/data/slmos_traces.py`
+(added in sub-ticket #879 / 61c). The ingester:
+
+1. Reads the file header, validates `magic`, `version`,
+   `record_size`, `state_dim`.
+2. Walks `record_count` records as a NumPy structured array.
+3. Filters by `kind`; DECISION records become `(state, action)`
+   training pairs; COMPLETION records contribute to the reward
+   signal via the simulator's existing `reward.py`.
+4. Emits a Parquet file in the same shape as the simulator output
+   so the existing `_train_mlp.py` / `_train_ppo.py` pipelines can
+   consume it via `--source slmos-traces`.
+
+## Version history
+
+| Version | Date       | Change                                                |
+|--------:|------------|-------------------------------------------------------|
+|       1 | 2026-05-16 | Initial format (DECISION + COMPLETION, 480 B records) |

--- a/kernel/include/sched_trace_ai.h
+++ b/kernel/include/sched_trace_ai.h
@@ -75,7 +75,9 @@ struct __attribute__((packed)) sched_trace_ai_record {
         } decision;
 
         struct __attribute__((packed)) {
-            uint64_t dispatch_ns;       /* offset 16, original DECISION timestamp_ns */
+            uint64_t dispatch_ns;       /* offset 16, original DECISION timestamp_ns; always 0 in v1
+                                         * (kernel doesn't yet track per-task dispatch separately
+                                         * — sibling-repo ingester correlates via task_id). */
             uint64_t completion_ns;     /* offset 24, when task_exit fired */
             uint64_t deadline_ns;       /* offset 32, copy of task->deadline_ns (0 = none) */
             uint32_t latency_to_complete_us; /* offset 40, completion_ns - dispatch_ns */

--- a/kernel/include/sched_trace_ai.h
+++ b/kernel/include/sched_trace_ai.h
@@ -1,0 +1,195 @@
+/*
+ * sched_trace_ai.h — AI-scheduler decision-trace ring buffer (#880).
+ *
+ * Captures per-decision state + action tuples (plus per-completion
+ * outcome records) so the sibling-repo training pipeline can fine-
+ * tune MLP/PPO policies on real SLM-OS scheduling behaviour (rather
+ * than only the simulated workloads in `slm_sim/workloads/`).
+ *
+ * This is DIFFERENT from the existing `kernel/include/sched_trace.h`
+ * cross-CPU dispatch visualizer (#195), which records 16-byte
+ * context-switch events for ASCII timelines. The AI trace is wider
+ * (~480 B per record — full 108-dim FP32 state vector) and is
+ * triggered on policy decisions, not context switches.
+ *
+ * Shell verb: `sched aitrace start/stop/stats/dump` — distinct from
+ * `sched trace ...` so neither tracer's UI breaks the other.
+ *
+ * Wire format documented in `docs/sched-trace-format.md`.
+ */
+
+#ifndef KERNEL_SCHED_TRACE_AI_H
+#define KERNEL_SCHED_TRACE_AI_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/* File-header magic for dumped traces. ASCII 'S' 'L' 'T' 'S' →
+ * "SLM-OS scheduler Trace, decisionS". Endianness: file is written
+ * little-endian (the platforms SLM-OS targets are all LE) but the
+ * format spec is byte-defined so cross-arch readers can interpret
+ * without endian-flipping. */
+#define SCHED_TRACE_AI_MAGIC    0x53544C53u
+#define SCHED_TRACE_AI_VERSION  1u
+
+/* Each record is a fixed 480 bytes regardless of kind. Wastes some
+ * space on COMPLETION records but lets the ring be a flat array and
+ * the file format a stream of equal-size frames the ingester can
+ * mmap or seek into without parsing a length prefix per record. */
+#define SCHED_TRACE_AI_RECORD_SIZE  480u
+
+/* Ring size in records. 4096 × 480 B = ~1.92 MB. Allocated from
+ * PMM at `sched_trace_ai_init()` so the BSS footprint of AI_SCHED
+ * builds doesn't grow when the trace is off. */
+#define SCHED_TRACE_AI_RING_ENTRIES 4096u
+
+/* AI state-vector dimension. Must match AI_STATE_DIM from ai_types.h.
+ * Asserted at init time. */
+#define SCHED_TRACE_AI_STATE_DIM    108u
+
+enum sched_trace_ai_kind {
+    SCHED_TRACE_AI_KIND_DECISION   = 1,
+    SCHED_TRACE_AI_KIND_COMPLETION = 2,
+};
+
+/* Fixed-size record. Two variants share a union so every slot in
+ * the ring is the same size. `kind` discriminates. Field offsets
+ * are pinned by docs/sched-trace-format.md — do NOT reorder without
+ * bumping SCHED_TRACE_AI_VERSION. */
+struct __attribute__((packed)) sched_trace_ai_record {
+    uint8_t  kind;              /* offset 0  — enum sched_trace_ai_kind */
+    uint8_t  cpu_recorded;      /* offset 1  — CPU that wrote the record */
+    uint16_t _hdr_pad;          /* offset 2 */
+    uint32_t task_id;           /* offset 4  — task slot id, matches across DECISION/COMPLETION */
+    uint64_t timestamp_ns;      /* offset 8  — slm_get_time_ns() at record time */
+
+    union {
+        struct __attribute__((packed)) {
+            char     policy_name[16];   /* offset 16, null-padded */
+            int32_t  action_core;       /* offset 32, CPU chosen by assign_cpu */
+            int32_t  action_priority;   /* offset 36, effective_priority at decision time */
+            int32_t  action_preempt;    /* offset 40, reserved for future preempt-action field */
+            uint32_t _decision_pad;     /* offset 44 */
+            float    state[SCHED_TRACE_AI_STATE_DIM]; /* offset 48..480 — 432 B */
+        } decision;
+
+        struct __attribute__((packed)) {
+            uint64_t dispatch_ns;       /* offset 16, original DECISION timestamp_ns */
+            uint64_t completion_ns;     /* offset 24, when task_exit fired */
+            uint64_t deadline_ns;       /* offset 32, copy of task->deadline_ns (0 = none) */
+            uint32_t latency_to_complete_us; /* offset 40, completion_ns - dispatch_ns */
+            uint8_t  ran_on_cpu;        /* offset 44, task->assigned_cpu at exit */
+            uint8_t  deadline_met;      /* offset 45, 1 if completion_ns <= deadline */
+            uint8_t  _completion_pad[2];/* offset 46 */
+            uint8_t  _tail_pad[480 - 48]; /* unused payload (zeroed) */
+        } completion;
+    } u;
+};
+
+_Static_assert(sizeof(struct sched_trace_ai_record) == SCHED_TRACE_AI_RECORD_SIZE,
+               "sched_trace_ai_record must be exactly 480 bytes");
+
+/* File header written by `sched_trace_ai_dump_to_buf` and read by
+ * the sibling-repo ingester. 32 bytes; followed immediately by
+ * `record_count` × SCHED_TRACE_AI_RECORD_SIZE bytes. */
+struct __attribute__((packed)) sched_trace_ai_file_header {
+    uint32_t magic;             /* SCHED_TRACE_AI_MAGIC */
+    uint16_t version;           /* SCHED_TRACE_AI_VERSION */
+    uint16_t record_size;       /* SCHED_TRACE_AI_RECORD_SIZE (sanity check) */
+    uint32_t record_count;      /* number of records following */
+    uint32_t state_dim;         /* SCHED_TRACE_AI_STATE_DIM */
+    uint64_t total_events_since_start;   /* unsaturated event counter at dump time */
+    uint64_t dropped_events;    /* how many records were overwritten before dump */
+};
+
+_Static_assert(sizeof(struct sched_trace_ai_file_header) == 32,
+               "file header must be exactly 32 bytes");
+
+/* ---- Initialization ---- */
+
+/* Allocate the ring buffer from PMM. Idempotent. Returns 0 on success,
+ * negative on alloc failure. Must be called before any record/start. */
+int sched_trace_ai_init(void);
+
+/* ---- Control plane (shell + Lua bindings call these) ---- */
+
+/* Start recording. Resets head/total/dropped counters. Cheap; just
+ * flips the atomic enable flag. */
+void sched_trace_ai_start(void);
+
+/* Stop recording. Existing records remain in the ring for `dump`. */
+void sched_trace_ai_stop(void);
+
+/* Discard all records. Safe to call while tracing is on. */
+void sched_trace_ai_clear(void);
+
+/* Is tracing currently enabled? */
+bool sched_trace_ai_is_enabled(void);
+
+/* Stats — for `sched aitrace stats`. */
+uint32_t sched_trace_ai_records_used(void);    /* min(total_events, ring_size) */
+uint64_t sched_trace_ai_total_events(void);    /* monotonic event counter since start */
+uint64_t sched_trace_ai_dropped(void);         /* records that wrapped before dump */
+
+/* ---- Hot path (called from scheduler_add_task / task_exit) ---- */
+
+/* Record a DECISION event. Called from `scheduler_add_task` right
+ * after `active_policy->assign_cpu(task)` returns. The state vector
+ * is extracted internally via `ai_extract_state(task, state)` so
+ * the policies don't need to be modified. No-op when tracing is
+ * disabled — single atomic load + branch.
+ *
+ * @task:          The task whose CPU was just chosen.
+ * @policy_name:   Active policy's name (string from sched_policy_ops.name).
+ * @action_core:   The CPU `assign_cpu` returned.
+ *
+ * Safe to call from any context. May not be called from inside an
+ * IRQ handler (the state extraction touches per-CPU data which the
+ * handler may have partially updated).
+ */
+struct task;
+void sched_trace_ai_record_decision(struct task *task,
+                                    const char *policy_name,
+                                    uint32_t action_core);
+
+/* Record a COMPLETION event. Called from `task_exit` (or wherever a
+ * task transitions to TASK_TERMINATED). No-op when tracing is
+ * disabled. */
+void sched_trace_ai_record_completion(struct task *task);
+
+/* ---- Dump ---- */
+
+/* Serialize the trace into a caller-supplied buffer. Layout:
+ *   [sched_trace_ai_file_header][record_0][record_1]...[record_N-1]
+ *
+ * Returns the number of bytes written, or 0 if buf is too small.
+ * Required size: sizeof(file_header) + records_used() * RECORD_SIZE.
+ *
+ * The dump is taken WHILE tracing may still be active; new records
+ * recorded during the dump are not included (snapshot semantics).
+ */
+size_t sched_trace_ai_dump_to_buf(uint8_t *buf, size_t buflen);
+
+/* Total buffer size required for a full dump at the current fill
+ * level. Useful for sizing the destination file or VFS write. */
+size_t sched_trace_ai_dump_size(void);
+
+/* Streaming dump — for sinks that can't fit the whole trace (up to
+ * ~1.9 MB) in a single buffer. `cb` is invoked one or more times
+ * with chunks of bytes that, concatenated in call order, form the
+ * same byte sequence `sched_trace_ai_dump_to_buf` would produce.
+ *
+ * Returns the total bytes streamed, or 0 if `cb` returned negative
+ * at any chunk. `cb` should return 0 on success and a negative
+ * errno-ish code to abort. */
+typedef int (*sched_trace_ai_dump_cb)(void *ctx, const void *bytes, size_t len);
+size_t sched_trace_ai_dump_stream(sched_trace_ai_dump_cb cb, void *ctx);
+
+/* Convenience: dump the trace to a VFS path. Returns number of bytes
+ * written on success, 0 on failure (mount not found, open failed,
+ * write failed). Used by both the shell `sched aitrace dump` verb
+ * and the `slm.sched_aitrace_dump` Lua binding. */
+size_t sched_trace_ai_dump_to_path(const char *path);
+
+#endif /* KERNEL_SCHED_TRACE_AI_H */

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -766,4 +766,10 @@ void sched_ai_init(void)
 #ifndef PLATFORM_X86_64
     sched_register_policy(&sched_policy_ai_hailo);
 #endif
+    /* AI decision-trace ring (#880). Allocates ~1.9 MB from PMM,
+     * stays inert until `sched aitrace start` flips the enable flag.
+     * Failure here just leaves the ring NULL — start/record_decision
+     * become no-ops and the shell reports the missing buffer. */
+    extern int sched_trace_ai_init(void);
+    (void)sched_trace_ai_init();
 }

--- a/kernel/sched/ai/sched_ai.c
+++ b/kernel/sched/ai/sched_ai.c
@@ -24,6 +24,7 @@
 #include "latency_hist.h"
 #include "rate_ewma.h"
 #include "sched.h"
+#include "sched_trace_ai.h"
 #include "smp.h"
 #include "slm_ffi.h"
 #include "debug.h"
@@ -770,6 +771,5 @@ void sched_ai_init(void)
      * stays inert until `sched aitrace start` flips the enable flag.
      * Failure here just leaves the ring NULL — start/record_decision
      * become no-ops and the shell reports the missing buffer. */
-    extern int sched_trace_ai_init(void);
     (void)sched_trace_ai_init();
 }

--- a/kernel/sched/ai/sched_trace_ai.c
+++ b/kernel/sched/ai/sched_trace_ai.c
@@ -1,0 +1,499 @@
+/*
+ * sched_trace_ai.c — AI-scheduler decision-trace ring buffer (#880).
+ *
+ * Design: per-CPU ring buffer of fixed-size 480-byte records. Each
+ * CPU writes only its own slots; no cross-CPU lock or atomic
+ * fetch-add on the hot path. The owning CPU cache_cleans every
+ * write so the dump path (typically on CPU 0) sees up-to-date data
+ * after cache_invalidate. This mirrors the sched_diag NC-counter
+ * pattern called out in `kernel/CLAUDE.md`.
+ *
+ * Per-CPU vs single-global was chosen because Pi 5 / Jetson have
+ * incoherent per-core L2 caches (no SMPEN) — a single global head
+ * index updated via atomic fetch-add would either need explicit DC
+ * CIVAC/DSB SY around every increment (expensive) or NC memory for
+ * the head (the run-queue NC region is small and the ring buffer
+ * itself can't fit there). Per-CPU rings sidestep both problems.
+ *
+ * Dump format documented in `docs/sched-trace-format.md`. The
+ * sibling-repo ingester (#879 / 61c) parses the same bytes.
+ */
+
+#if defined(CONFIG_AI_SCHEDULER)
+
+#include "sched_trace_ai.h"
+#include "ai_types.h"
+#include "ai_state.h"
+#include "task.h"
+#include "smp.h"
+#include "cache.h"
+#include "pmm.h"
+#include "string.h"
+#include "config.h"
+
+extern uint64_t slm_get_time_ns(void);
+
+/* Sanity-check the state dimension constant matches the policy
+ * runtime's expectation. If a future change desyncs them the
+ * compile breaks here rather than producing silently misshapen
+ * trace records. */
+_Static_assert(SCHED_TRACE_AI_STATE_DIM == AI_STATE_DIM,
+               "trace state_dim must match AI_STATE_DIM");
+
+/* Per-CPU ring length. Total ring = MAX_CPUS * PERCPU_ENTRIES. With
+ * 8 CPUs × 512 entries × 480 B = ~1.92 MB. */
+#define PERCPU_ENTRIES  (SCHED_TRACE_AI_RING_ENTRIES / MAX_CPUS)
+
+_Static_assert(PERCPU_ENTRIES * MAX_CPUS == SCHED_TRACE_AI_RING_ENTRIES,
+               "ring entries must divide evenly across MAX_CPUS");
+
+struct sched_trace_ai_percpu {
+    /* head: index of the slot the NEXT write will land in
+     * (mod PERCPU_ENTRIES). Monotonic counter — never wrapped at
+     * the variable; only the slot index wraps. */
+    volatile uint64_t total_written;
+    volatile uint32_t head;
+    volatile uint32_t _pad0;
+    /* Cacheline padding so adjacent CPUs' percpu structs don't
+     * false-share the head counter. */
+    uint8_t  _hdrpad[64 - 16];
+    struct sched_trace_ai_record ring[PERCPU_ENTRIES];
+};
+
+_Static_assert(offsetof(struct sched_trace_ai_percpu, ring) == 64,
+               "ring must start on the second cacheline of the percpu struct");
+
+static struct sched_trace_ai_percpu *tracer_percpu;  /* MAX_CPUS-element array */
+static volatile uint32_t tracer_enabled;             /* 0 / 1 atomic flag */
+static volatile uint32_t tracer_initialized;
+
+/* ---- Initialization ---- */
+
+int sched_trace_ai_init(void)
+{
+    if (tracer_initialized) {
+        return 0;
+    }
+    size_t total = sizeof(struct sched_trace_ai_percpu) * MAX_CPUS;
+    size_t pages = (total + 4095u) / 4096u;
+    tracer_percpu = pmm_alloc_pages(pages);
+    if (!tracer_percpu) {
+        return -1;
+    }
+    memset(tracer_percpu, 0, total);
+    /* Initial cache_clean so secondary CPUs reading their own head
+     * see 0 rather than uninitialized garbage. */
+    cache_clean_range(tracer_percpu, total);
+    tracer_initialized = 1;
+    return 0;
+}
+
+/* ---- Control plane ---- */
+
+static void clear_locked(void)
+{
+    if (!tracer_initialized || !tracer_percpu) return;
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        tracer_percpu[i].head = 0;
+        tracer_percpu[i].total_written = 0;
+        /* Zero the ring so a dump of a freshly-cleared trace
+         * doesn't leak prior recording's contents. */
+        memset(tracer_percpu[i].ring, 0, sizeof(tracer_percpu[i].ring));
+    }
+    cache_clean_range(tracer_percpu,
+                      sizeof(struct sched_trace_ai_percpu) * MAX_CPUS);
+}
+
+void sched_trace_ai_start(void)
+{
+    if (!tracer_initialized && sched_trace_ai_init() != 0) {
+        return;
+    }
+    clear_locked();
+    __atomic_store_n(&tracer_enabled, 1u, __ATOMIC_RELEASE);
+}
+
+void sched_trace_ai_stop(void)
+{
+    __atomic_store_n(&tracer_enabled, 0u, __ATOMIC_RELEASE);
+}
+
+void sched_trace_ai_clear(void)
+{
+    /* Briefly suspend writes so we don't race the clear. Restored
+     * to caller's prior state on exit. */
+    uint32_t prev = __atomic_exchange_n(&tracer_enabled, 0u, __ATOMIC_ACQ_REL);
+    clear_locked();
+    __atomic_store_n(&tracer_enabled, prev, __ATOMIC_RELEASE);
+}
+
+bool sched_trace_ai_is_enabled(void)
+{
+    return __atomic_load_n(&tracer_enabled, __ATOMIC_ACQUIRE) != 0;
+}
+
+static uint64_t total_written_sum(void)
+{
+    if (!tracer_initialized || !tracer_percpu) return 0;
+    uint64_t sum = 0;
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        cache_invalidate_range(&tracer_percpu[i],
+                               offsetof(struct sched_trace_ai_percpu, ring));
+        sum += tracer_percpu[i].total_written;
+    }
+    return sum;
+}
+
+uint32_t sched_trace_ai_records_used(void)
+{
+    if (!tracer_initialized || !tracer_percpu) return 0;
+    uint32_t used = 0;
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        cache_invalidate_range(&tracer_percpu[i],
+                               offsetof(struct sched_trace_ai_percpu, ring));
+        uint64_t w = tracer_percpu[i].total_written;
+        used += (w > PERCPU_ENTRIES) ? PERCPU_ENTRIES : (uint32_t)w;
+    }
+    return used;
+}
+
+uint64_t sched_trace_ai_total_events(void)
+{
+    return total_written_sum();
+}
+
+uint64_t sched_trace_ai_dropped(void)
+{
+    if (!tracer_initialized || !tracer_percpu) return 0;
+    uint64_t dropped = 0;
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        cache_invalidate_range(&tracer_percpu[i],
+                               offsetof(struct sched_trace_ai_percpu, ring));
+        uint64_t w = tracer_percpu[i].total_written;
+        if (w > PERCPU_ENTRIES) {
+            dropped += (w - PERCPU_ENTRIES);
+        }
+    }
+    return dropped;
+}
+
+/* ---- Hot path ---- */
+
+/* Copy `src` into `dst[0..max-1]`, zero-padding the remainder.
+ * Always null-terminates. Used for the fixed 16-byte policy name
+ * field so the on-disk record never has trailing garbage. */
+static void copy_policy_name(char *dst, size_t max, const char *src)
+{
+    memset(dst, 0, max);
+    if (!src) return;
+    size_t i = 0;
+    while (i < max - 1 && src[i] != '\0') {
+        dst[i] = src[i];
+        i++;
+    }
+    /* Last byte already zero from memset — guarantees null term. */
+}
+
+void sched_trace_ai_record_decision(struct task *task,
+                                    const char *policy_name,
+                                    uint32_t action_core)
+{
+    if (!__atomic_load_n(&tracer_enabled, __ATOMIC_ACQUIRE)) return;
+    if (!tracer_percpu) return;
+
+    uint32_t cpu = cpu_id();
+    if (cpu >= MAX_CPUS) return;  /* defensive */
+
+    struct sched_trace_ai_percpu *pc = &tracer_percpu[cpu];
+    uint32_t slot = (uint32_t)(pc->total_written % PERCPU_ENTRIES);
+    struct sched_trace_ai_record *r = &pc->ring[slot];
+
+    /* Fill the header. */
+    r->kind = (uint8_t)SCHED_TRACE_AI_KIND_DECISION;
+    r->cpu_recorded = (uint8_t)cpu;
+    r->_hdr_pad = 0;
+    r->task_id = task ? task->id : 0u;
+    r->timestamp_ns = slm_get_time_ns();
+
+    /* Decision body. */
+    copy_policy_name(r->u.decision.policy_name,
+                     sizeof(r->u.decision.policy_name), policy_name);
+    r->u.decision.action_core = (int32_t)action_core;
+    r->u.decision.action_priority = task ? (int32_t)task->effective_priority : -1;
+    r->u.decision.action_preempt = 0;  /* reserved */
+    r->u.decision._decision_pad = 0;
+
+    /* State vector — full 108-dim FP32 snapshot. ai_extract_state
+     * reads global scheduler state; it doesn't touch the running
+     * task. Stage in an aligned local buffer then memcpy: the
+     * record is `__attribute__((packed))` so taking the address of
+     * the embedded state[] array yields an "unaligned pointer"
+     * warning, but a memcpy from a properly-aligned source is fine. */
+    float state_buf[AI_STATE_DIM] __attribute__((aligned(8)));
+    ai_extract_state(state_buf);
+    memcpy(r->u.decision.state, state_buf, sizeof(state_buf));
+
+    /* Push the record to PoC so dump (on a possibly different CPU)
+     * sees it without depending on an L2 coherency event. */
+    cache_clean_range(r, sizeof(*r));
+
+    pc->total_written++;
+    pc->head = (slot + 1u) % PERCPU_ENTRIES;
+    cache_clean_range(pc,
+                      offsetof(struct sched_trace_ai_percpu, ring));
+}
+
+void sched_trace_ai_record_completion(struct task *task)
+{
+    if (!__atomic_load_n(&tracer_enabled, __ATOMIC_ACQUIRE)) return;
+    if (!tracer_percpu || !task) return;
+
+    uint32_t cpu = cpu_id();
+    if (cpu >= MAX_CPUS) return;
+
+    struct sched_trace_ai_percpu *pc = &tracer_percpu[cpu];
+    uint32_t slot = (uint32_t)(pc->total_written % PERCPU_ENTRIES);
+    struct sched_trace_ai_record *r = &pc->ring[slot];
+
+    r->kind = (uint8_t)SCHED_TRACE_AI_KIND_COMPLETION;
+    r->cpu_recorded = (uint8_t)cpu;
+    r->_hdr_pad = 0;
+    r->task_id = task->id;
+    r->timestamp_ns = slm_get_time_ns();
+
+    uint64_t dispatch_ns = 0;  /* not currently tracked per-task; left 0 */
+    uint64_t deadline_ns = task->deadline_ns;
+    uint64_t completion_ns = r->timestamp_ns;
+    r->u.completion.dispatch_ns = dispatch_ns;
+    r->u.completion.completion_ns = completion_ns;
+    r->u.completion.deadline_ns = deadline_ns;
+    r->u.completion.latency_to_complete_us =
+        (dispatch_ns != 0 && completion_ns > dispatch_ns)
+            ? (uint32_t)((completion_ns - dispatch_ns) / 1000ULL)
+            : 0u;
+    r->u.completion.ran_on_cpu = (uint8_t)task->assigned_cpu;
+    r->u.completion.deadline_met =
+        (deadline_ns == 0 || completion_ns <= deadline_ns) ? 1u : 0u;
+    r->u.completion._completion_pad[0] = 0;
+    r->u.completion._completion_pad[1] = 0;
+    memset(r->u.completion._tail_pad, 0, sizeof(r->u.completion._tail_pad));
+
+    cache_clean_range(r, sizeof(*r));
+    pc->total_written++;
+    pc->head = (slot + 1u) % PERCPU_ENTRIES;
+    cache_clean_range(pc,
+                      offsetof(struct sched_trace_ai_percpu, ring));
+}
+
+/* ---- Dump ---- */
+
+size_t sched_trace_ai_dump_size(void)
+{
+    uint32_t used = sched_trace_ai_records_used();
+    return sizeof(struct sched_trace_ai_file_header) +
+           (size_t)used * SCHED_TRACE_AI_RECORD_SIZE;
+}
+
+size_t sched_trace_ai_dump_stream(sched_trace_ai_dump_cb cb, void *ctx)
+{
+    if (!cb || !tracer_initialized || !tracer_percpu) return 0;
+
+    uint32_t used = sched_trace_ai_records_used();
+    uint64_t total = sched_trace_ai_total_events();
+    uint64_t dropped = sched_trace_ai_dropped();
+
+    struct sched_trace_ai_file_header hdr = {
+        .magic = SCHED_TRACE_AI_MAGIC,
+        .version = (uint16_t)SCHED_TRACE_AI_VERSION,
+        .record_size = (uint16_t)SCHED_TRACE_AI_RECORD_SIZE,
+        .record_count = used,
+        .state_dim = SCHED_TRACE_AI_STATE_DIM,
+        .total_events_since_start = total,
+        .dropped_events = dropped,
+    };
+    if (cb(ctx, &hdr, sizeof(hdr)) < 0) return 0;
+    size_t emitted = sizeof(hdr);
+
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        cache_invalidate_range(&tracer_percpu[i], sizeof(tracer_percpu[i]));
+        uint64_t w = tracer_percpu[i].total_written;
+        uint32_t count = (w > PERCPU_ENTRIES) ? PERCPU_ENTRIES : (uint32_t)w;
+        if (count == 0) continue;
+        uint32_t start = (w > PERCPU_ENTRIES) ? tracer_percpu[i].head : 0u;
+        for (uint32_t k = 0; k < count; k++) {
+            uint32_t idx = (start + k) % PERCPU_ENTRIES;
+            if (cb(ctx, &tracer_percpu[i].ring[idx],
+                   SCHED_TRACE_AI_RECORD_SIZE) < 0) {
+                return 0;
+            }
+            emitted += SCHED_TRACE_AI_RECORD_SIZE;
+        }
+    }
+    return emitted;
+}
+
+size_t sched_trace_ai_dump_to_buf(uint8_t *buf, size_t buflen)
+{
+    if (!buf || !tracer_initialized || !tracer_percpu) return 0;
+    size_t need = sched_trace_ai_dump_size();
+    if (buflen < need) return 0;
+
+    uint32_t used = sched_trace_ai_records_used();
+    uint64_t total = sched_trace_ai_total_events();
+    uint64_t dropped = sched_trace_ai_dropped();
+
+    struct sched_trace_ai_file_header hdr = {
+        .magic = SCHED_TRACE_AI_MAGIC,
+        .version = (uint16_t)SCHED_TRACE_AI_VERSION,
+        .record_size = (uint16_t)SCHED_TRACE_AI_RECORD_SIZE,
+        .record_count = used,
+        .state_dim = SCHED_TRACE_AI_STATE_DIM,
+        .total_events_since_start = total,
+        .dropped_events = dropped,
+    };
+    memcpy(buf, &hdr, sizeof(hdr));
+
+    /* Walk each per-CPU ring in oldest→newest order and copy out.
+     * Records from different CPUs are interleaved by insertion
+     * order within each CPU; the ingester merge-sorts by
+     * timestamp_ns if a strict global order is needed. */
+    uint8_t *out = buf + sizeof(hdr);
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        cache_invalidate_range(&tracer_percpu[i], sizeof(tracer_percpu[i]));
+        uint64_t w = tracer_percpu[i].total_written;
+        uint32_t count = (w > PERCPU_ENTRIES) ? PERCPU_ENTRIES : (uint32_t)w;
+        if (count == 0) continue;
+        /* If we wrapped, oldest is at head; otherwise oldest is at 0. */
+        uint32_t start = (w > PERCPU_ENTRIES)
+            ? tracer_percpu[i].head
+            : 0u;
+        for (uint32_t k = 0; k < count; k++) {
+            uint32_t idx = (start + k) % PERCPU_ENTRIES;
+            memcpy(out, &tracer_percpu[i].ring[idx],
+                   SCHED_TRACE_AI_RECORD_SIZE);
+            out += SCHED_TRACE_AI_RECORD_SIZE;
+        }
+    }
+    return (size_t)(out - buf);
+}
+
+/* ---- Shell CLI ----
+ *
+ * Lives here (vs in shell_sys.c) so the file-write dependency on
+ * LittleFS / VFS is co-located with the trace API rather than
+ * scattered across the shell. Called from shell_sys.c via extern.
+ */
+
+#include "vfs.h"
+#include "littlefs_slm.h"
+#include "shell.h"
+#include "shell_internal.h"
+
+struct aitrace_dump_ctx {
+    struct lfs_mount *mnt;
+    int fd;
+    int err;
+    size_t bytes_written;
+};
+
+static int aitrace_dump_cb(void *vctx, const void *bytes, size_t len)
+{
+    struct aitrace_dump_ctx *ctx = (struct aitrace_dump_ctx *)vctx;
+    if (ctx->err) return ctx->err;
+    int rc = littlefs_file_write(ctx->mnt, ctx->fd, bytes, len);
+    if (rc < 0) {
+        ctx->err = rc;
+        return rc;
+    }
+    if ((size_t)rc != len) {
+        ctx->err = -1;
+        return -1;
+    }
+    ctx->bytes_written += len;
+    return 0;
+}
+
+size_t sched_trace_ai_dump_to_path(const char *path)
+{
+    if (!path) return 0;
+    char resolved[256];
+    if (shell_resolve_path(path, resolved, sizeof(resolved)) < 0) {
+        return 0;
+    }
+    const char *subpath = 0;
+    struct lfs_mount *mnt = vfs_get_mount_ctx(resolved, &subpath);
+    if (!mnt) return 0;
+    int fd = littlefs_file_open(mnt, subpath,
+                                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fd < 0) return 0;
+    struct aitrace_dump_ctx ctx = { .mnt = mnt, .fd = fd,
+                                     .err = 0, .bytes_written = 0 };
+    size_t total = sched_trace_ai_dump_stream(aitrace_dump_cb, &ctx);
+    littlefs_file_close(mnt, fd);
+    if (ctx.err) return 0;
+    return total;
+}
+
+int sched_aitrace_cli(int argc, char *argv[])
+{
+    const char *sub = (argc >= 3) ? argv[2] : "stats";
+
+    if (strcmp(sub, "start") == 0) {
+        sched_trace_ai_start();
+        shell_printf("AI decision trace started (%u slots, %u B/record, "
+                     "ring = %u KB total)\r\n",
+                     (unsigned)SCHED_TRACE_AI_RING_ENTRIES,
+                     (unsigned)SCHED_TRACE_AI_RECORD_SIZE,
+                     (unsigned)((SCHED_TRACE_AI_RING_ENTRIES *
+                                 SCHED_TRACE_AI_RECORD_SIZE) / 1024u));
+        return 0;
+    }
+    if (strcmp(sub, "stop") == 0) {
+        sched_trace_ai_stop();
+        shell_printf("AI decision trace stopped (%u records used, "
+                     "%lu events total, %lu dropped)\r\n",
+                     (unsigned)sched_trace_ai_records_used(),
+                     (unsigned long)sched_trace_ai_total_events(),
+                     (unsigned long)sched_trace_ai_dropped());
+        return 0;
+    }
+    if (strcmp(sub, "clear") == 0) {
+        sched_trace_ai_clear();
+        shell_puts("AI decision trace cleared\r\n");
+        return 0;
+    }
+    if (strcmp(sub, "stats") == 0) {
+        shell_printf("AI decision trace: %s\r\n",
+                     sched_trace_ai_is_enabled() ? "ON" : "OFF");
+        shell_printf("  records used   : %u / %u\r\n",
+                     (unsigned)sched_trace_ai_records_used(),
+                     (unsigned)SCHED_TRACE_AI_RING_ENTRIES);
+        shell_printf("  total events   : %lu\r\n",
+                     (unsigned long)sched_trace_ai_total_events());
+        shell_printf("  dropped events : %lu\r\n",
+                     (unsigned long)sched_trace_ai_dropped());
+        shell_printf("  dump size      : %lu bytes\r\n",
+                     (unsigned long)sched_trace_ai_dump_size());
+        return 0;
+    }
+    if (strcmp(sub, "dump") == 0) {
+        if (argc < 4) {
+            shell_puts("Usage: sched aitrace dump <path>\r\n");
+            shell_puts("  e.g. sched aitrace dump /mnt/files/sched_trace.bin\r\n");
+            return 1;
+        }
+        size_t total = sched_trace_ai_dump_to_path(argv[3]);
+        if (total == 0) {
+            shell_printf("aitrace: dump to %s failed (bad path, "
+                         "unmounted FS, or write error)\r\n", argv[3]);
+            return 1;
+        }
+        shell_printf("aitrace: dumped %lu bytes to %s\r\n",
+                     (unsigned long)total, argv[3]);
+        return 0;
+    }
+    shell_puts("Usage: sched aitrace [start|stop|stats|clear|dump <path>]\r\n");
+    return 1;
+}
+
+#endif /* CONFIG_AI_SCHEDULER */

--- a/kernel/sched/ai/sched_trace_ai.c
+++ b/kernel/sched/ai/sched_trace_ai.c
@@ -53,15 +53,15 @@ _Static_assert(PERCPU_ENTRIES * MAX_CPUS == SCHED_TRACE_AI_RING_ENTRIES,
                "ring entries must divide evenly across MAX_CPUS");
 
 struct sched_trace_ai_percpu {
-    /* head: index of the slot the NEXT write will land in
-     * (mod PERCPU_ENTRIES). Monotonic counter — never wrapped at
-     * the variable; only the slot index wraps. */
+    /* Monotonic count of records written by this CPU. Slot index
+     * derives from `total_written % PERCPU_ENTRIES`; readers compute
+     * the same value rather than reading a separately-stored `head`
+     * field (eliminates a cross-CPU write-order race where a reader
+     * could observe total_written++ before head was updated). */
     volatile uint64_t total_written;
-    volatile uint32_t head;
-    volatile uint32_t _pad0;
     /* Cacheline padding so adjacent CPUs' percpu structs don't
-     * false-share the head counter. */
-    uint8_t  _hdrpad[64 - 16];
+     * false-share the counter. */
+    uint8_t  _hdrpad[64 - 8];
     struct sched_trace_ai_record ring[PERCPU_ENTRIES];
 };
 
@@ -72,8 +72,14 @@ static struct sched_trace_ai_percpu *tracer_percpu;  /* MAX_CPUS-element array *
 static volatile uint32_t tracer_enabled;             /* 0 / 1 atomic flag */
 static volatile uint32_t tracer_initialized;
 
-/* ---- Initialization ---- */
-
+/* ---- Initialization ----
+ *
+ * Called from `sched_ai_init()` (boot, CPU 0) and from
+ * `sched_trace_ai_start()` (shell, CPU 0). The check-then-allocate
+ * below is intentionally NOT atomic — both call sites run on CPU 0
+ * in the shell/init task. A future caller from a non-CPU-0 path
+ * (e.g. a Lua/IPC binding scheduled onto a secondary) must add an
+ * external lock or replace the body with a compare-and-swap. */
 int sched_trace_ai_init(void)
 {
     if (tracer_initialized) {
@@ -86,7 +92,7 @@ int sched_trace_ai_init(void)
         return -1;
     }
     memset(tracer_percpu, 0, total);
-    /* Initial cache_clean so secondary CPUs reading their own head
+    /* Initial cache_clean so secondary CPUs reading their own counter
      * see 0 rather than uninitialized garbage. */
     cache_clean_range(tracer_percpu, total);
     tracer_initialized = 1;
@@ -95,11 +101,14 @@ int sched_trace_ai_init(void)
 
 /* ---- Control plane ---- */
 
-static void clear_locked(void)
+/* Zero every per-CPU ring + counter. NOT synchronized against
+ * concurrent hot-path writers — the caller must pause writes (via
+ * the `tracer_enabled` atomic) before invoking. `sched_trace_ai_start`
+ * and `sched_trace_ai_clear` both follow this contract. */
+static void clear_rings_unsynchronized(void)
 {
     if (!tracer_initialized || !tracer_percpu) return;
     for (uint32_t i = 0; i < MAX_CPUS; i++) {
-        tracer_percpu[i].head = 0;
         tracer_percpu[i].total_written = 0;
         /* Zero the ring so a dump of a freshly-cleared trace
          * doesn't leak prior recording's contents. */
@@ -114,7 +123,17 @@ void sched_trace_ai_start(void)
     if (!tracer_initialized && sched_trace_ai_init() != 0) {
         return;
     }
-    clear_locked();
+    /* Disable first so the clear below isn't racing concurrent
+     * hot-path writers on other CPUs. A narrow residual window still
+     * exists: a writer that already passed the `tracer_enabled`
+     * load in record_decision/completion can be mid-record when the
+     * atomic store flips the flag to 0. That window is bounded by
+     * the IRQ-disabled critical section length (~hundreds of cycles),
+     * so at most one partially-zeroed record per CPU can survive the
+     * clear — acceptable for a trace ring whose ingester tolerates
+     * occasional dropped records. */
+    __atomic_store_n(&tracer_enabled, 0u, __ATOMIC_RELEASE);
+    clear_rings_unsynchronized();
     __atomic_store_n(&tracer_enabled, 1u, __ATOMIC_RELEASE);
 }
 
@@ -126,9 +145,10 @@ void sched_trace_ai_stop(void)
 void sched_trace_ai_clear(void)
 {
     /* Briefly suspend writes so we don't race the clear. Restored
-     * to caller's prior state on exit. */
+     * to caller's prior state on exit. Same residual-window caveat
+     * as `sched_trace_ai_start` applies. */
     uint32_t prev = __atomic_exchange_n(&tracer_enabled, 0u, __ATOMIC_ACQ_REL);
-    clear_locked();
+    clear_rings_unsynchronized();
     __atomic_store_n(&tracer_enabled, prev, __ATOMIC_RELEASE);
 }
 
@@ -189,6 +209,7 @@ uint64_t sched_trace_ai_dropped(void)
  * field so the on-disk record never has trailing garbage. */
 static void copy_policy_name(char *dst, size_t max, const char *src)
 {
+    if (max == 0) return;
     memset(dst, 0, max);
     if (!src) return;
     size_t i = 0;
@@ -252,16 +273,12 @@ void sched_trace_ai_record_decision(struct task *task,
      * sees it without depending on an L2 coherency event. */
     cache_clean_range(r, sizeof(*r));
 
-    /* total_written and head are co-located on the first cacheline
-     * (head + total_written + padding span offset 0..63; the ring
-     * starts at offset 64). A single cache_clean_range here pushes
-     * both counters atomically — cross-CPU readers in the dump path
-     * see a consistent (head, total_written) pair. If the
-     * `_hdrpad` shrinks below 48 bytes a future maintainer must
-     * re-verify this invariant; the _Static_assert at offsetof(ring)
-     * == 64 above guards against that. */
+    /* Bump the per-CPU counter and push it. Slot index is derived
+     * from `total_written % PERCPU_ENTRIES` everywhere it's needed
+     * (both writer and dump reader) — no separately-stored `head`
+     * field, no cross-CPU write-order race between two counter
+     * stores. */
     pc->total_written++;
-    pc->head = (slot + 1u) % PERCPU_ENTRIES;
     cache_clean_range(pc,
                       offsetof(struct sched_trace_ai_percpu, ring));
 
@@ -310,7 +327,6 @@ void sched_trace_ai_record_completion(struct task *task)
 
     cache_clean_range(r, sizeof(*r));
     pc->total_written++;
-    pc->head = (slot + 1u) % PERCPU_ENTRIES;
     cache_clean_range(pc,
                       offsetof(struct sched_trace_ai_percpu, ring));
 
@@ -334,7 +350,6 @@ size_t sched_trace_ai_dump_size(void)
  * `record_count` disagrees with the byte stream. */
 struct trace_snapshot {
     uint64_t total;
-    uint32_t head;
     uint32_t count;
     uint32_t start;
 };
@@ -352,9 +367,16 @@ static void take_snapshot(struct trace_snapshot snap[MAX_CPUS],
                                offsetof(struct sched_trace_ai_percpu, ring));
         uint64_t w = tracer_percpu[i].total_written;
         snap[i].total = w;
-        snap[i].head = tracer_percpu[i].head;
         snap[i].count = (w > PERCPU_ENTRIES) ? PERCPU_ENTRIES : (uint32_t)w;
-        snap[i].start = (w > PERCPU_ENTRIES) ? snap[i].head : 0u;
+        /* Oldest record sits at the next-write slot, which is
+         * (total_written % PERCPU_ENTRIES) for a wrapped ring. Derive
+         * here rather than reading a separately-stored head field —
+         * keeps the writer's two counter updates collapsed into a
+         * single monotonic counter and removes the cross-CPU write-
+         * order race that would otherwise put `start` one slot
+         * behind `total`. */
+        snap[i].start = (w > PERCPU_ENTRIES)
+            ? (uint32_t)(w % PERCPU_ENTRIES) : 0u;
         used += snap[i].count;
         total += w;
         if (w > PERCPU_ENTRIES) dropped += (w - PERCPU_ENTRIES);

--- a/kernel/sched/ai/sched_trace_ai.c
+++ b/kernel/sched/ai/sched_trace_ai.c
@@ -28,8 +28,13 @@
 #include "smp.h"
 #include "cache.h"
 #include "pmm.h"
+#include "spinlock.h"   /* irq_save / irq_restore */
 #include "string.h"
 #include "config.h"
+#include "vfs.h"
+#include "littlefs_slm.h"
+#include "shell.h"
+#include "shell_internal.h"
 
 extern uint64_t slm_get_time_ns(void);
 
@@ -201,8 +206,18 @@ void sched_trace_ai_record_decision(struct task *task,
     if (!__atomic_load_n(&tracer_enabled, __ATOMIC_ACQUIRE)) return;
     if (!tracer_percpu) return;
 
+    /* IRQ-disable for the per-CPU critical section. Cheap (single
+     * DAIF write on ARM64; STI/CLI pair on x86) and clearly correct:
+     * keeps a timer IRQ that re-enters the scheduler path from
+     * overwriting the slot we just claimed before `total_written++`
+     * commits. The hook itself doesn't yield. */
+    irq_flags_t irq_flags = irq_save();
+
     uint32_t cpu = cpu_id();
-    if (cpu >= MAX_CPUS) return;  /* defensive */
+    if (cpu >= MAX_CPUS) {  /* defensive */
+        irq_restore(irq_flags);
+        return;
+    }
 
     struct sched_trace_ai_percpu *pc = &tracer_percpu[cpu];
     uint32_t slot = (uint32_t)(pc->total_written % PERCPU_ENTRIES);
@@ -237,10 +252,20 @@ void sched_trace_ai_record_decision(struct task *task,
      * sees it without depending on an L2 coherency event. */
     cache_clean_range(r, sizeof(*r));
 
+    /* total_written and head are co-located on the first cacheline
+     * (head + total_written + padding span offset 0..63; the ring
+     * starts at offset 64). A single cache_clean_range here pushes
+     * both counters atomically — cross-CPU readers in the dump path
+     * see a consistent (head, total_written) pair. If the
+     * `_hdrpad` shrinks below 48 bytes a future maintainer must
+     * re-verify this invariant; the _Static_assert at offsetof(ring)
+     * == 64 above guards against that. */
     pc->total_written++;
     pc->head = (slot + 1u) % PERCPU_ENTRIES;
     cache_clean_range(pc,
                       offsetof(struct sched_trace_ai_percpu, ring));
+
+    irq_restore(irq_flags);
 }
 
 void sched_trace_ai_record_completion(struct task *task)
@@ -248,8 +273,13 @@ void sched_trace_ai_record_completion(struct task *task)
     if (!__atomic_load_n(&tracer_enabled, __ATOMIC_ACQUIRE)) return;
     if (!tracer_percpu || !task) return;
 
+    irq_flags_t irq_flags = irq_save();
+
     uint32_t cpu = cpu_id();
-    if (cpu >= MAX_CPUS) return;
+    if (cpu >= MAX_CPUS) {
+        irq_restore(irq_flags);
+        return;
+    }
 
     struct sched_trace_ai_percpu *pc = &tracer_percpu[cpu];
     uint32_t slot = (uint32_t)(pc->total_written % PERCPU_ENTRIES);
@@ -283,6 +313,8 @@ void sched_trace_ai_record_completion(struct task *task)
     pc->head = (slot + 1u) % PERCPU_ENTRIES;
     cache_clean_range(pc,
                       offsetof(struct sched_trace_ai_percpu, ring));
+
+    irq_restore(irq_flags);
 }
 
 /* ---- Dump ---- */
@@ -294,13 +326,53 @@ size_t sched_trace_ai_dump_size(void)
            (size_t)used * SCHED_TRACE_AI_RECORD_SIZE;
 }
 
+/* Snapshot each CPU's (total_written, head) tuple into a local
+ * array. Used by the dump path so the file header and the records
+ * emitted derive from the same observation point — without the
+ * snapshot, a hot-path write that lands between header computation
+ * and the record-iteration loop produces a file whose
+ * `record_count` disagrees with the byte stream. */
+struct trace_snapshot {
+    uint64_t total;
+    uint32_t head;
+    uint32_t count;
+    uint32_t start;
+};
+
+static void take_snapshot(struct trace_snapshot snap[MAX_CPUS],
+                          uint32_t *used_out,
+                          uint64_t *total_out,
+                          uint64_t *dropped_out)
+{
+    uint32_t used = 0;
+    uint64_t total = 0;
+    uint64_t dropped = 0;
+    for (uint32_t i = 0; i < MAX_CPUS; i++) {
+        cache_invalidate_range(&tracer_percpu[i],
+                               offsetof(struct sched_trace_ai_percpu, ring));
+        uint64_t w = tracer_percpu[i].total_written;
+        snap[i].total = w;
+        snap[i].head = tracer_percpu[i].head;
+        snap[i].count = (w > PERCPU_ENTRIES) ? PERCPU_ENTRIES : (uint32_t)w;
+        snap[i].start = (w > PERCPU_ENTRIES) ? snap[i].head : 0u;
+        used += snap[i].count;
+        total += w;
+        if (w > PERCPU_ENTRIES) dropped += (w - PERCPU_ENTRIES);
+    }
+    *used_out = used;
+    *total_out = total;
+    *dropped_out = dropped;
+}
+
 size_t sched_trace_ai_dump_stream(sched_trace_ai_dump_cb cb, void *ctx)
 {
     if (!cb || !tracer_initialized || !tracer_percpu) return 0;
 
-    uint32_t used = sched_trace_ai_records_used();
-    uint64_t total = sched_trace_ai_total_events();
-    uint64_t dropped = sched_trace_ai_dropped();
+    struct trace_snapshot snap[MAX_CPUS];
+    uint32_t used;
+    uint64_t total;
+    uint64_t dropped;
+    take_snapshot(snap, &used, &total, &dropped);
 
     struct sched_trace_ai_file_header hdr = {
         .magic = SCHED_TRACE_AI_MAGIC,
@@ -315,13 +387,13 @@ size_t sched_trace_ai_dump_stream(sched_trace_ai_dump_cb cb, void *ctx)
     size_t emitted = sizeof(hdr);
 
     for (uint32_t i = 0; i < MAX_CPUS; i++) {
-        cache_invalidate_range(&tracer_percpu[i], sizeof(tracer_percpu[i]));
-        uint64_t w = tracer_percpu[i].total_written;
-        uint32_t count = (w > PERCPU_ENTRIES) ? PERCPU_ENTRIES : (uint32_t)w;
-        if (count == 0) continue;
-        uint32_t start = (w > PERCPU_ENTRIES) ? tracer_percpu[i].head : 0u;
-        for (uint32_t k = 0; k < count; k++) {
-            uint32_t idx = (start + k) % PERCPU_ENTRIES;
+        if (snap[i].count == 0) continue;
+        /* Re-invalidate the ring portion only; the header was
+         * already invalidated by take_snapshot. */
+        cache_invalidate_range(tracer_percpu[i].ring,
+                               sizeof(tracer_percpu[i].ring));
+        for (uint32_t k = 0; k < snap[i].count; k++) {
+            uint32_t idx = (snap[i].start + k) % PERCPU_ENTRIES;
             if (cb(ctx, &tracer_percpu[i].ring[idx],
                    SCHED_TRACE_AI_RECORD_SIZE) < 0) {
                 return 0;
@@ -335,12 +407,21 @@ size_t sched_trace_ai_dump_stream(sched_trace_ai_dump_cb cb, void *ctx)
 size_t sched_trace_ai_dump_to_buf(uint8_t *buf, size_t buflen)
 {
     if (!buf || !tracer_initialized || !tracer_percpu) return 0;
-    size_t need = sched_trace_ai_dump_size();
-    if (buflen < need) return 0;
 
-    uint32_t used = sched_trace_ai_records_used();
-    uint64_t total = sched_trace_ai_total_events();
-    uint64_t dropped = sched_trace_ai_dropped();
+    /* Snapshot first so the header's record_count and the iterated
+     * bytes derive from the same observation. Without this, a
+     * tight `buflen == dump_size()` caller would overflow when a
+     * concurrent hot-path write advances total_written between the
+     * size check and the loop. */
+    struct trace_snapshot snap[MAX_CPUS];
+    uint32_t used;
+    uint64_t total;
+    uint64_t dropped;
+    take_snapshot(snap, &used, &total, &dropped);
+
+    size_t need = sizeof(struct sched_trace_ai_file_header) +
+                  (size_t)used * SCHED_TRACE_AI_RECORD_SIZE;
+    if (buflen < need) return 0;
 
     struct sched_trace_ai_file_header hdr = {
         .magic = SCHED_TRACE_AI_MAGIC,
@@ -353,22 +434,17 @@ size_t sched_trace_ai_dump_to_buf(uint8_t *buf, size_t buflen)
     };
     memcpy(buf, &hdr, sizeof(hdr));
 
-    /* Walk each per-CPU ring in oldest→newest order and copy out.
-     * Records from different CPUs are interleaved by insertion
-     * order within each CPU; the ingester merge-sorts by
-     * timestamp_ns if a strict global order is needed. */
+    /* Walk each per-CPU ring in oldest→newest order using snapshot
+     * counts. Records from different CPUs are interleaved by
+     * insertion order within each CPU; the sibling-repo ingester
+     * merge-sorts by timestamp_ns if a strict global order is needed. */
     uint8_t *out = buf + sizeof(hdr);
     for (uint32_t i = 0; i < MAX_CPUS; i++) {
-        cache_invalidate_range(&tracer_percpu[i], sizeof(tracer_percpu[i]));
-        uint64_t w = tracer_percpu[i].total_written;
-        uint32_t count = (w > PERCPU_ENTRIES) ? PERCPU_ENTRIES : (uint32_t)w;
-        if (count == 0) continue;
-        /* If we wrapped, oldest is at head; otherwise oldest is at 0. */
-        uint32_t start = (w > PERCPU_ENTRIES)
-            ? tracer_percpu[i].head
-            : 0u;
-        for (uint32_t k = 0; k < count; k++) {
-            uint32_t idx = (start + k) % PERCPU_ENTRIES;
+        if (snap[i].count == 0) continue;
+        cache_invalidate_range(tracer_percpu[i].ring,
+                               sizeof(tracer_percpu[i].ring));
+        for (uint32_t k = 0; k < snap[i].count; k++) {
+            uint32_t idx = (snap[i].start + k) % PERCPU_ENTRIES;
             memcpy(out, &tracer_percpu[i].ring[idx],
                    SCHED_TRACE_AI_RECORD_SIZE);
             out += SCHED_TRACE_AI_RECORD_SIZE;
@@ -382,12 +458,8 @@ size_t sched_trace_ai_dump_to_buf(uint8_t *buf, size_t buflen)
  * Lives here (vs in shell_sys.c) so the file-write dependency on
  * LittleFS / VFS is co-located with the trace API rather than
  * scattered across the shell. Called from shell_sys.c via extern.
- */
-
-#include "vfs.h"
-#include "littlefs_slm.h"
-#include "shell.h"
-#include "shell_internal.h"
+ * (VFS / LittleFS / shell headers are pulled in at the top of this
+ * translation unit.) */
 
 struct aitrace_dump_ctx {
     struct lfs_mount *mnt;

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -11,6 +11,9 @@
 #include "sched.h"
 #include "sched_policy.h"
 #include "sched_trace.h"
+#ifdef CONFIG_AI_SCHEDULER
+#include "sched_trace_ai.h"
+#endif
 #include "task.h"
 #include "uart.h"
 #include "debug.h"
@@ -1231,6 +1234,16 @@ void scheduler_add_task(struct task *task)
         target_cpu = task->cpu_affinity;
     } else {
         target_cpu = active_policy->assign_cpu(task);
+
+#ifdef CONFIG_AI_SCHEDULER
+        /* Record the policy's decision before the S5 override below
+         * potentially modifies it — the trace is meant for training
+         * the policy that just made the choice, not the
+         * post-override target. The S5 outcome is recoverable from
+         * later events anyway (the next decision's state vector
+         * reflects the override). */
+        sched_trace_ai_record_decision(task, active_policy->name, target_cpu);
+#endif
 
         /* S5 proactive load-balance override. Only for unpinned tasks,
          * never to isolated CPUs, never when the target is lightly

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -705,6 +705,13 @@ void task_exit(void)
         extern void sched_ai_record_completion(struct task *task);
         sched_ai_record_completion(task);
     }
+    /* Decision-trace completion record (#880, separate from the
+     * sched_ai utilization counter above). No-op when the AI trace
+     * is not active. */
+    {
+        extern void sched_trace_ai_record_completion(struct task *task);
+        sched_trace_ai_record_completion(task);
+    }
 #endif
 
     /* Atomically set TASK_TERMINATED and dequeue under rq_lock.

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -16,6 +16,9 @@
 #include "vmm.h"
 #include "elf.h"
 #endif
+#ifdef CONFIG_AI_SCHEDULER
+#include "sched_trace_ai.h"
+#endif
 #include <stddef.h>
 
 /* Task table - NC on Pi 5, BSS fallback otherwise */
@@ -708,10 +711,7 @@ void task_exit(void)
     /* Decision-trace completion record (#880, separate from the
      * sched_ai utilization counter above). No-op when the AI trace
      * is not active. */
-    {
-        extern void sched_trace_ai_record_completion(struct task *task);
-        sched_trace_ai_record_completion(task);
-    }
+    sched_trace_ai_record_completion(task);
 #endif
 
     /* Atomically set TASK_TERMINATED and dequeue under rq_lock.

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -1258,19 +1258,9 @@ static int l_sched_stats(lua_State *L) {
 }
 
 #if defined(CONFIG_AI_SCHEDULER)
-/* AI decision-trace Lua bindings (#880, sub-ticket of #61). The C
- * implementations live in kernel/sched/ai/sched_trace_ai.c; forward-
- * declared here so we don't need to pull sched_trace_ai.h into the
- * lua include surface. */
-extern void sched_trace_ai_start(void);
-extern void sched_trace_ai_stop(void);
-extern void sched_trace_ai_clear(void);
-extern bool sched_trace_ai_is_enabled(void);
-extern uint32_t sched_trace_ai_records_used(void);
-extern uint64_t sched_trace_ai_total_events(void);
-extern uint64_t sched_trace_ai_dropped(void);
-extern size_t sched_trace_ai_dump_size(void);
-extern size_t sched_trace_ai_dump_to_path(const char *path);
+/* AI decision-trace Lua bindings (#880, sub-ticket of #61). C
+ * implementations live in kernel/sched/ai/sched_trace_ai.c. */
+#include "sched_trace_ai.h"
 
 /**
  * slm.sched_aitrace_start() - Begin capturing AI scheduler decisions

--- a/kernel/src/lua_slm.c
+++ b/kernel/src/lua_slm.c
@@ -1257,6 +1257,86 @@ static int l_sched_stats(lua_State *L) {
     return 1;
 }
 
+#if defined(CONFIG_AI_SCHEDULER)
+/* AI decision-trace Lua bindings (#880, sub-ticket of #61). The C
+ * implementations live in kernel/sched/ai/sched_trace_ai.c; forward-
+ * declared here so we don't need to pull sched_trace_ai.h into the
+ * lua include surface. */
+extern void sched_trace_ai_start(void);
+extern void sched_trace_ai_stop(void);
+extern void sched_trace_ai_clear(void);
+extern bool sched_trace_ai_is_enabled(void);
+extern uint32_t sched_trace_ai_records_used(void);
+extern uint64_t sched_trace_ai_total_events(void);
+extern uint64_t sched_trace_ai_dropped(void);
+extern size_t sched_trace_ai_dump_size(void);
+extern size_t sched_trace_ai_dump_to_path(const char *path);
+
+/**
+ * slm.sched_aitrace_start() - Begin capturing AI scheduler decisions
+ * Returns nothing
+ */
+static int l_sched_aitrace_start(lua_State *L) {
+    (void)L;
+    sched_trace_ai_start();
+    return 0;
+}
+
+/**
+ * slm.sched_aitrace_stop() - Stop capturing
+ */
+static int l_sched_aitrace_stop(lua_State *L) {
+    (void)L;
+    sched_trace_ai_stop();
+    return 0;
+}
+
+/**
+ * slm.sched_aitrace_clear() - Drop all recorded events
+ */
+static int l_sched_aitrace_clear(lua_State *L) {
+    (void)L;
+    sched_trace_ai_clear();
+    return 0;
+}
+
+/**
+ * slm.sched_aitrace_dump(path) - Write the trace to a VFS path
+ * Returns bytes written on success, nil on failure.
+ */
+static int l_sched_aitrace_dump(lua_State *L) {
+    if (!L) return 0;
+    const char *path = luaL_checkstring(L, 1);
+    size_t n = sched_trace_ai_dump_to_path(path);
+    if (n == 0) {
+        lua_pushnil(L);
+    } else {
+        lua_pushinteger(L, (lua_Integer)n);
+    }
+    return 1;
+}
+
+/**
+ * slm.sched_aitrace_stats() - Return capture stats
+ * Returns table: {enabled, used, total, dropped, dump_size}
+ */
+static int l_sched_aitrace_stats(lua_State *L) {
+    if (!L) return 0;
+    lua_createtable(L, 0, 5);
+    lua_pushboolean(L, sched_trace_ai_is_enabled());
+    lua_setfield(L, -2, "enabled");
+    lua_pushinteger(L, (lua_Integer)sched_trace_ai_records_used());
+    lua_setfield(L, -2, "used");
+    lua_pushinteger(L, (lua_Integer)sched_trace_ai_total_events());
+    lua_setfield(L, -2, "total");
+    lua_pushinteger(L, (lua_Integer)sched_trace_ai_dropped());
+    lua_setfield(L, -2, "dropped");
+    lua_pushinteger(L, (lua_Integer)sched_trace_ai_dump_size());
+    lua_setfield(L, -2, "dump_size");
+    return 1;
+}
+#endif /* CONFIG_AI_SCHEDULER */
+
 /**
  * slm.sched_set_policy(name) - Switch scheduler policy by name
  * Returns true on success, false on failure (unknown policy name)
@@ -4529,6 +4609,11 @@ static const luaL_Reg slm_lib_safe[] = {
     {"sched_policy_list", l_sched_policy_list},
     {"ai_sched_stats", l_ai_sched_stats},
     {"ai_sched_decision", l_ai_sched_decision},
+#if defined(CONFIG_AI_SCHEDULER)
+    /* AI decision-trace ring (#880, sub-ticket of #61). Mutators in
+     * admin lib below; this entry exposes the read-only stats getter. */
+    {"sched_aitrace_stats", l_sched_aitrace_stats},
+#endif
     /* Admin & telemetry suite (M1) */
     {"sched_decision_rate", l_sched_decision_rate},
     {"latency_histogram", l_latency_histogram},
@@ -4606,6 +4691,15 @@ static const luaL_Reg slm_lib_admin[] = {
     {"infer_stress", l_infer_stress},
     /* Scheduler / task mutation */
     {"sched_set_policy", l_sched_set_policy},
+#if defined(CONFIG_AI_SCHEDULER)
+    /* AI decision-trace control (#880, sub-ticket of #61). Mutators
+     * live in the admin lib because start/stop/clear alter recording
+     * state. The stats getter is in the read-only lib above. */
+    {"sched_aitrace_start", l_sched_aitrace_start},
+    {"sched_aitrace_stop", l_sched_aitrace_stop},
+    {"sched_aitrace_clear", l_sched_aitrace_clear},
+    {"sched_aitrace_dump", l_sched_aitrace_dump},
+#endif
     {"task_migrate", l_task_migrate},
     {"task_create", l_task_create},
     {"task_kill", l_task_kill},

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -7784,8 +7784,23 @@ int cmd_sched(int argc, char *argv[])
         return 0;
     }
 
+#if defined(CONFIG_AI_SCHEDULER)
+    if (strcmp(argv[1], "aitrace") == 0) {
+        /* AI-decision trace control (#880). Distinct from `sched trace`,
+         * which captures 16-byte cross-CPU dispatch events (#195). The
+         * AI trace records full 108-dim state vectors + chosen actions
+         * for sibling-repo fine-tuning. */
+        extern int sched_aitrace_cli(int argc, char *argv[]);
+        return sched_aitrace_cli(argc, argv);
+    }
+#endif
+
     shell_puts("Usage: sched [policy [<name>] | stats | compare | "
-              "trace [start|stop|clear|per-cpu]]\r\n");
+              "trace [start|stop|clear|per-cpu]"
+#if defined(CONFIG_AI_SCHEDULER)
+              " | aitrace [start|stop|stats|clear|dump <path>]"
+#endif
+              "]\r\n");
     return 1;
 }
 

--- a/kernel/tests/test_scheduler.c
+++ b/kernel/tests/test_scheduler.c
@@ -5009,6 +5009,116 @@ static void test_bench_workload_run_heuristic_mixed(void)
 }
 #endif /* ENABLE_BOOT_TESTS */
 
+/* ============================================================================
+ * AI-decision trace tests (#880, sub-ticket of #61)
+ *
+ * Pin the wire-format constants the sibling-repo ingester depends on,
+ * and round-trip start→record→dump→parse so future layout changes
+ * surface here before the ingester silently mis-parses.
+ * ============================================================================ */
+
+#include "sched_trace_ai.h"
+#include "string.h"
+
+static void test_aitrace_format_constants(void)
+{
+    TEST_ASSERT_EQUAL_UINT32(0x53544C53u, SCHED_TRACE_AI_MAGIC);
+    TEST_ASSERT_EQUAL_UINT32(1u, SCHED_TRACE_AI_VERSION);
+    TEST_ASSERT_EQUAL_UINT32(480u, SCHED_TRACE_AI_RECORD_SIZE);
+    TEST_ASSERT_EQUAL_UINT32(108u, SCHED_TRACE_AI_STATE_DIM);
+    /* Compile-time _Static_assert in the header already enforces
+     * sizeof(record) == 480 and sizeof(header) == 32. The runtime
+     * checks below are belt-and-suspenders against a struct-layout
+     * regression that somehow slips through. */
+    TEST_ASSERT_EQUAL_INT(480, (int)sizeof(struct sched_trace_ai_record));
+    TEST_ASSERT_EQUAL_INT(32, (int)sizeof(struct sched_trace_ai_file_header));
+}
+
+static void test_aitrace_start_stop_idempotent(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, sched_trace_ai_init());
+    TEST_ASSERT_EQUAL_INT(0, sched_trace_ai_init());
+
+    sched_trace_ai_stop();
+    TEST_ASSERT_FALSE(sched_trace_ai_is_enabled());
+
+    sched_trace_ai_start();
+    TEST_ASSERT_TRUE(sched_trace_ai_is_enabled());
+
+    sched_trace_ai_stop();
+    TEST_ASSERT_FALSE(sched_trace_ai_is_enabled());
+
+    /* Re-start clears prior records. */
+    sched_trace_ai_start();
+    TEST_ASSERT_EQUAL_UINT64(0u, (uint64_t)sched_trace_ai_total_events());
+    sched_trace_ai_stop();
+}
+
+static void test_aitrace_disabled_record_is_noop(void)
+{
+    sched_trace_ai_init();
+    sched_trace_ai_stop();
+    sched_trace_ai_clear();
+    TEST_ASSERT_EQUAL_UINT64(0u, (uint64_t)sched_trace_ai_total_events());
+
+    sched_trace_ai_record_decision(NULL, "test", 0);
+    sched_trace_ai_record_completion(NULL);
+    TEST_ASSERT_EQUAL_UINT64(0u, (uint64_t)sched_trace_ai_total_events());
+}
+
+static void test_aitrace_dump_roundtrip(void)
+{
+    sched_trace_ai_init();
+    sched_trace_ai_clear();
+    sched_trace_ai_start();
+
+    struct task *self = task_current();
+    TEST_ASSERT_NOT_NULL(self);
+    for (int i = 0; i < 3; i++) {
+        sched_trace_ai_record_decision(self, "heuristic", (uint32_t)i);
+    }
+    sched_trace_ai_stop();
+
+    TEST_ASSERT_TRUE(sched_trace_ai_total_events() >= 3);
+    TEST_ASSERT_TRUE(sched_trace_ai_records_used() >= 3);
+
+    size_t needed = sched_trace_ai_dump_size();
+    TEST_ASSERT_TRUE(needed >= sizeof(struct sched_trace_ai_file_header)
+                              + 3u * SCHED_TRACE_AI_RECORD_SIZE);
+
+    static uint8_t dump_buf[16 * 1024];
+    TEST_ASSERT_TRUE(needed <= sizeof(dump_buf));
+    size_t written = sched_trace_ai_dump_to_buf(dump_buf, sizeof(dump_buf));
+    TEST_ASSERT_EQUAL_INT((int)needed, (int)written);
+
+    struct sched_trace_ai_file_header hdr;
+    memcpy(&hdr, dump_buf, sizeof(hdr));
+    TEST_ASSERT_EQUAL_UINT32(SCHED_TRACE_AI_MAGIC, hdr.magic);
+    TEST_ASSERT_EQUAL_UINT32(SCHED_TRACE_AI_VERSION, hdr.version);
+    TEST_ASSERT_EQUAL_UINT32(SCHED_TRACE_AI_RECORD_SIZE, hdr.record_size);
+    TEST_ASSERT_TRUE(hdr.record_count >= 3u);
+    TEST_ASSERT_EQUAL_UINT32(SCHED_TRACE_AI_STATE_DIM, hdr.state_dim);
+
+    /* First DECISION record after the header — kind + policy_name. */
+    struct sched_trace_ai_record r0;
+    memcpy(&r0, dump_buf + sizeof(hdr), sizeof(r0));
+    TEST_ASSERT_EQUAL_UINT8(SCHED_TRACE_AI_KIND_DECISION, r0.kind);
+    TEST_ASSERT_EQUAL_STRING("heuristic", r0.u.decision.policy_name);
+}
+
+static void test_aitrace_dump_short_buffer_rejected(void)
+{
+    sched_trace_ai_init();
+    sched_trace_ai_clear();
+    sched_trace_ai_start();
+    struct task *self = task_current();
+    sched_trace_ai_record_decision(self, "heuristic", 0);
+    sched_trace_ai_stop();
+
+    uint8_t tiny[16];
+    size_t n = sched_trace_ai_dump_to_buf(tiny, sizeof(tiny));
+    TEST_ASSERT_EQUAL_INT(0, (int)n);
+}
 #endif /* CONFIG_AI_SCHEDULER */
 
 /* ============================================================================
@@ -5287,6 +5397,13 @@ int test_suite_scheduler(void)
 #if defined(ENABLE_BOOT_TESTS)
     RUN_TEST(test_bench_workload_run_heuristic_mixed);
 #endif
+
+    /* #880 — AI-decision trace ring (kernel/sched/ai/sched_trace_ai.c). */
+    RUN_TEST(test_aitrace_format_constants);
+    RUN_TEST(test_aitrace_start_stop_idempotent);
+    RUN_TEST(test_aitrace_disabled_record_is_noop);
+    RUN_TEST(test_aitrace_dump_roundtrip);
+    RUN_TEST(test_aitrace_dump_short_buffer_rejected);
 #endif
 
     return UnityEnd();


### PR DESCRIPTION
## Summary

Closes [#880](https://github.com/SLM-OS/SLM-Operating-System/issues/880) (sub-ticket of [#61](https://github.com/SLM-OS/SLM-Operating-System/issues/61)). Adds a per-CPU 480-byte fixed-size ring buffer that captures `(state, action)` pairs at every `scheduler_add_task` plus per-task `(completion, outcome)` records at `task_exit`. The sibling-repo fine-tune (#879 / 61c) reads these dumps.

## What changed

- **New header:** `kernel/include/sched_trace_ai.h`
- **New impl:** `kernel/sched/ai/sched_trace_ai.c`
- **New docs:** `docs/sched-trace-format.md` — pins the wire format
- **Hooks (CONFIG_AI_SCHEDULER-gated):** `scheduler_add_task` and `task_exit`
- **Shell:** `sched aitrace [start|stop|stats|clear|dump <path>]`
- **Lua:** `slm.sched_aitrace_{start,stop,clear,dump,stats}`
- **Tests:** 5 new in `kernel/tests/test_scheduler.c`, all pass on QEMU

The new `aitrace` verb is **distinct** from the existing `sched trace ...` (issue [#195](https://github.com/SLM-OS/SLM-Operating-System/issues/195)'s 16-byte cross-CPU context-switch tracer) so neither tracer's UI breaks the other.

## Architecture

- **Per-CPU rings, no shared lock or fetch-add on the hot path** — mirrors the `sched_diag` NC-counter pattern documented in `kernel/CLAUDE.md` §"Cache Maintenance". Cross-CPU coherency via writer-side `cache_clean_range` + reader-side `cache_invalidate_range` per buffer.
- **Ring sized ~1.92 MB** (4096 slots × 480 B), PMM-allocated at `sched_ai_init` so the BSS footprint of AI_SCHED builds is unchanged when the trace is off.
- **DECISION variant** (480 B): 16-B header + policy_name + `(core, prio, preempt)` + full FP32 108-dim state vector (via `ai_extract_state`).
- **COMPLETION variant** (480 B): 16-B header + `completion_ns / deadline_ns / ran_on_cpu / deadline_met`, zero-padded.

## Hook policy

`scheduler_add_task` records DECISION **right after `active_policy->assign_cpu` returns, before the S5 load-balance override** — the trace is for training the policy that just chose; the override is recoverable from later state.

`task_exit` records COMPLETION alongside the existing `sched_ai_record_completion` utilization counter (independent code paths; both run unconditionally under AI_SCHED).

## Test plan

- [x] `make test AI_SCHED=ON` — clean; 5/5 new aitrace tests pass, same 8 pre-existing failures as main
- [x] `make kernel PLATFORM=RASPI5 AI_SCHED=ON` — clean
- [x] Wire-format pinned in `docs/sched-trace-format.md` with explicit byte offsets per #880's acceptance criteria
- [ ] Hardware overhead measurement (<5% target) — deferred to [#884 (61d)](https://github.com/SLM-OS/SLM-Operating-System/issues/884) once the comparison-matrix workstream can coordinate hardware time on pi-5-2 / jetson-nano-1 with @johnjezl

## Out of scope (per #880's "Out of scope")

- Sibling-repo trace ingester + fine-tune → [#879](https://github.com/SLM-OS/SLM-Operating-System/issues/879) (61c)
- The bench harness that drives meaningful captures → [#882](https://github.com/SLM-OS/SLM-Operating-System/issues/882) (61a, PR #928)

## Notes for #879

The sibling-repo ingester should parse exactly the byte layout in `docs/sched-trace-format.md` v1. Header magic is `0x53544C53` (ASCII `'SLTS'`). Record kinds: `1` = DECISION (state + action), `2` = COMPLETION (outcome). DECISION + COMPLETION records correlate via `task_id`.

Refs #61 (parent), #880 (this sub-ticket), #195 (existing trace), #848 (framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)