### PR TITLE
x86-64: three independent fixes to unbreak the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1031,7 +1031,7 @@ endif
 .PHONY: runtime
 runtime:
 	@echo "Building runtime... (cargo features: $(if $(CARGO_FEATURES),$(CARGO_FEATURES),none))"
-	cd runtime && SLM_DEFAULT_EVICTION_POLICY=$(EVICTION_DEFAULT_POLICY) $(if $(RUST_RUSTFLAGS),RUSTFLAGS="$(RUST_RUSTFLAGS)") cargo build $(RUST_TARGET_FLAG) $(if $(filter Release,$(BUILD_TYPE)),--release,) $(CARGO_FEATURES_FLAG)
+	cd runtime && SLM_DEFAULT_EVICTION_POLICY=$(EVICTION_DEFAULT_POLICY) $(if $(RUST_RUSTFLAGS),RUSTFLAGS="$$RUSTFLAGS $(RUST_RUSTFLAGS)") cargo build $(RUST_TARGET_FLAG) $(if $(filter Release,$(BUILD_TYPE)),--release,) $(CARGO_FEATURES_FLAG)
 
 .PHONY: runtime-clean
 runtime-clean:

--- a/Makefile
+++ b/Makefile
@@ -1005,14 +1005,33 @@ test-rpc:
 # Rust target selection based on platform
 ifeq ($(PLATFORM),X86_64)
     RUST_TARGET_FLAG := --target x86_64-unknown-none
+    # Issue #141 workaround: fat LTO (the `lto = true` in Cargo.toml's
+    # release profile) trips the rustc-LLVM "do not know how to soften
+    # this operator's operand!" legalizer crash on `x86_64-unknown-none`
+    # somewhere inside the slm forward path's f16 code. Thin LTO does
+    # not exercise the cross-function legalisation site that triggers
+    # the crash and still recovers most of fat LTO's size win.
+    #
+    # Scope: x86_64-unknown-none ONLY. ARM64 targets keep fat LTO; the
+    # ARM64 legalizer doesn't have the soften lowering gap that x86-64
+    # does. `mathf::sqrtf` / `mathf::tanhf` in runtime/src/inference/
+    # mathf.rs are the call-site workarounds for two specific libm
+    # functions that crash even under thin LTO; the thin-LTO switch
+    # here covers every other soften site the slm feature exposes.
+    #
+    # Revisit once: (a) the upstream LLVM legalizer fix lands, OR
+    # (b) libm 0.2 splits its f16 paths, OR (c) Rust's
+    # `x86_64-unknown-none` target gains a working f16 ABI.
+    RUST_RUSTFLAGS := -C lto=thin
 else
     RUST_TARGET_FLAG :=
+    RUST_RUSTFLAGS :=
 endif
 
 .PHONY: runtime
 runtime:
 	@echo "Building runtime... (cargo features: $(if $(CARGO_FEATURES),$(CARGO_FEATURES),none))"
-	cd runtime && SLM_DEFAULT_EVICTION_POLICY=$(EVICTION_DEFAULT_POLICY) cargo build $(RUST_TARGET_FLAG) $(if $(filter Release,$(BUILD_TYPE)),--release,) $(CARGO_FEATURES_FLAG)
+	cd runtime && SLM_DEFAULT_EVICTION_POLICY=$(EVICTION_DEFAULT_POLICY) $(if $(RUST_RUSTFLAGS),RUSTFLAGS="$(RUST_RUSTFLAGS)") cargo build $(RUST_TARGET_FLAG) $(if $(filter Release,$(BUILD_TYPE)),--release,) $(CARGO_FEATURES_FLAG)
 
 .PHONY: runtime-clean
 runtime-clean:

--- a/kernel/ai_accel/hailo/hailo_fw.S
+++ b/kernel/ai_accel/hailo/hailo_fw.S
@@ -24,12 +24,19 @@
 
     .global hailo_fw_start
     .global hailo_fw_end
-    /* .align 6 = 64 B = one ARM64 cache line. Keeps the blob's
-     * start at a cache-line boundary so any future code path that
-     * DMAs directly from the embedded image (instead of copying
-     * first) doesn't straddle a line. Today's path goes through
-     * BAR4 MMIO writes where alignment is only required at 4 B. */
-    .align 6
+    /* 64 B = one ARM64 cache line. Keeps the blob's start at a
+     * cache-line boundary so any future code path that DMAs directly
+     * from the embedded image (instead of copying first) doesn't
+     * straddle a line. Today's path goes through BAR4 MMIO writes
+     * where alignment is only required at 4 B.
+     *
+     * `.balign` (literal-byte align) instead of `.align` because GAS
+     * resolves `.align N` differently per arch: ARM64 takes N as the
+     * power-of-2 exponent (so `.align 6` = 64 B), x86 takes N as a
+     * literal byte count and rejects non-power-of-2 values (so
+     * `.align 6` = "alignment not a power of 2"). `.balign` is always
+     * literal-byte regardless of arch. */
+    .balign 64
 hailo_fw_start:
     .incbin xstr(HAILO_FW_BLOB_PATH)
 hailo_fw_end:

--- a/kernel/sched/task.c
+++ b/kernel/sched/task.c
@@ -898,6 +898,7 @@ void task_destroy(struct task *task)
 #else
     (void)user_l1_pa;
     (void)user_stack_phys;
+    (void)user_asid;
 #endif
 
     /* Note: DEBUG_PRINT removed here to avoid output interleaving issues


### PR DESCRIPTION
## Summary

x86-64 has been red on three independent, pre-existing issues that accumulated across recent merges. None of them were caused by any single PR — they're three different mistakes that each broke x86-64 without affecting ARM64. This PR fixes all three.

### Fix 1 — runtime: thin LTO on x86-64 (workaround for #141)

`lto = true` in `runtime/Cargo.toml`'s release profile (= fat LTO) trips `rustc-LLVM ERROR: Do not know how to soften this operator's operand!` on `x86_64-unknown-none`. Bisected: \`lto=off\` and \`lto=thin\` both succeed; only \`lto=fat\` crashes. The soften site is somewhere inside the slm forward path's f16 code that only the fat-LTO cross-function legalisation pass reaches.

Existing `mathf::sqrtf` / `mathf::tanhf` in `runtime/src/inference/mathf.rs` cover two specific libm sites the workaround was originally built for; this is a different site the workarounds don't catch.

**Fix:** per-platform `RUST_RUSTFLAGS := -C lto=thin` in the Makefile, scoped to `PLATFORM=X86_64`. ARM64 keeps fat LTO unchanged. Long Makefile comment documents the three conditions under which the workaround can be retired (upstream LLVM fix, libm 0.2 f16 split, or working f16 ABI on \`x86_64-unknown-none\`).

### Fix 2 — kernel/sched/task.c: missing `(void)user_asid` on x86-64

PR #738 (per-task ASID tagging) added `uint16_t user_asid = task->user_asid;` to `task_destroy` but only used it inside the `#if !defined(PLATFORM_X86_64)` branch. The `#else` branch already had `(void)user_l1_pa;` and `(void)user_stack_phys;` for the same reason but missed `user_asid`. Pre-existing -Werror=unused-variable on x86-64.

**Fix:** one-line `(void)user_asid;` in the x86-64 `#else` branch matching the pattern.

### Fix 3 — kernel/ai_accel/hailo/hailo_fw.S: `.align 6` is arch-ambiguous

GAS resolves `.align N` differently per arch:
- ARM64: N is the power-of-2 exponent (so `.align 6` = 64 B)
- x86: N is a literal byte count and must be a power of 2 (so `.align 6` errors out with \"alignment not a power of 2\")

The file has an `#if defined(__x86_64__)` branch in the trailing `.note.GNU-stack` directive, so it was intended to compile on x86-64, but the `.align 6` at `hailo_fw_start` never got the arch-portable treatment.

**Fix:** `.align 6` → `.balign 64`. `.balign` (binary-byte align) is always literal-byte regardless of arch, so 64 B on both. Comment explains the rationale.

## Test plan

- [x] `make kernel PLATFORM=X86_64` — clean (was failing on all three issues)
- [x] `make kernel PLATFORM=QEMU_VIRT` — clean
- [x] `make kernel PLATFORM=RASPI5` — clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO` — clean
- [x] `make test` — all 620+ tests pass

x86-64 is now part of the green tier alongside the three ARM64 targets for the first time in this audit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)