### PR TITLE
build: flock per-dir to prevent concurrent-build clobber (closes #934)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,19 @@ endif
 BUILD_DIR := build
 KERNEL_BUILD_DIR := $(BUILD_DIR)/kernel
 KERNEL_TEST_BUILD_DIR := $(BUILD_DIR)/kernel-test
+
+# Per-build-dir lock files (#934). Two `make kernel PLATFORM=X` invocations
+# against different platforms used to silently clobber each other in
+# $(KERNEL_BUILD_DIR); the resulting ELF was whichever build finished
+# last, regardless of which target the user thought they were building.
+# Wrapping the build targets in `flock` on these files makes concurrent
+# invocations serialise instead of race. Lock files live in $(BUILD_DIR)
+# (parent of the build dirs) so `kernel-clean` and friends don't delete
+# them mid-wait.
+KERNEL_BUILD_LOCK         := $(BUILD_DIR)/.kernel.lock
+KERNEL_TEST_BUILD_LOCK    := $(BUILD_DIR)/.kernel-test.lock
+KERNEL_KEXEC_BUILD_LOCK   := $(BUILD_DIR)/.kernel-kexec.lock
+KERNEL_BZIMAGE_BUILD_LOCK := $(BUILD_DIR)/.kernel-bzimage.lock
 ifeq ($(PLATFORM),X86_64)
     RUNTIME_BUILD_DIR := runtime/target/x86_64-unknown-none
 else
@@ -255,7 +268,13 @@ kernel-config-check:
 	fi
 
 .PHONY: kernel
-kernel: check-build-dir runtime kernel-config-check $(KERNEL_BUILD_DIR)/Makefile
+kernel:
+	@mkdir -p $(BUILD_DIR)
+	@flock --verbose $(KERNEL_BUILD_LOCK) \
+	    $(MAKE) --no-print-directory _kernel-build PLATFORM=$(PLATFORM)
+
+.PHONY: _kernel-build
+_kernel-build: check-build-dir runtime kernel-config-check $(KERNEL_BUILD_DIR)/Makefile
 	@echo "Building kernel..."
 	$(CMAKE) --build $(KERNEL_BUILD_DIR)
 
@@ -525,10 +544,16 @@ KERNEL_KEXEC_BUILD_DIR := $(BUILD_DIR)/kernel-kexec
 KERNEL_KEXEC_ELF := $(KERNEL_KEXEC_BUILD_DIR)/slmos.elf
 
 .PHONY: kernel-kexec
-kernel-kexec: runtime kernel-kexec-config-check $(KERNEL_KEXEC_BUILD_DIR)/Makefile
+kernel-kexec:
 ifneq ($(PLATFORM),X86_64)
 	@echo "kernel-kexec requires PLATFORM=X86_64 (got $(PLATFORM))"; exit 1
 endif
+	@mkdir -p $(BUILD_DIR)
+	@flock --verbose $(KERNEL_KEXEC_BUILD_LOCK) \
+	    $(MAKE) --no-print-directory _kernel-kexec-build PLATFORM=$(PLATFORM)
+
+.PHONY: _kernel-kexec-build
+_kernel-kexec-build: runtime kernel-kexec-config-check $(KERNEL_KEXEC_BUILD_DIR)/Makefile
 	@echo "Building kernel (kexec variant, link address 0x20000000)..."
 	$(CMAKE) --build $(KERNEL_KEXEC_BUILD_DIR)
 	@echo "kexec ELF: $(KERNEL_KEXEC_ELF)"
@@ -651,10 +676,16 @@ KERNEL_BZIMAGE_ELF       := $(KERNEL_BZIMAGE_BUILD_DIR)/slmos.elf
 KERNEL_BZIMAGE           := $(KERNEL_BZIMAGE_BUILD_DIR)/slmos.bzimage
 
 .PHONY: kernel-bzimage
-kernel-bzimage: runtime $(KERNEL_BZIMAGE_BUILD_DIR)/Makefile
+kernel-bzimage:
 ifneq ($(PLATFORM),X86_64)
 	@echo "kernel-bzimage requires PLATFORM=X86_64 (got $(PLATFORM))"; exit 1
 endif
+	@mkdir -p $(BUILD_DIR)
+	@flock --verbose $(KERNEL_BZIMAGE_BUILD_LOCK) \
+	    $(MAKE) --no-print-directory _kernel-bzimage-build PLATFORM=$(PLATFORM)
+
+.PHONY: _kernel-bzimage-build
+_kernel-bzimage-build: runtime $(KERNEL_BZIMAGE_BUILD_DIR)/Makefile
 	@echo "Building kernel (bzImage variant)..."
 	$(CMAKE) --build $(KERNEL_BZIMAGE_BUILD_DIR)
 	@echo "Wrapping ELF as Linux bzImage..."
@@ -1269,7 +1300,13 @@ QEMU_GUARD := $(shell if command -v systemd-run >/dev/null 2>&1 && systemd-run -
 
 # Build kernel with ENABLE_BOOT_TESTS (runs tests at boot and exits)
 .PHONY: kernel-test
-kernel-test: check-kernel-test-build-dir runtime kernel-test-config-check $(KERNEL_TEST_BUILD_DIR)/Makefile
+kernel-test:
+	@mkdir -p $(BUILD_DIR)
+	@flock --verbose $(KERNEL_TEST_BUILD_LOCK) \
+	    $(MAKE) --no-print-directory _kernel-test-build PLATFORM=$(PLATFORM)
+
+.PHONY: _kernel-test-build
+_kernel-test-build: check-kernel-test-build-dir runtime kernel-test-config-check $(KERNEL_TEST_BUILD_DIR)/Makefile
 	@echo "Building test kernel..."
 	$(CMAKE) --build $(KERNEL_TEST_BUILD_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ kernel-config-check:
 kernel:
 	@mkdir -p $(BUILD_DIR)
 	@flock --verbose $(KERNEL_BUILD_LOCK) \
-	    $(MAKE) --no-print-directory _kernel-build PLATFORM=$(PLATFORM)
+	    $(MAKE) --no-print-directory _kernel-build
 
 .PHONY: _kernel-build
 _kernel-build: check-build-dir runtime kernel-config-check $(KERNEL_BUILD_DIR)/Makefile
@@ -550,7 +550,7 @@ ifneq ($(PLATFORM),X86_64)
 endif
 	@mkdir -p $(BUILD_DIR)
 	@flock --verbose $(KERNEL_KEXEC_BUILD_LOCK) \
-	    $(MAKE) --no-print-directory _kernel-kexec-build PLATFORM=$(PLATFORM)
+	    $(MAKE) --no-print-directory _kernel-kexec-build
 
 .PHONY: _kernel-kexec-build
 _kernel-kexec-build: runtime kernel-kexec-config-check $(KERNEL_KEXEC_BUILD_DIR)/Makefile
@@ -682,7 +682,7 @@ ifneq ($(PLATFORM),X86_64)
 endif
 	@mkdir -p $(BUILD_DIR)
 	@flock --verbose $(KERNEL_BZIMAGE_BUILD_LOCK) \
-	    $(MAKE) --no-print-directory _kernel-bzimage-build PLATFORM=$(PLATFORM)
+	    $(MAKE) --no-print-directory _kernel-bzimage-build
 
 .PHONY: _kernel-bzimage-build
 _kernel-bzimage-build: runtime $(KERNEL_BZIMAGE_BUILD_DIR)/Makefile
@@ -1303,7 +1303,7 @@ QEMU_GUARD := $(shell if command -v systemd-run >/dev/null 2>&1 && systemd-run -
 kernel-test:
 	@mkdir -p $(BUILD_DIR)
 	@flock --verbose $(KERNEL_TEST_BUILD_LOCK) \
-	    $(MAKE) --no-print-directory _kernel-test-build PLATFORM=$(PLATFORM)
+	    $(MAKE) --no-print-directory _kernel-test-build
 
 .PHONY: _kernel-test-build
 _kernel-test-build: check-kernel-test-build-dir runtime kernel-test-config-check $(KERNEL_TEST_BUILD_DIR)/Makefile


### PR DESCRIPTION
## Summary

- Wrap `kernel`, `kernel-test`, `kernel-kexec`, `kernel-bzimage` in `flock` on per-build-dir lock files.
- Concurrent invocations against the same build dir now block on the lock instead of racing through `kernel-config-check` and clobbering each other's CMake state.
- Per-dir locks keep unrelated builds (e.g. `kernel` + `kernel-test`) parallel-safe, and `make -j N` still parallelises within a single invocation.

Closes #934.

## Verification

| Scenario | Before | After |
|---|---|---|
| `make kernel PLATFORM=X` (single) | works | works (lock acquired in 3 µs) |
| `make kernel PLATFORM=A &` + `make kernel PLATFORM=B &` from clean | race; final ELF mixed/wrong | second waits, then builds cleanly |
| `make -j8 kernel` | works | works (sub-make inherits jobserver, real 1m42s vs user 1m24s — same parallelism) |
| `make test` | works | works (all suites pass) |

Race-test transcript with the change in place:

```
make kernel-clean
(make kernel PLATFORM=RASPI5 …) &
(make kernel PLATFORM=JETSON_ORIN_NANO …) &
wait
# Jetson:  flock: getting lock took 0.000003 seconds
# Pi 5:    flock: getting lock took 103.324537 seconds
# Final ELF entry point: 0x80000  (Pi 5 — last writer wins, deterministically)
```

Before this change, the same test produced an ELF whose entry point depended on race order — sometimes 0x80000000 (Jetson) with a mix of Pi 5 objects, sometimes vice versa, sometimes a link failure mid-race.

## Why flock and not per-platform build dirs

Option (1) from #934 (per-platform build dirs like `build/kernel-raspi5/`) is cleaner long-term but would require touching every script/doc that references `build/kernel/slmos.elf` or `build/kernel/slmos.bin`. Option (2) (this PR) is the lowest-disruption fix: zero changes outside the Makefile, the existing `kernel-config-check` continues to handle per-platform reconfig, and the same `build/kernel/slmos.bin` path keeps working for every downstream consumer (`labctl sdwire_update`, `scripts/capture-hailo-trace.sh`, etc.). If we later decide to split the dirs anyway, the locks become redundant but harmless.

## Test plan

- [x] Build for QEMU_VIRT, RASPI5, JETSON_ORIN_NANO in series — each succeeds, the per-platform reconfig prints normally.
- [x] Concurrent `make kernel PLATFORM=A &` + `make kernel PLATFORM=B &` from clean build dir — second blocks on flock; both finish 0; final ELF matches whichever finished last.
- [x] `make -j8 kernel` — sub-make parallelises, no double-build.
- [x] `make test` — passes (QEMU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)