### PR TITLE
scripts/jetson-deploy-retry: require shell-prompt match for PASS (closes #935)

### DIFF
--- a/scripts/jetson-deploy-retry.sh
+++ b/scripts/jetson-deploy-retry.sh
@@ -149,9 +149,6 @@ log "  test:     $([[ "$SKIP_TEST" == "1" ]] && echo 'skip (shell-only)' || echo
 log "  started:  $(date -Is)"
 log ""
 
-# attempt_deploy — one full deploy cycle. Returns 0 on PASS, 1 on FAIL.
-#   $1 = attempt index (1-based, for logging)
-#   $2 = per-attempt log file
 # Capture serial output and verify a pattern was actually matched (#935).
 #
 # `labctl serial capture --until PATTERN` exits 0 even when the pattern
@@ -178,15 +175,20 @@ capture_until_match() {
         return 1
     fi
     # labctl prints a status line like `[Captured N lines in T, pattern '...' matched]`
-    # on success or `[Captured 0 lines in T, timeout]` on timeout. Match the
-    # explicit "matched]" suffix — fragile to format changes but lets us
-    # distinguish "saw the pattern" from "ran the clock out."
+    # on success or `[Captured 0 lines in T, timeout]` on timeout. We match
+    # the explicit "matched]" suffix on any line of the capture output —
+    # fragile to format changes but lets us distinguish "saw the pattern"
+    # from "ran the clock out." Status line need not be the last line of
+    # output (labctl may emit benign trailers after it).
     if printf '%s\n' "$out" | grep -qE 'matched\]\s*$'; then
         return 0
     fi
     return 1
 }
 
+# attempt_deploy — one full deploy cycle. Returns 0 on PASS, 1 on FAIL.
+#   $1 = attempt index (1-based, for logging)
+#   $2 = per-attempt log file
 attempt_deploy() {
     local n="$1"
     local log_file="$2"

--- a/scripts/jetson-deploy-retry.sh
+++ b/scripts/jetson-deploy-retry.sh
@@ -152,6 +152,41 @@ log ""
 # attempt_deploy — one full deploy cycle. Returns 0 on PASS, 1 on FAIL.
 #   $1 = attempt index (1-based, for logging)
 #   $2 = per-attempt log file
+# Capture serial output and verify a pattern was actually matched (#935).
+#
+# `labctl serial capture --until PATTERN` exits 0 even when the pattern
+# never matched and the capture timed out. Relying on its exit code alone
+# turned "kexec went silent, BL31 reset, no SLM-OS output" into a false
+# PASS during PMU #60 hardware validation. This wrapper:
+#
+#   1. Captures stdout+stderr into a variable so the actual lines are
+#      available for inspection.
+#   2. Tees them into the per-attempt log_file (same as the original).
+#   3. Fails the step if the trailing `[N lines, T, ...]` status line
+#      reports `timeout` instead of `... matched]`.
+#
+# Args: <port-name> <timeout-sec> <pattern> <tail-n> <log-file>
+# Returns: 0 if labctl exited 0 AND the status line reports a match,
+#          1 otherwise.
+capture_until_match() {
+    local port="$1" timeout="$2" pattern="$3" tail_n="$4" log_file="$5"
+    local out rc
+    out=$(labctl serial capture "$port" -t "$timeout" -u "$pattern" -n "$tail_n" 2>&1)
+    rc=$?
+    printf '%s\n' "$out" >> "$log_file"
+    if (( rc != 0 )); then
+        return 1
+    fi
+    # labctl prints a status line like `[Captured N lines in T, pattern '...' matched]`
+    # on success or `[Captured 0 lines in T, timeout]` on timeout. Match the
+    # explicit "matched]" suffix — fragile to format changes but lets us
+    # distinguish "saw the pattern" from "ran the clock out."
+    if printf '%s\n' "$out" | grep -qE 'matched\]\s*$'; then
+        return 0
+    fi
+    return 1
+}
+
 attempt_deploy() {
     local n="$1"
     local log_file="$2"
@@ -170,8 +205,7 @@ attempt_deploy() {
 
     # 2. Wait for Linux login prompt over serial
     echo "[2/5] waiting for Linux login" >> "$log_file"
-    if ! labctl serial capture "$TARGET" -t "$LINUX_LOGIN_TIMEOUT" -u "login:" -n 3 \
-            >> "$log_file" 2>&1; then
+    if ! capture_until_match "$TARGET" "$LINUX_LOGIN_TIMEOUT" "login:" 3 "$log_file"; then
         echo "      FAIL detail: stage=linux-login-timeout" >> "$log_file"
         return 1
     fi
@@ -202,8 +236,7 @@ attempt_deploy() {
     # session is torn down by kexec; we don't wait on it.
 
     # Wait for SLM-OS shell.
-    if ! labctl serial capture "$TARGET" -t "$SLMOS_SHELL_TIMEOUT" -u "slmos>" -n 5 \
-            >> "$log_file" 2>&1; then
+    if ! capture_until_match "$TARGET" "$SLMOS_SHELL_TIMEOUT" "slmos>" 5 "$log_file"; then
         echo "      FAIL detail: stage=slmos-shell-timeout" >> "$log_file"
         return 1
     fi

--- a/scripts/tests/test-jetson-deploy-retry-matcher.sh
+++ b/scripts/tests/test-jetson-deploy-retry-matcher.sh
@@ -139,6 +139,31 @@ run_case \
     0 \
     0
 
+# Multi-status-line case: labctl may emit benign trailers (reconnect
+# logs, disconnect notices, etc.) after the status line. The matcher
+# must still find `matched]` on its own line via grep's `$` line
+# anchor. Pins the contract so a future regex change doesn't
+# accidentally require `matched]` to be the last line of output.
+run_case \
+    "matched followed by trailer lines → rc=0" \
+    "[Captured 3 lines in 0.5s, pattern 'slmos>' matched]
+content line 1
+slmos>
+[ser2net] connection closed
+[ser2net] reconnect attempt 1" \
+    0 \
+    0
+
+# Multi-status-line negative: timeout status followed by trailer lines.
+# Must NOT trip the matcher just because trailing lines are appended.
+# Belt-and-suspenders coverage for the regex anchor.
+run_case \
+    "timeout followed by trailer lines → rc=1" \
+    "[Captured 0 lines in 90.0s, timeout]
+[ser2net] disconnect" \
+    0 \
+    1
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 if (( FAIL > 0 )); then

--- a/scripts/tests/test-jetson-deploy-retry-matcher.sh
+++ b/scripts/tests/test-jetson-deploy-retry-matcher.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+# test-jetson-deploy-retry-matcher.sh - Unit test for the
+# `capture_until_match` helper in jetson-deploy-retry.sh (#935).
+#
+# Before #935, the deploy script declared PASS even when `labctl serial
+# capture` timed out with zero matched lines, because the wrapping tool
+# exits 0 on timeout. The new helper distinguishes match from timeout
+# by parsing labctl's trailing status line. This test stubs labctl with
+# a fake that emits known status lines and asserts the helper's exit
+# code matches.
+#
+# Runs on any Linux host. No Jetson required.
+set -euo pipefail
+
+# Source the helper. The script defines `capture_until_match` near the
+# top of attempt_deploy; we source the whole file but skip the main
+# control flow by setting a guard env var that doesn't exist — sourcing
+# defines functions but doesn't invoke the bottom-of-file loop because
+# this test exits before reaching it.
+#
+# To make sourcing safe, we override the parser-driven argument loop's
+# preconditions: set ATTEMPTS=0 so the for-loop doesn't fire, and stub
+# labctl/log so any incidental calls don't escape.
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/jetson-deploy-retry.sh"
+
+if [[ ! -f "$DEPLOY_SCRIPT" ]]; then
+    echo "FAIL: $DEPLOY_SCRIPT not found"
+    exit 2
+fi
+
+# Stub PATH with a fake labctl that emits a configurable status line.
+# Each test case writes the desired stub output to $LABCTL_STUB_OUT and
+# the desired exit code to $LABCTL_STUB_RC; the stub reads those env
+# vars and replays them.
+STUB_DIR=$(mktemp -d)
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+cat > "$STUB_DIR/labctl" <<'STUB'
+#!/bin/bash
+# Print the canned output and exit with the canned rc.
+printf '%s\n' "${LABCTL_STUB_OUT:-}"
+exit "${LABCTL_STUB_RC:-0}"
+STUB
+chmod +x "$STUB_DIR/labctl"
+export PATH="$STUB_DIR:$PATH"
+
+# Extract just the helper function definition from the deploy script to
+# avoid running its top-level arg parser. We sed out the function body
+# from `capture_until_match() {` through its closing `^}`.
+HELPER_FILE=$(mktemp)
+trap 'rm -rf "$STUB_DIR" "$HELPER_FILE"' EXIT
+
+# Match from `capture_until_match() {` up to the next `^}` at column 0.
+awk '
+    /^capture_until_match\(\) \{$/ { in_fn = 1 }
+    in_fn { print }
+    in_fn && /^}$/ { exit }
+' "$DEPLOY_SCRIPT" > "$HELPER_FILE"
+
+# Sanity check: the extraction must have at least 3 lines (signature,
+# body, closing brace). Otherwise the regex drifted and the test would
+# silently pass without exercising anything.
+if (( $(wc -l < "$HELPER_FILE") < 3 )); then
+    echo "FAIL: failed to extract capture_until_match from $DEPLOY_SCRIPT"
+    echo "      sed-out file has only $(wc -l < "$HELPER_FILE") lines"
+    exit 2
+fi
+
+# shellcheck disable=SC1090
+source "$HELPER_FILE"
+
+PASS=0
+FAIL=0
+LOG_FILE=$(mktemp)
+trap 'rm -rf "$STUB_DIR" "$HELPER_FILE" "$LOG_FILE"' EXIT
+
+run_case() {
+    local desc="$1" stub_out="$2" stub_rc="$3" expect_rc="$4"
+    # Must `export` — the labctl stub runs as a subprocess and only
+    # sees the value through the environment.
+    export LABCTL_STUB_OUT="$stub_out"
+    export LABCTL_STUB_RC="$stub_rc"
+    : > "$LOG_FILE"
+    set +e
+    capture_until_match port 1 "slmos>" 5 "$LOG_FILE"
+    local got_rc=$?
+    set -e
+    if [[ "$got_rc" == "$expect_rc" ]]; then
+        echo "  [PASS] $desc (rc=$got_rc)"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] $desc (expected rc=$expect_rc, got $got_rc)"
+        echo "         stub_out=<<<$stub_out>>>"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "test capture_until_match — labctl status-line parsing"
+
+# Happy path: labctl exit 0, status line says "matched]". Helper returns 0.
+run_case \
+    "matched pattern → rc=0" \
+    "[Captured 5 lines in 0.1s, pattern 'slmos>' matched]
+content line 1
+slmos>" \
+    0 \
+    0
+
+# The bug from #935: labctl exit 0 but status line says "timeout".
+# Pre-fix the helper would have returned 0 (false PASS); now it must
+# return 1.
+run_case \
+    "timeout with labctl rc=0 → rc=1 (the #935 false-PASS path)" \
+    "[Captured 0 lines in 90.0s, timeout]" \
+    0 \
+    1
+
+# labctl itself errors out (e.g. port not bound). Helper returns 1.
+run_case \
+    "labctl non-zero exit → rc=1" \
+    "Error: port not bound" \
+    2 \
+    1
+
+# Edge case: empty output (shouldn't happen in practice, but the helper
+# must not return success on it).
+run_case \
+    "empty labctl output → rc=1" \
+    "" \
+    0 \
+    1
+
+# Edge case: status line has trailing whitespace. The grep uses \s*$.
+run_case \
+    "trailing whitespace on status line → rc=0" \
+    "[Captured 1 lines in 0.1s, pattern 'slmos>' matched]   " \
+    0 \
+    0
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if (( FAIL > 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- `labctl serial capture --until PATTERN` exits 0 on timeout, so the script's `if ! labctl serial capture ...` branches never tripped on silent kexec failures. The script declared PASS after a 90 s zero-line capture.
- Add a `capture_until_match` helper that parses labctl's trailing status line and distinguishes \"pattern matched\" from \"capture timed out.\"
- Route both `labctl serial capture` call sites (Linux login wait at step 2/5, SLM-OS shell wait at step 4/5) through the helper. Both had the same broken pattern.
- Add `scripts/tests/test-jetson-deploy-retry-matcher.sh` — runs on any Linux host (no Jetson), exercises the helper against canned labctl outputs via a PATH-stubbed labctl.

Closes #935.

## What was actually happening (the #935 reproducer)

```
[4/5] deploying build/kernel/slmos.elf
... scp + slmos-kexec ssh launched
[0 lines, 90.0s, timeout]
[5/5] SKIPPING test (--skip-test): shell reached, declaring PASS
```

The literal string `shell reached, declaring PASS` was printed even though step 5's serial capture got nothing. Behind the scenes, Linux's `kexec_load` had rejected the ELF, SLM-OS never ran, and the script had no way to tell.

## After the fix

Same scenario now writes the labctl status line to the log, fails the step, and triggers the script's normal failure-detail / retry path:

```
[4/5] deploying build/kernel/slmos.elf
... scp + slmos-kexec ssh launched
[Captured 0 lines in 90.0s, timeout]
      FAIL detail: stage=slmos-shell-timeout
```

## Test plan

- [x] `scripts/tests/test-jetson-deploy-retry-matcher.sh` — 5 cases, all pass.
  - matched pattern → rc=0
  - timeout with labctl rc=0 → rc=1 (the #935 false-PASS path)
  - labctl non-zero exit → rc=1
  - empty labctl output → rc=1
  - trailing whitespace on status line → rc=0 (regex robustness)
- [x] `bash -n scripts/jetson-deploy-retry.sh` — syntax OK.
- [x] `scripts/jetson-deploy-retry.sh --help` — still renders cleanly.
- [ ] Real-Jetson smoke not run as part of this PR; the helper is unit-tested against the labctl wire format, and the deploy script's call-site refactor is a single mechanical s/`labctl serial capture ...`/`capture_until_match ...`/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)