### PR TITLE
sched/xgb: binary classifier fix + #910 kind regression (closes #920)

### DIFF
--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -6964,6 +6964,7 @@ static uint16_t sched_model_kind_id(const char *name)
     if (strcmp(name, "config") == 0) return SCHED_MODEL_KIND_CONFIG;
     if (strcmp(name, "thresholds") == 0) return SCHED_MODEL_KIND_THRESHOLDS;
     if (strcmp(name, "rebalance") == 0) return SCHED_MODEL_KIND_REBALANCE;
+    if (strcmp(name, "xgboost") == 0) return SCHED_MODEL_KIND_XGBOOST;
     return 0;
 }
 
@@ -6975,6 +6976,7 @@ static const char *sched_model_kind_name(uint16_t kind_id)
         case SCHED_MODEL_KIND_CONFIG: return "config";
         case SCHED_MODEL_KIND_THRESHOLDS: return "thresholds";
         case SCHED_MODEL_KIND_REBALANCE: return "rebalance";
+        case SCHED_MODEL_KIND_XGBOOST: return "xgboost";
         default: return "unknown";
     }
 }
@@ -7166,7 +7168,7 @@ static int sched_model_autoload_cmd(int argc, char *argv[])
     static const uint16_t kinds[] = {
         SCHED_MODEL_KIND_MLP, SCHED_MODEL_KIND_PPO,
         SCHED_MODEL_KIND_CONFIG, SCHED_MODEL_KIND_THRESHOLDS,
-        SCHED_MODEL_KIND_REBALANCE
+        SCHED_MODEL_KIND_REBALANCE, SCHED_MODEL_KIND_XGBOOST
     };
 
     if (argc < 4 || strcmp(argv[3], "status") == 0) {
@@ -7274,6 +7276,7 @@ int cmd_sched(int argc, char *argv[])
             if (sched_model_status_one(SCHED_MODEL_KIND_CONFIG) != 0) return 1;
             if (sched_model_status_one(SCHED_MODEL_KIND_THRESHOLDS) != 0) return 1;
             if (sched_model_status_one(SCHED_MODEL_KIND_REBALANCE) != 0) return 1;
+            if (sched_model_status_one(SCHED_MODEL_KIND_XGBOOST) != 0) return 1;
             if (argc < 3) {
                 shell_puts("\r\nUsage:\r\n");
                 shell_puts("  sched model status\r\n");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -784,7 +784,7 @@ pub extern "C" fn rust_run_tests() -> i32 {
         print_test_result(b"sched_xgb_is_active_after_activate\0", is_active);
         if !is_active { failures += 1; }
 
-        let state = [0.0_f32; 108];
+        let state = [0.0_f32; sched::xgb::STATE_DIM];
         let mut core: i32 = -1;
         let mut prio: i32 = -1;
         let mut preempt: i32 = -1;
@@ -835,7 +835,7 @@ pub extern "C" fn rust_run_tests() -> i32 {
         };
         let mut equiv_ok = stage_rc == 0 && activate_rc == 0;
         for k in 0..16u32 {
-            let mut s = [0.0_f32; 108];
+            let mut s = [0.0_f32; sched::xgb::STATE_DIM];
             // Vary each state slightly so we know the loop isn't
             // returning a cached predict result.
             s[0] = k as f32;
@@ -878,7 +878,7 @@ pub extern "C" fn rust_run_tests() -> i32 {
         let mut bin_c: i32 = -1;
         let mut bin_p: i32 = -1;
         let mut bin_e: i32 = -1;
-        let bin_state = [0.0_f32; 108];
+        let bin_state = [0.0_f32; sched::xgb::STATE_DIM];
         let bin_predict_rc = if bin_activate == 0 {
             sched::xgb::rust_sched_xgb_predict(
                 bin_state.as_ptr(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -858,6 +858,46 @@ pub extern "C" fn rust_run_tests() -> i32 {
         print_test_result(b"sched_xgb_equiv_loop_synthetic\0", equiv_ok);
         if !equiv_ok { failures += 1; }
 
+        // Binary classifier regression (#920). XGBoost binary stores
+        // 1 tree per boosting round (all contributing to a single
+        // class-1 margin); predict_label has to sum + threshold, not
+        // route through predict_argmax's `cls = i % n_classes` split.
+        // build_binary_cascade_smoke_blob is shaped so the pre-fix
+        // argmax path would return (42, 10, 40) and the post-fix
+        // binary-margin path returns (42, 20, 30).
+        sched::xgb::clear();
+        let bin_blob = sched::xgb::build_binary_cascade_smoke_blob();
+        let bin_stage = sched::xgb::rust_sched_xgb_stage_blob(
+            bin_blob.as_ptr(), bin_blob.len(),
+        );
+        let bin_activate = if bin_stage == 0 {
+            sched::xgb::rust_sched_xgb_activate()
+        } else {
+            -1
+        };
+        let mut bin_c: i32 = -1;
+        let mut bin_p: i32 = -1;
+        let mut bin_e: i32 = -1;
+        let bin_state = [0.0_f32; 108];
+        let bin_predict_rc = if bin_activate == 0 {
+            sched::xgb::rust_sched_xgb_predict(
+                bin_state.as_ptr(),
+                &mut bin_c as *mut i32,
+                &mut bin_p as *mut i32,
+                &mut bin_e as *mut i32,
+            )
+        } else {
+            -1
+        };
+        let binary_ok = bin_stage == 0
+            && bin_activate == 0
+            && bin_predict_rc == 0
+            && bin_c == 42
+            && bin_p == 20
+            && bin_e == 30;
+        print_test_result(b"sched_xgb_binary_predict_label\0", binary_ok);
+        if !binary_ok { failures += 1; }
+
         sched::xgb::clear();
     }
 

--- a/runtime/src/ml/xgb_tree.rs
+++ b/runtime/src/ml/xgb_tree.rs
@@ -601,11 +601,22 @@ impl XgbModel {
     /// (see #920).
     pub fn predict_label(&self, features: &[f32], n_classes: usize) -> i32 {
         let idx = if n_classes == 2 {
-            let mut margin = 0.0_f32;
-            for &root in &self.roots {
-                margin += self.eval_tree(root as usize, features);
+            // Empty `roots` is unreachable from `parse_*` (rejected as
+            // `EmptyModel`); guard anyway so `from_parts_for_test`
+            // can't trigger the implicit "no trees → margin 0 → class
+            // 1" fallthrough below. NaN propagated through any leaf
+            // value compares false against `>= 0.0` and lands on
+            // class 0, which matches the eval_tree fallback semantics
+            // for malformed trees.
+            if self.roots.is_empty() {
+                0usize
+            } else {
+                let mut margin = 0.0_f32;
+                for &root in &self.roots {
+                    margin += self.eval_tree(root as usize, features);
+                }
+                if margin >= 0.0 { 1usize } else { 0usize }
             }
-            if margin >= 0.0 { 1usize } else { 0usize }
         } else {
             self.predict_argmax(features, n_classes)
         };

--- a/runtime/src/ml/xgb_tree.rs
+++ b/runtime/src/ml/xgb_tree.rs
@@ -601,20 +601,26 @@ impl XgbModel {
     /// (see #920).
     pub fn predict_label(&self, features: &[f32], n_classes: usize) -> i32 {
         let idx = if n_classes == 2 {
-            // Empty `roots` is unreachable from `parse_*` (rejected as
-            // `EmptyModel`); guard anyway so `from_parts_for_test`
-            // can't trigger the implicit "no trees → margin 0 → class
-            // 1" fallthrough below. NaN propagated through any leaf
-            // value compares false against `>= 0.0` and lands on
-            // class 0, which matches the eval_tree fallback semantics
-            // for malformed trees.
             if self.roots.is_empty() {
+                // Unreachable from `parse_*` (rejected as `EmptyModel`),
+                // but `from_parts_for_test` can construct it. Without
+                // this branch the sum loop below would leave `margin`
+                // at the initial 0.0 and the `>= 0.0` threshold would
+                // pick class 1, which is the multiclass fallback
+                // (lowest-index argmax) inverted — return class 0
+                // explicitly to match.
                 0usize
             } else {
                 let mut margin = 0.0_f32;
                 for &root in &self.roots {
                     margin += self.eval_tree(root as usize, features);
                 }
+                // `NaN >= 0.0` is false in IEEE-754, so a NaN leaf
+                // (only reachable via `from_parts_for_test`; the
+                // parser rejects via `validate_node`) routes to class
+                // 0. Treating it as "negative margin" matches the
+                // class-0 fallback the empty-roots branch above
+                // returns, so both degenerate inputs agree.
                 if margin >= 0.0 { 1usize } else { 0usize }
             }
         } else {

--- a/runtime/src/ml/xgb_tree.rs
+++ b/runtime/src/ml/xgb_tree.rs
@@ -588,8 +588,27 @@ impl XgbModel {
     /// Convenience: argmax + label-class lookup. Returns the raw label
     /// (e.g. an action id) emitted by the trained classifier. Falls
     /// back to the argmax index itself if `label_classes` is empty.
+    ///
+    /// `n_classes == 2` routes through the binary path: XGBoost's
+    /// `binary:logistic` objective stores one tree per boosting round
+    /// (all contributing to a single class-1 margin), not two — so the
+    /// multiclass `cls = i % n_classes` mapping in `predict_argmax`
+    /// would split a single margin's trees alternately into the two
+    /// class buckets. Sum all trees, threshold the margin at zero
+    /// (`sigmoid(margin) >= 0.5`), then map through `label_classes`.
+    /// `XGBClassifier` picks `binary:logistic` automatically for any
+    /// 2-class fit, so the trigger matches what the trainer emits
+    /// (see #920).
     pub fn predict_label(&self, features: &[f32], n_classes: usize) -> i32 {
-        let idx = self.predict_argmax(features, n_classes);
+        let idx = if n_classes == 2 {
+            let mut margin = 0.0_f32;
+            for &root in &self.roots {
+                margin += self.eval_tree(root as usize, features);
+            }
+            if margin >= 0.0 { 1usize } else { 0usize }
+        } else {
+            self.predict_argmax(features, n_classes)
+        };
         if idx < self.label_classes.len() {
             self.label_classes[idx]
         } else {
@@ -789,17 +808,21 @@ mod tests {
 
     #[test]
     fn parse_cascade_round_trips_two_classifiers() {
+        // The cascade builder writes each classifier with n_classes == 2.
+        // Per #920, that routes through the binary-logistic margin path:
+        // sum all tree leaves, threshold at zero, then label_classes
+        // lookup. The previous multiclass-style expectation was wrong.
         let bytes = build_cascade_two_classifiers();
         let cascade = parse_cascade(&bytes, &[1, 1]).expect("parse cascade");
         assert_eq!(cascade.classifiers.len(), 2);
 
         let features = [0.0_f32; 1];
-        // Classifier 0: class 0 score 0.5 vs class 1 score 0.1 → label 7.
+        // Classifier 0: margin = 0.5 + 0.1 = 0.6 >= 0 → class 1 → label 9.
         assert_eq!(
             cascade.classifiers[0].predict_label(&features, 2),
-            7
+            9
         );
-        // Classifier 1: class 0 score 0.0 vs class 1 score 1.0 → label 200.
+        // Classifier 1: margin = 0.0 + 1.0 = 1.0 >= 0 → class 1 → label 200.
         assert_eq!(
             cascade.classifiers[1].predict_label(&features, 2),
             200
@@ -813,5 +836,58 @@ mod tests {
             parse_cascade(&bytes, &[1]),
             Err(XgbError::BadLength)
         ));
+    }
+
+    /// XGBoost `binary:logistic` stores ONE tree per boosting round
+    /// (all contribute to a single class-1 margin). `predict_label`
+    /// with `n_classes == 2` must sum every tree's leaf value, threshold
+    /// the margin at zero, and look up `label_classes[predicted]` —
+    /// NOT route through `predict_argmax`'s `i % n_classes` split,
+    /// which would alternate trees into separate buckets and produce
+    /// noise. Regression for #920.
+    #[test]
+    fn predict_label_binary_uses_margin_threshold() {
+        // 3 trees, each a single-leaf root contributing +0.4. Sum = +1.2 >= 0
+        // → class 1 → label_classes[1] = 99.
+        let leaf = |v: f32| Node {
+            feature_idx: 0,
+            flags: FLAG_LEAF,
+            left_idx: 0,
+            right_idx: 0,
+            threshold: 0.0,
+            value: v,
+        };
+        let model_pos = XgbModel::from_parts_for_test(
+            alloc::vec![0u32, 1u32, 2u32],
+            alloc::vec![leaf(0.4), leaf(0.4), leaf(0.4)],
+            alloc::vec![7i32, 99i32],
+        );
+        let features = [0.0_f32; 1];
+        assert_eq!(model_pos.predict_label(&features, 2), 99);
+
+        // Same shape, leaves negative → margin -1.2 < 0 → class 0 → label 7.
+        let model_neg = XgbModel::from_parts_for_test(
+            alloc::vec![0u32, 1u32, 2u32],
+            alloc::vec![leaf(-0.4), leaf(-0.4), leaf(-0.4)],
+            alloc::vec![7i32, 99i32],
+        );
+        assert_eq!(model_neg.predict_label(&features, 2), 7);
+
+        // Mixed signs where `predict_argmax` (multiclass-style i % 2)
+        // and the binary margin disagree:
+        //   - Trees 0 (cls 0 by i%2), 2 (cls 0): -0.6, -0.6 → scores[0] = -1.2
+        //   - Tree 1 (cls 1 by i%2): +0.4 → scores[1] = +0.4
+        //   - predict_argmax → class 1 → label 99
+        //   - actual binary margin = -0.6 + 0.4 - 0.6 = -0.8 < 0 → class 0 → label 7
+        // predict_label MUST follow the binary margin, not the argmax.
+        let model_mixed = XgbModel::from_parts_for_test(
+            alloc::vec![0u32, 1u32, 2u32],
+            alloc::vec![leaf(-0.6), leaf(0.4), leaf(-0.6)],
+            alloc::vec![7i32, 99i32],
+        );
+        assert_eq!(model_mixed.predict_label(&features, 2), 7);
+        // Sanity check that predict_argmax does NOT match — confirms
+        // the test is actually exercising the binary-specific path.
+        assert_eq!(model_mixed.predict_argmax(&features, 2), 1);
     }
 }

--- a/runtime/src/sched/xgb.rs
+++ b/runtime/src/sched/xgb.rs
@@ -776,6 +776,82 @@ pub fn build_smoke_blob() -> Vec<u8> {
     blob
 }
 
+/// Build a tiny SEMB+XGBC blob whose stage 2 and stage 3 classifiers
+/// are 2-class. Used by the kernel-side `rust_run_tests` regression
+/// for #920: with the multiclass-only `predict_argmax` path (pre-fix),
+/// `predict_label` would split each classifier's trees alternately
+/// into score buckets and pick the wrong label. With the binary
+/// margin-threshold path (post-fix), the cascade returns the labels
+/// pinned below.
+///
+/// Layout per classifier:
+/// - Classifier 0: n_classes=1 (multiclass-trivial), always emits label `42`.
+/// - Classifier 1: n_classes=2, two leaves `[0.5, 0.5]`. Binary margin = 1.0
+///   ≥ 0 → class 1 → label `20`. Argmax-only path would tie-break to
+///   class 0 → label `10`.
+/// - Classifier 2: n_classes=2, two leaves `[-0.6, +0.4]`. Binary margin
+///   = -0.2 < 0 → class 0 → label `30`. Argmax-only path would pick
+///   class 1 (0.4 > -0.6) → label `40`.
+///
+/// Expected post-fix output: `(42, 20, 30)`.
+pub fn build_binary_cascade_smoke_blob() -> Vec<u8> {
+    let mut payload: Vec<u8> = Vec::new();
+    payload.extend_from_slice(b"XGBC");
+    payload.extend_from_slice(&1u16.to_le_bytes()); // version
+    payload.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    payload.extend_from_slice(&3u16.to_le_bytes()); // n_classifiers
+    payload.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    payload.extend_from_slice(&0u32.to_le_bytes()); // reserved
+
+    // Helper closure shape: one leaf-only tree per root.
+    let push_classifier =
+        |payload: &mut Vec<u8>, leaves: &[f32], labels: &[i32]| {
+            let n_trees = leaves.len() as u32;
+            let n_nodes = leaves.len() as u32;
+            let n_classes = labels.len() as u16;
+            payload.extend_from_slice(&n_trees.to_le_bytes());
+            payload.extend_from_slice(&n_nodes.to_le_bytes());
+            payload.extend_from_slice(&n_classes.to_le_bytes());
+            payload.extend_from_slice(&0u16.to_le_bytes()); // reserved (u16)
+            payload.extend_from_slice(&0u32.to_le_bytes()); // reserved (u32)
+            // Roots — one per tree, addressed by tree index (each tree
+            // is one node, so root[i] = i).
+            for i in 0..leaves.len() as u32 {
+                payload.extend_from_slice(&i.to_le_bytes());
+            }
+            for &leaf in leaves {
+                payload.extend_from_slice(&0u16.to_le_bytes()); // feature
+                payload.extend_from_slice(&1u16.to_le_bytes()); // FLAG_LEAF
+                payload.extend_from_slice(&0u32.to_le_bytes()); // left
+                payload.extend_from_slice(&0u32.to_le_bytes()); // right
+                payload.extend_from_slice(&0.0_f32.to_le_bytes()); // threshold
+                payload.extend_from_slice(&leaf.to_le_bytes()); // value
+            }
+            for &lbl in labels {
+                payload.extend_from_slice(&lbl.to_le_bytes());
+            }
+        };
+
+    push_classifier(&mut payload, &[1.0_f32], &[42i32]);
+    push_classifier(&mut payload, &[0.5_f32, 0.5_f32], &[10i32, 20i32]);
+    push_classifier(&mut payload, &[-0.6_f32, 0.4_f32], &[30i32, 40i32]);
+
+    let payload_len = payload.len() as u32;
+    let checksum = fnv1a_32(&payload);
+
+    let mut blob: Vec<u8> = Vec::with_capacity(SEMB_OUTER_HEADER_LEN + payload.len());
+    blob.extend_from_slice(&SEMB_MAGIC);
+    blob.extend_from_slice(&SEMB_BLOB_VERSION_V1.to_le_bytes());
+    blob.extend_from_slice(&SCHED_MODEL_KIND_XGBOOST.to_le_bytes());
+    blob.extend_from_slice(&SCHED_MODEL_SCHEMA_V1.to_le_bytes());
+    blob.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    blob.extend_from_slice(&payload_len.to_le_bytes());
+    blob.extend_from_slice(&checksum.to_le_bytes());
+    blob.extend_from_slice(&0u32.to_le_bytes()); // trailing reserved
+    blob.extend_from_slice(&payload);
+    blob
+}
+
 // ---------------------------------------------------------------------
 // Unit tests. Exercise every part of the path: SEMB outer-header
 // round-trip, cascade parse, staged → active dance, derived-feature


### PR DESCRIPTION
## Summary

Fixes the on-device cascade walker divergence from Python's `TripleClassifier.predict` that #920 captured (Pi 5 was reporting 23/1000 match on the verification corpus). After this PR + the companion exporter change in slm-os-scheduler-ai PR #4, `bench xgb-equiv` reports **1000/1000 match PASS** at 242 µs/predict on pi-5-2.

## Root cause

XGBoost's `binary:logistic` objective stores ONE tree per boosting round (all contributing to a single class-1 margin, with `sigmoid(margin) >= 0.5` → class 1). `multi:softprob` stores `n_classes` trees per round, one per class. The `predict_argmax` walker in `runtime/src/ml/xgb_tree.rs` only knew the multiclass layout — for the cascade's binary `priority_clf` (2 classes, 100 trees) and `preempt_clf` (2 classes, 100 trees), `cls = i % n_classes` split every class-1 margin's trees alternately into two class score buckets, producing noise. `core_clf` is genuinely multiclass (6 classes × 200 rounds = 1200 trees) and was unaffected, matching the observed "core agrees, priority/preempt diverge" symptom.

## Fix

`predict_label` now branches on `n_classes == 2`: sum every tree's contribution into a single margin, threshold at zero, then look up `label_classes[predicted]`. The `n_classes` trigger matches what sklearn's `XGBClassifier` emits — any 2-class fit becomes `binary:logistic` automatically.

This pairs with slm-os-scheduler-ai PR #4 (branch `xgb-fold-base-margin-into-trees`) which prepends synthetic single-leaf base-margin trees to fold XGBoost's `base_score` offset into the tree walk. Preempt's `base_score ≈ 0.0023` → logit ≈ -6.1, which flips most decisions to class 1 when ignored. Both fixes are needed: the runtime alone got 284/1000, the exporter alone wouldn't help without the binary-detection fix.

## PR #910 regression also fixed here

PR #910 (PMU) silently removed `xgboost` from `sched_model_kind_id`/`_name`, the `kinds[]` autoload array, and the `sched model status` enumeration in `kernel/src/shell_sys.c`. Without that, `sched model load xgboost ...` returns "Unknown scheduler model kind: 'xgboost'" and the verification path can't even start. Restored as part of this PR since it directly blocks #920 verification and is the same class of bug (silent xgboost drop on rebase — same one that bit `bench_xgb_one` previously). Total diff is ~4 lines.

(PR #910 also dropped `bench_xgb_one` itself; that restoration is separate scope and not addressed here.)

## Test plan

- [x] `make test AI_SCHED=ON` — new `sched_xgb_binary_predict_label` kernel test PASSes; all 8 existing test failures are pre-existing on main (unchanged by this PR).
- [x] New `predict_label_binary_uses_margin_threshold` unit test in `xgb_tree.rs` covers positive/negative/mixed-sign margins and asserts `predict_argmax` returns the pre-fix wrong answer on the mixed-sign case to prove the test exercises the binary-specific path.
- [x] Existing `parse_cascade_round_trips_two_classifiers` expectations updated to match the corrected binary semantics (prior values encoded the bug as intended behavior).
- [x] Hardware: pi-5-2, `bench xgb-equiv 0:/slmstore/test_vectors_xgb.bin 0:/slmstore/expected_actions_xgb.bin` reports `1000/1000 match  PASS` at 242 µs/predict.
- [ ] CI.

## Related

- Closes #920
- Companion: SLM-OS/slm-os-scheduler-ai#4
- Regression source: #910 (PMU PR silently dropped `xgboost` from shell_sys.c)
- Original verb: #921 (closes #904)

🤖 Generated with [Claude Code](https://claude.com/claude-code)