### PR TITLE
msg_router: reject-when-busy + flow-control counters (#869)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,12 +191,24 @@ Pub/Sub" for the full reference):
   component, even when a newer message lands in a *different* mailbox
   between the receive and the ack. The bookkeeping survives genuine
   cross-CPU activity (publish on one CPU while ack runs on another).
-- **Known limitation — single-slot mailbox overwrite.** A *single*
-  mailbox can lose a message if two `publish_internal` calls target it
-  back-to-back with no intervening ack. The standard ack-waiting publish
-  loop blocks between iterations so a single publisher cannot trigger
-  this; the case requires multiple concurrent publishers writing to the
-  same subscriber's mailbox. Tracked for post-capstone follow-up as #869.
+- **Mailbox flow control (#869, reject-when-busy).** `Mailbox::try_deliver`
+  refuses to write while a prior message is still unacked. The
+  ack-waiting `msg_router_publish` / `msg_router_publish_priority` path
+  yields and retries inside the same `ACK_TIMEOUT_SECS` budget, so the
+  zero-loss contract holds for concurrent publishers writing to the same
+  mailbox. The fire-and-forget `msg_router_publish_nowait` path drops
+  the message instead of overwriting and excludes the target from its
+  `delivered` return value, so the caller can see that the send didn't
+  land. Two counters — `flow_control_busy_retries` (ack-waiting path
+  yielded and retried; no loss) and `flow_control_nowait_drops`
+  (nowait path dropped a message; caller opted out of blocking) — are
+  exposed via `msg_router_flow_control_stats()` and the shell
+  `msg stats` command. A residual TOCTOU window remains where two
+  CPUs racing into `try_deliver` for the same mailbox can both see
+  `ready == 0` between the Acquire load and the Release stores;
+  closing it requires a CAS-loop redesign or the full queued-mailbox
+  option in #869's scope, neither of which is needed for the workloads
+  in tree today.
 
 ### SMP Support
 

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -2001,6 +2001,17 @@ static void test_msg_router_ack_targets_last_received_cross_cpu(void)
  *
  * Requires cpu_count >= 4 (publisher A on CPU 1, publisher B on CPU 2,
  * subscriber on CPU 3, plus shell on CPU 0).
+ *
+ * IMPORTANT — QEMU vs hardware: this test passes on QEMU virt regardless
+ * of whether the fix is present, because QEMU's serial TCG scheduler
+ * interleaves the publishers and subscriber deterministically and never
+ * opens the race window in the first place. The test's primary value is
+ * on real Pi 5 / Jetson SMP hardware where publishers genuinely run
+ * concurrently. A green QEMU run is structural only — do NOT conclude
+ * from it that the underlying mailbox semantics are correct without a
+ * hardware run. The matching same-CPU contract canary in
+ * test_msg_router.c (`test_publish_nowait_basic_contract`) DOES fire on
+ * QEMU and is the day-to-day regression guard.
  * ============================================================================ */
 
 #define SM_C_COMPONENT 24

--- a/kernel/tests/test_integration.c
+++ b/kernel/tests/test_integration.c
@@ -120,6 +120,14 @@ static struct {
 /* msg_router #67c: cross-CPU LAST_RECEIVED ack-targeting test. */
 #define NC_MSGAR_TRIGGER     31  /* main → helper: publish /b now */
 #define NC_MSGAR_HELPER_DONE 32  /* helper → main: publish complete */
+/* msg_router #869: same-mailbox concurrent-publisher zero-loss test. */
+#define NC_MSGSM_A_DELIVERED 33  /* pub_a's total delivered count */
+#define NC_MSGSM_B_DELIVERED 34  /* pub_b's total delivered count */
+#define NC_MSGSM_SUB_A_SEEN  35  /* subscriber's count of A-payloads */
+#define NC_MSGSM_SUB_B_SEEN  36  /* subscriber's count of B-payloads */
+#define NC_MSGSM_PUB_A_DONE  37
+#define NC_MSGSM_PUB_B_DONE  38
+#define NC_MSGSM_SUB_DONE    39
 
 static void nc_sync_clear(uint32_t start, uint32_t count)
 {
@@ -1969,6 +1977,230 @@ static void test_msg_router_ack_targets_last_received_cross_cpu(void)
 }
 
 /* ============================================================================
+ * Regression: msg_router same-mailbox zero-loss under concurrent
+ * publishers (#869)
+ *
+ * Two publishers on different CPUs target the SAME topic — and therefore
+ * the SAME subscriber mailbox — while a subscriber on a third CPU drains
+ * messages and acks each. Pre-#869 the mailbox was single-slot:
+ * publisher A's deliver() set ready=1; publisher B's concurrent deliver()
+ * overwrote the data in place while ready was still 1. The subscriber
+ * saw only one of the two messages, but BOTH publishers observed the
+ * subscriber's ack and reported delivered=1 — silent data loss with no
+ * observable error.
+ *
+ * After #869, deliver() refuses to overwrite an unacked mailbox; the
+ * publisher waits for ack and retries. Both messages reach the subscriber.
+ *
+ * Test invariant:
+ *   subscriber A-payload count + B-payload count
+ *     == pub_a_delivered + pub_b_delivered
+ *
+ * On main pre-fix this invariant fails — the publisher counts can
+ * exceed what the subscriber actually saw. Post-fix they match exactly.
+ *
+ * Requires cpu_count >= 4 (publisher A on CPU 1, publisher B on CPU 2,
+ * subscriber on CPU 3, plus shell on CPU 0).
+ * ============================================================================ */
+
+#define SM_C_COMPONENT 24
+#define SM_TOPIC       ((const uint8_t *)"/sm")
+#define SM_MESSAGES    5
+#define SM_PRIO        0
+
+static volatile uint32_t sm_a_delivered = 0;
+static volatile uint32_t sm_b_delivered = 0;
+static volatile uint32_t sm_sub_a_seen  = 0;
+static volatile uint32_t sm_sub_b_seen  = 0;
+static volatile uint32_t sm_pub_a_done  = 0;
+static volatile uint32_t sm_pub_b_done  = 0;
+static volatile uint32_t sm_sub_done    = 0;
+
+static void sm_publisher_a(void *arg)
+{
+    (void)arg;
+    delay(50000);
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < SM_MESSAGES; i++) {
+        uint8_t payload[4] = { 'A', (uint8_t)('0' + i), 0, 0 };
+        int delivered = msg_router_publish_priority(SM_TOPIC, payload, SM_PRIO);
+        if (delivered > 0) total += (uint32_t)delivered;
+    }
+    sm_a_delivered = total;
+    sm_pub_a_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGSM_A_DELIVERED) = total;
+    NC_SYNC(NC_MSGSM_PUB_A_DONE) = 1;
+#else
+    cache_clean((void *)&sm_a_delivered);
+    cache_clean((void *)&sm_pub_a_done);
+#endif
+}
+
+static void sm_publisher_b(void *arg)
+{
+    (void)arg;
+    delay(50000);
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < SM_MESSAGES; i++) {
+        uint8_t payload[4] = { 'B', (uint8_t)('0' + i), 0, 0 };
+        int delivered = msg_router_publish_priority(SM_TOPIC, payload, SM_PRIO);
+        if (delivered > 0) total += (uint32_t)delivered;
+    }
+    sm_b_delivered = total;
+    sm_pub_b_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGSM_B_DELIVERED) = total;
+    NC_SYNC(NC_MSGSM_PUB_B_DONE) = 1;
+#else
+    cache_clean((void *)&sm_b_delivered);
+    cache_clean((void *)&sm_pub_b_done);
+#endif
+}
+
+static void sm_subscriber(void *arg)
+{
+    (void)arg;
+    uint8_t topic_buf[16];
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 10;
+    uint32_t a = 0;
+    uint32_t b = 0;
+
+    while (a + b < SM_MESSAGES * 2u) {
+        if ((timer_get_count() - start) >= limit) break;
+        const uint8_t *data = msg_router_receive(SM_C_COMPONENT, topic_buf);
+        if (data) {
+            if (data[0] == 'A') {
+                a++;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+                NC_SYNC(NC_MSGSM_SUB_A_SEEN) = a;
+#endif
+            } else if (data[0] == 'B') {
+                b++;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+                NC_SYNC(NC_MSGSM_SUB_B_SEEN) = b;
+#endif
+            }
+            sm_sub_a_seen = a;
+            sm_sub_b_seen = b;
+#if !defined(PLATFORM_HAS_NC_MEMORY)
+            cache_clean((void *)&sm_sub_a_seen);
+            cache_clean((void *)&sm_sub_b_seen);
+#endif
+            msg_router_ack(SM_C_COMPONENT);
+        } else {
+            yield();
+        }
+    }
+
+    sm_sub_done = 1;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    NC_SYNC(NC_MSGSM_SUB_DONE) = 1;
+#else
+    cache_clean((void *)&sm_sub_done);
+#endif
+}
+
+static void test_msg_router_same_mailbox_zero_loss(void)
+{
+    /* shell on 0, pub_a on 1, pub_b on 2, sub on 3 */
+    if (cpu_count < 4) {
+        TEST_IGNORE_MESSAGE("Requires cpu_count >= 4");
+        return;
+    }
+
+    msg_router_init();
+    sm_a_delivered = 0;
+    sm_b_delivered = 0;
+    sm_sub_a_seen = 0;
+    sm_sub_b_seen = 0;
+    sm_pub_a_done = 0;
+    sm_pub_b_done = 0;
+    sm_sub_done = 0;
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    nc_sync_clear(NC_MSGSM_A_DELIVERED, 7);
+#else
+    cache_clean((void *)&sm_a_delivered);
+    cache_clean((void *)&sm_b_delivered);
+    cache_clean((void *)&sm_sub_a_seen);
+    cache_clean((void *)&sm_sub_b_seen);
+    cache_clean((void *)&sm_pub_a_done);
+    cache_clean((void *)&sm_pub_b_done);
+    cache_clean((void *)&sm_sub_done);
+#endif
+
+    TEST_ASSERT_EQUAL_INT(0, msg_router_subscribe(SM_TOPIC, SM_C_COMPONENT));
+
+    struct task *sub   = task_create("sm_sub",   sm_subscriber, NULL);
+    struct task *pub_a = task_create("sm_pub_a", sm_publisher_a, NULL);
+    struct task *pub_b = task_create("sm_pub_b", sm_publisher_b, NULL);
+    TEST_ASSERT_NOT_NULL(sub);
+    TEST_ASSERT_NOT_NULL(pub_a);
+    TEST_ASSERT_NOT_NULL(pub_b);
+
+    scheduler_add_task_to_cpu(pub_a, 1);
+    scheduler_add_task_to_cpu(pub_b, 2);
+    scheduler_add_task_to_cpu(sub, 3);
+
+    uint64_t start = timer_get_count();
+    uint64_t limit = timer_get_frequency() * 15;
+    while ((timer_get_count() - start) < limit) {
+#if defined(PLATFORM_HAS_NC_MEMORY)
+        if (NC_SYNC(NC_MSGSM_PUB_A_DONE) &&
+            NC_SYNC(NC_MSGSM_PUB_B_DONE) &&
+            NC_SYNC(NC_MSGSM_SUB_DONE)) break;
+#else
+        cache_invalidate((void *)&sm_pub_a_done);
+        cache_invalidate((void *)&sm_pub_b_done);
+        cache_invalidate((void *)&sm_sub_done);
+        if (sm_pub_a_done && sm_pub_b_done && sm_sub_done) break;
+#endif
+        yield();
+    }
+
+    msg_router_unsubscribe_all(SM_C_COMPONENT);
+
+#if defined(PLATFORM_HAS_NC_MEMORY)
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGSM_PUB_A_DONE), "pub_a hung");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGSM_PUB_B_DONE), "pub_b hung");
+    TEST_ASSERT_MESSAGE(NC_SYNC(NC_MSGSM_SUB_DONE),   "subscriber hung");
+    uint32_t a_seen = NC_SYNC(NC_MSGSM_SUB_A_SEEN);
+    uint32_t b_seen = NC_SYNC(NC_MSGSM_SUB_B_SEEN);
+    uint32_t a_del  = NC_SYNC(NC_MSGSM_A_DELIVERED);
+    uint32_t b_del  = NC_SYNC(NC_MSGSM_B_DELIVERED);
+#else
+    cache_invalidate((void *)&sm_pub_a_done);
+    cache_invalidate((void *)&sm_pub_b_done);
+    cache_invalidate((void *)&sm_sub_done);
+    cache_invalidate((void *)&sm_sub_a_seen);
+    cache_invalidate((void *)&sm_sub_b_seen);
+    cache_invalidate((void *)&sm_a_delivered);
+    cache_invalidate((void *)&sm_b_delivered);
+    TEST_ASSERT_MESSAGE(sm_pub_a_done, "pub_a hung");
+    TEST_ASSERT_MESSAGE(sm_pub_b_done, "pub_b hung");
+    TEST_ASSERT_MESSAGE(sm_sub_done,   "subscriber hung");
+    uint32_t a_seen = sm_sub_a_seen;
+    uint32_t b_seen = sm_sub_b_seen;
+    uint32_t a_del  = sm_a_delivered;
+    uint32_t b_del  = sm_b_delivered;
+#endif
+
+    /* Invariant: every message a publisher counted as delivered must
+     * have been seen by the subscriber. With single-slot semantics the
+     * publisher counts can exceed the subscriber-seen counts because
+     * two deliveries collapse into one acked mailbox state. */
+    TEST_ASSERT_MESSAGE(a_del == SM_MESSAGES,
+        "pub_a: not every publish returned delivered>0");
+    TEST_ASSERT_MESSAGE(b_del == SM_MESSAGES,
+        "pub_b: not every publish returned delivered>0");
+    TEST_ASSERT_MESSAGE(a_seen == SM_MESSAGES,
+        "subscriber lost A-payloads (mailbox overwrite bug)");
+    TEST_ASSERT_MESSAGE(b_seen == SM_MESSAGES,
+        "subscriber lost B-payloads (mailbox overwrite bug)");
+}
+
+/* ============================================================================
  * smp_notify_cpu (Prereq #3) — direct functional tests
  *
  * `scheduler_add_task_to_cpu()` invokes `smp_notify_cpu(cpu)` after
@@ -2131,6 +2363,9 @@ int test_suite_integration(void)
 
     /* Regression: msg_router LAST_RECEIVED ack-targeting (#67c / #867) */
     RUN_TEST(test_msg_router_ack_targets_last_received_cross_cpu);
+
+    /* Regression: msg_router same-mailbox zero-loss (#869) */
+    RUN_TEST(test_msg_router_same_mailbox_zero_loss);
 
     /* Prereq #3: smp_notify_cpu abstraction */
     RUN_TEST(test_smp_notify_cpu_safe);

--- a/kernel/tests/test_msg_router.c
+++ b/kernel/tests/test_msg_router.c
@@ -18,6 +18,9 @@ extern int msg_router_publish_nowait(const uint8_t *topic_name,
                                      const uint8_t *data);
 extern const uint8_t *msg_router_receive(int component_idx, uint8_t *topic_out);
 extern void msg_router_ack(int component_idx);
+extern void msg_router_flow_control_stats(uint32_t *busy_retries_out,
+                                          uint32_t *nowait_drops_out);
+extern void msg_router_flow_control_reset(void);
 
 /*
  * Regression for GitHub issue #80: msg_router_publish hangs on Pi 5 when
@@ -442,28 +445,31 @@ static void test_publish_nowait_basic_contract(void)
     TEST_ASSERT_EQUAL_INT(1, delivered);
     TEST_ASSERT_LESS_THAN(freq, elapsed);
 
-    /* Contract (5): second nowait deliver to the same unacked mailbox
-     * overwrites the first. The subscriber receives only the second
-     * payload — first is lost. This pins the documented limitation
-     * tracked as #869; if a queued-mailbox redesign lands, this test
-     * is the canary that forces the test to be updated together with
-     * the doc/runtime change. */
+    /* Contract (5): second nowait deliver to a mailbox that already
+     * holds an unacked message is REJECTED — returns 0, does not
+     * overwrite, increments FLOW_CONTROL_NOWAIT_DROPS. The subscriber
+     * receives the FIRST payload, not the second. This is the #869
+     * fix landing: pre-fix the second publish silently overwrote the
+     * first; post-fix the caller is told the message didn't land. */
+    uint32_t drops_before = 0;
+    msg_router_flow_control_stats(NULL, &drops_before);
     delivered = msg_router_publish_nowait(
         (const uint8_t *)"/nw/one", (const uint8_t *)"two");
-    TEST_ASSERT_EQUAL_INT(1, delivered);
+    TEST_ASSERT_EQUAL_INT(0, delivered);  /* refused — mailbox busy */
+    uint32_t drops_after = 0;
+    msg_router_flow_control_stats(NULL, &drops_after);
+    TEST_ASSERT_EQUAL_UINT32(drops_before + 1, drops_after);
 
     uint8_t topic_buf[16];
     const uint8_t *msg = msg_router_receive(9, topic_buf);
     TEST_ASSERT_NOT_NULL(msg);
     TEST_ASSERT_EQUAL_STRING("/nw/one", (const char *)topic_buf);
-    /* Single-slot mailbox: only the second message survives — the
-     * first ("hi") was overwritten in place by the second ("two"). */
-    TEST_ASSERT_EQUAL_STRING("two", (const char *)msg);
+    /* Zero-loss: the first message ("hi") survived; the second
+     * ("two") was rejected at deliver time, not silently overwritten. */
+    TEST_ASSERT_EQUAL_STRING("hi", (const char *)msg);
     msg_router_ack(9);
 
-    /* Mailbox now empty — a second receive returns NULL (confirms
-     * the overwrite collapsed two publishes into one mailbox slot,
-     * not two slots). */
+    /* Mailbox now empty — receive returns NULL. */
     TEST_ASSERT_NULL(msg_router_receive(9, topic_buf));
 
     msg_router_unsubscribe_all(9);

--- a/runtime/CLAUDE.md
+++ b/runtime/CLAUDE.md
@@ -287,23 +287,76 @@ publish/ack sequence wedges immediately — `kernel/tests/test_integration.c`
 `test_msg_router_multi_subscriber` and `test_msg_router_priority_concurrent`
 are the regression catch-points.
 
-### Single-slot mailbox limitation (post-capstone follow-up — #869)
+### Single-slot mailbox flow control (#869, reject-when-busy)
 
 `Mailbox` carries a single set of `ready`/`ack`/`data` atomics per
-subscription. Two `publish_internal` calls that target the *same*
-mailbox before the subscriber has acked the first message will see
-the second `deliver()` overwrite the first in place. The standard
-ack-waiting publish path cannot trigger this — its loop blocks on
-ack between iterations — but multiple concurrent publishers writing
-to the same subscriber's mailbox can. A queued mailbox redesign
-(bounded ring per subscription, with per-mailbox lock + sequence
-counter) is the planned fix; see #869 for the queued vs.
-reject-when-busy decision.
+subscription. `Mailbox::try_deliver` (formerly `deliver`) refuses to
+write when `ready == 1` — i.e. when a prior message is still
+unacked — and returns `false`. Two flavors of caller behavior follow:
+
+- **`publish_internal` (ack-waiting):** if `try_deliver` returns
+  `false`, the publisher bumps `FLOW_CONTROL_BUSY_RETRIES`, yields,
+  and retries inside the same overall `ACK_TIMEOUT_SECS` budget. A
+  slow subscriber spends the budget either in the busy-retry loop or
+  in the post-deliver ack-wait — the publisher's `delivered` return
+  value distinguishes "successfully sent" (was acked in time) from
+  "subscriber never acked" (delivered=0).
+- **`publish_internal_nowait` (fire-and-forget):** if `try_deliver`
+  returns `false`, the publisher bumps `FLOW_CONTROL_NOWAIT_DROPS`,
+  does NOT retry (caller asked for non-blocking), and excludes the
+  failed target from the `delivered` return count. Pre-#869 this
+  path silently overwrote the prior message; post-fix the caller is
+  told the message didn't land.
+
+The two counters are read via `msg_router_flow_control_stats(busy_out,
+drops_out)` and reset by `msg_router_flow_control_reset()`. The shell
+`msg stats` surfaces them so operators can distinguish "publisher
+waited briefly" (busy retries > 0, drops = 0) from "data was lost on a
+nowait path" (drops > 0).
+
+This fix preserves zero-loss on the ack-waiting path and converts
+silent loss to explicit, observable loss on the nowait path — the
+contract a non-blocking publisher implicitly accepts. The queued-
+mailbox redesign (option 1 in #869's scope comment) remains a future
+option if measured publisher latency under contention proves too
+high; it's a strictly larger change (per-mailbox ring + lock +
+sequence counter) and isn't needed for the workloads in tree today.
+
+Regression coverage:
+- `kernel/tests/test_msg_router.c::test_publish_nowait_basic_contract`
+  pins the new "no silent overwrite + nowait_drops counter increments"
+  contract.
+- `kernel/tests/test_integration.c::test_msg_router_same_mailbox_zero_loss`
+  exercises two concurrent publishers writing to the same mailbox; the
+  invariant is that publisher counts and subscriber-seen counts match
+  exactly. QEMU's serial TCG hides the race window, so this test's
+  primary value is on real Pi 5 / Jetson SMP hardware.
 
 This is distinct from the LAST_RECEIVED ack-targeting case
 (`msg_router_ack` clears the right mailbox when the component has
 multiple mailboxes), which works correctly and is pinned by the
 67c tests.
+
+### Concurrent-publisher TOCTOU caveat (residual, not fixed by #869)
+
+`try_deliver`'s ready-then-write sequence is not a single atomic
+operation. Two publishers that both observe `ready == 0` between their
+Acquire load and their later Release stores will both proceed to
+write, and the second arrival's `ready.store(1)` will overwrite the
+first's data in-place — the same loss this method is meant to prevent.
+
+In practice the in-tree caller (`publish_internal`) holds
+`MSG_ROUTER_LOCK` only across the gather phase, not the deliver phase,
+so two publishers CAN arrive at `try_deliver` concurrently for the
+SAME mailbox edge if they both publish to the SAME topic with one
+subscriber. The check in `try_deliver` closes the larger
+"deliver-then-deliver-without-yield" window that single-publisher
+sequential code can hit; the smaller "both-CPUs-in-flight-at-the-same-
+nanosecond" window remains. A CAS-loop redesign (treat `ready` as
+0=idle, 2=writing, 1=ready) or the full queued-mailbox option from
+#869's scope would close this. Not done here because the workloads in
+tree today don't sustain enough simultaneity to surface it; if a
+telemetry fan-in or sensor producer trips it on hardware, escalate.
 
 ---
 

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -84,9 +84,17 @@ impl Mailbox {
         self.priority.store(0, Ordering::Release);
     }
 
-    /// Deliver a message to this mailbox. Writes data and topic first,
-    /// then priority (Release), then ready=1 (Release) so the receiver
-    /// sees consistent data when it reads ready=1 (Acquire).
+    /// Attempt to deliver a message to this mailbox.
+    ///
+    /// Returns `true` on success, `false` if the mailbox already holds
+    /// an unacked message (`ready == 1`). The caller is expected to
+    /// retry after yielding so the subscriber has a chance to ack.
+    /// See #869 for the design rationale (option 2 — reject-when-busy,
+    /// publisher retries; preserves zero-loss semantics).
+    ///
+    /// Writes data and topic first, then priority (Release), then
+    /// ready=1 (Release) so the receiver sees consistent data when it
+    /// reads ready=1 (Acquire).
     ///
     /// IMPORTANT (memory ordering invariant): the `data` and `topic`
     /// arrays are written with plain (non-atomic) stores, but they are
@@ -98,15 +106,39 @@ impl Mailbox {
     /// will become a true data race and the receiver will see torn /
     /// stale bytes. Keep ready, priority, and ack as Release stores.
     ///
+    /// CAVEAT (concurrent publishers): the `ready.load → write → store`
+    /// sequence is not a single atomic operation. Two publishers that
+    /// both observe `ready == 0` between their Acquire load and their
+    /// later Release stores will both proceed to write, and the second
+    /// arrival's `ready.store(1)` will overwrite the first's data
+    /// in-place — the same single-slot-mailbox loss this method is
+    /// meant to prevent. In practice the in-tree caller
+    /// (`publish_internal`) holds MSG_ROUTER_LOCK only across the
+    /// gather phase, not the deliver phase, so two publishers CAN
+    /// arrive here concurrently for different topic→mailbox edges; for
+    /// the SAME mailbox edge they would have had to subscribe a single
+    /// component to a single topic — covered by this check but with
+    /// the residual TOCTOU window noted above. A full fix is the
+    /// queued-mailbox redesign (option 1 in #869), tracked separately.
+    ///
     /// # Safety
     /// Caller promises `topic_name` and `data` are NUL-terminated within
     /// `TOPIC_NAME_LEN` and `MAX_MSG_LEN` bytes respectively.
-    unsafe fn deliver(&mut self, topic_name: *const u8, data: *const u8, prio: u8) {
+    unsafe fn try_deliver(
+        &mut self,
+        topic_name: *const u8,
+        data: *const u8,
+        prio: u8,
+    ) -> bool {
+        if self.ready.load(Ordering::Acquire) != 0 {
+            return false;
+        }
         str_copy(&mut self.data, data, MAX_MSG_LEN);
         str_copy(&mut self.topic, topic_name, TOPIC_NAME_LEN);
         self.ack.store(0, Ordering::Release);
         self.priority.store(prio as u32, Ordering::Release);
         self.ready.store(1, Ordering::Release);
+        true
     }
 }
 
@@ -274,6 +306,35 @@ static mut LAST_RECEIVED: [LastReceived; MAX_COMPONENTS] = [LastReceived::none()
 ///    guard per call, and `publish_internal` releases its guard before
 ///    yielding.
 static MSG_ROUTER_LOCK: AtomicBool = AtomicBool::new(false);
+
+/// Counter incremented each time `try_deliver` rejects a write because
+/// the target mailbox already holds an unacked message.
+///
+/// On the ack-waiting publish path (`publish_internal`) the publisher
+/// retries after yielding — the counter reflects publisher-side latency
+/// under contention, not lost messages. On the nowait path
+/// (`publish_internal_nowait`) the counter reflects messages the caller
+/// asked to send without blocking that were dropped because the
+/// mailbox was full.
+///
+/// Exposed via `msg_router_flow_control_stats` for the shell `msg stats`
+/// command, so operators can distinguish "publisher waited briefly" from
+/// "data was actually lost." Saturates at u32::MAX; reset to zero by
+/// `msg_router_flow_control_reset`.
+static FLOW_CONTROL_BUSY_RETRIES: AtomicU32 = AtomicU32::new(0);
+static FLOW_CONTROL_NOWAIT_DROPS: AtomicU32 = AtomicU32::new(0);
+
+fn flow_control_bump(counter: &AtomicU32) {
+    /* Saturating increment; the counter is observational, no point in
+     * overflowing back to zero. */
+    let mut prev = counter.load(Ordering::Relaxed);
+    while prev != u32::MAX {
+        match counter.compare_exchange_weak(prev, prev + 1, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => return,
+            Err(actual) => prev = actual,
+        }
+    }
+}
 
 /// RAII guard for `MSG_ROUTER_LOCK`.
 ///
@@ -674,8 +735,36 @@ unsafe fn publish_internal(topic_name: *const u8, data: *const u8, priority: u8)
         // SAFETY: pointer points at a Mailbox inside the TOPICS /
         // WILDCARD_SUBS static arrays (stable storage).
         let mb = &mut *targets[t];
-        mb.deliver(topic_name, data, priority);
+
+        // Try to deliver, retrying with yield while the mailbox is
+        // busy (a prior message is still unacked). The same overall
+        // ACK_TIMEOUT budget covers both the busy-wait and the
+        // post-deliver ack-wait — a slow subscriber spends its budget
+        // wherever the contention surfaces.
         let start = timer_get_count();
+        let mut delivered_this_target = false;
+        loop {
+            if mb.try_deliver(topic_name, data, priority) {
+                delivered_this_target = true;
+                break;
+            }
+            flow_control_bump(&FLOW_CONTROL_BUSY_RETRIES);
+            if timer_get_count().wrapping_sub(start) >= timeout_cycles {
+                /* Subscriber never acked the prior message — abandon
+                 * this target. The publisher's `delivered` count
+                 * correctly excludes this message, distinguishing the
+                 * pre-#869 silent-overwrite case (publisher saw
+                 * delivered=1, subscriber lost the data) from the
+                 * post-fix explicit-failure case (publisher sees
+                 * delivered=0, knows the send didn't land). */
+                break;
+            }
+            sched_yield();
+        }
+        if !delivered_this_target {
+            continue;
+        }
+
         loop {
             if mb.ack.load(Ordering::Acquire) != 0 {
                 delivered += 1;
@@ -738,8 +827,15 @@ unsafe fn publish_internal_nowait(
     for t in 0..target_count {
         // SAFETY: pointer into stable static storage.
         let mb = &mut *targets[t];
-        mb.deliver(topic_name, data, priority);
-        delivered += 1;
+        if mb.try_deliver(topic_name, data, priority) {
+            delivered += 1;
+        } else {
+            /* Mailbox holds an unacked message — caller opted out of
+             * blocking, so drop and count for observability. Pre-#869
+             * the nowait path silently overwrote the prior message;
+             * post-fix it returns a drop count the caller can monitor. */
+            flow_control_bump(&FLOW_CONTROL_NOWAIT_DROPS);
+        }
     }
     delivered
 }
@@ -1073,4 +1169,40 @@ pub extern "C" fn msg_router_list() {
             }
         }
     }
+}
+
+/// Read the flow-control counters into caller-provided slots.
+///
+/// `busy_retries_out` receives the count of times `try_deliver` was
+/// rejected on the ack-waiting publish path (publisher then yielded
+/// and retried — no data lost). `nowait_drops_out` receives the count
+/// of times the nowait publish path dropped a message because the
+/// target mailbox held an unacked prior message (caller opted out of
+/// blocking, so the drop is by contract). Either pointer may be NULL.
+///
+/// Counters saturate at u32::MAX. Use `msg_router_flow_control_reset`
+/// to zero them.
+///
+/// # Safety
+/// `busy_retries_out` and `nowait_drops_out`, when non-NULL, must
+/// point to writable `u32` storage owned by the caller for the duration
+/// of the call.
+#[no_mangle]
+pub unsafe extern "C" fn msg_router_flow_control_stats(
+    busy_retries_out: *mut u32,
+    nowait_drops_out: *mut u32,
+) {
+    if !busy_retries_out.is_null() {
+        *busy_retries_out = FLOW_CONTROL_BUSY_RETRIES.load(Ordering::Relaxed);
+    }
+    if !nowait_drops_out.is_null() {
+        *nowait_drops_out = FLOW_CONTROL_NOWAIT_DROPS.load(Ordering::Relaxed);
+    }
+}
+
+/// Reset both flow-control counters to zero.
+#[no_mangle]
+pub extern "C" fn msg_router_flow_control_reset() {
+    FLOW_CONTROL_BUSY_RETRIES.store(0, Ordering::Relaxed);
+    FLOW_CONTROL_NOWAIT_DROPS.store(0, Ordering::Relaxed);
 }

--- a/runtime/src/msg_router.rs
+++ b/runtime/src/msg_router.rs
@@ -55,20 +55,36 @@ fn puts(s: &[u8]) {
 // Data Structures
 // =============================================================================
 
+/// `Mailbox::ready` state constants.
+///
+/// Currently two-valued (`READY_IDLE` / `READY_FULL`). A future fix
+/// for the concurrent-publisher TOCTOU window noted in
+/// `Mailbox::try_deliver` would extend this to a three-valued protocol
+/// (idle → writing → full) with a CAS into the writing state. Named
+/// constants now so the future change is a constant-substitution, not
+/// a hunt-and-replace of magic 0/1 literals scattered across receive,
+/// ack, and unsubscribe paths.
+const READY_IDLE: u32 = 0;
+const READY_FULL: u32 = 1;
+
 /// Per-subscriber mailbox for message delivery.
 struct Mailbox {
+    /// One of `READY_IDLE` / `READY_FULL`. Released by the producer
+    /// (`try_deliver`) once data + topic + priority + ack are written,
+    /// and reset to `READY_IDLE` by the consumer (`msg_router_ack`).
     ready: AtomicU32,
     ack: AtomicU32,
     data: [u8; MAX_MSG_LEN],
     topic: [u8; TOPIC_NAME_LEN],
-    /// Atomic to prevent reordering: priority must be visible before ready=1.
+    /// Atomic to prevent reordering: priority must be visible before
+    /// `ready = READY_FULL`.
     priority: AtomicU32,
 }
 
 impl Mailbox {
     const fn new() -> Self {
         Self {
-            ready: AtomicU32::new(0),
+            ready: AtomicU32::new(READY_IDLE),
             ack: AtomicU32::new(0),
             data: [0; MAX_MSG_LEN],
             topic: [0; TOPIC_NAME_LEN],
@@ -77,7 +93,7 @@ impl Mailbox {
     }
 
     fn clear(&mut self) {
-        self.ready.store(0, Ordering::Release);
+        self.ready.store(READY_IDLE, Ordering::Release);
         self.ack.store(0, Ordering::Release);
         self.data = [0; MAX_MSG_LEN];
         self.topic = [0; TOPIC_NAME_LEN];
@@ -87,30 +103,33 @@ impl Mailbox {
     /// Attempt to deliver a message to this mailbox.
     ///
     /// Returns `true` on success, `false` if the mailbox already holds
-    /// an unacked message (`ready == 1`). The caller is expected to
-    /// retry after yielding so the subscriber has a chance to ack.
-    /// See #869 for the design rationale (option 2 — reject-when-busy,
-    /// publisher retries; preserves zero-loss semantics).
+    /// an unacked message (`ready == READY_FULL`). The caller is
+    /// expected to retry after yielding so the subscriber has a chance
+    /// to ack. See #869 for the design rationale (option 2 —
+    /// reject-when-busy, publisher retries; preserves zero-loss
+    /// semantics).
     ///
     /// Writes data and topic first, then priority (Release), then
-    /// ready=1 (Release) so the receiver sees consistent data when it
-    /// reads ready=1 (Acquire).
+    /// `ready = READY_FULL` (Release) so the receiver sees consistent
+    /// data when it reads ready as `READY_FULL` (Acquire).
     ///
     /// IMPORTANT (memory ordering invariant): the `data` and `topic`
     /// arrays are written with plain (non-atomic) stores, but they are
     /// published to the receiver via the Release on `ready` below.
     /// The receiver's Acquire load on `ready` carries the prior plain
     /// stores into its observation, so this is sound as long as
-    /// `ready.store(1, Release)` remains the single publication point.
-    /// If a future change relaxes that store to `Relaxed`, the data
-    /// will become a true data race and the receiver will see torn /
-    /// stale bytes. Keep ready, priority, and ack as Release stores.
+    /// `ready.store(READY_FULL, Release)` remains the single
+    /// publication point. If a future change relaxes that store to
+    /// `Relaxed`, the data will become a true data race and the
+    /// receiver will see torn / stale bytes. Keep ready, priority,
+    /// and ack as Release stores.
     ///
     /// CAVEAT (concurrent publishers): the `ready.load → write → store`
     /// sequence is not a single atomic operation. Two publishers that
-    /// both observe `ready == 0` between their Acquire load and their
-    /// later Release stores will both proceed to write, and the second
-    /// arrival's `ready.store(1)` will overwrite the first's data
+    /// both observe `ready == READY_IDLE` between their Acquire load
+    /// and their later Release stores will both proceed to write, and
+    /// the second arrival's `ready.store(READY_FULL)` will overwrite
+    /// the first's data
     /// in-place — the same single-slot-mailbox loss this method is
     /// meant to prevent. In practice the in-tree caller
     /// (`publish_internal`) holds MSG_ROUTER_LOCK only across the
@@ -130,14 +149,14 @@ impl Mailbox {
         data: *const u8,
         prio: u8,
     ) -> bool {
-        if self.ready.load(Ordering::Acquire) != 0 {
+        if self.ready.load(Ordering::Acquire) != READY_IDLE {
             return false;
         }
         str_copy(&mut self.data, data, MAX_MSG_LEN);
         str_copy(&mut self.topic, topic_name, TOPIC_NAME_LEN);
         self.ack.store(0, Ordering::Release);
         self.priority.store(prio as u32, Ordering::Release);
-        self.ready.store(1, Ordering::Release);
+        self.ready.store(READY_FULL, Ordering::Release);
         true
     }
 }
@@ -737,11 +756,15 @@ unsafe fn publish_internal(topic_name: *const u8, data: *const u8, priority: u8)
         let mb = &mut *targets[t];
 
         // Try to deliver, retrying with yield while the mailbox is
-        // busy (a prior message is still unacked). The same overall
-        // ACK_TIMEOUT budget covers both the busy-wait and the
-        // post-deliver ack-wait — a slow subscriber spends its budget
-        // wherever the contention surfaces.
-        let start = timer_get_count();
+        // busy (a prior message is still unacked). The busy-wait and
+        // post-deliver ack-wait get INDEPENDENT timeout budgets so a
+        // slow prior subscriber consuming the busy-wait budget cannot
+        // cause this publisher to skip its own ack-wait and return
+        // `delivered=0` for a message that DID land in the mailbox.
+        // Worst-case wall time per target is therefore
+        // 2 * ACK_TIMEOUT_SECS — acceptable for an op that was
+        // previously infinitely loss-prone under the same contention.
+        let busy_start = timer_get_count();
         let mut delivered_this_target = false;
         loop {
             if mb.try_deliver(topic_name, data, priority) {
@@ -749,7 +772,7 @@ unsafe fn publish_internal(topic_name: *const u8, data: *const u8, priority: u8)
                 break;
             }
             flow_control_bump(&FLOW_CONTROL_BUSY_RETRIES);
-            if timer_get_count().wrapping_sub(start) >= timeout_cycles {
+            if timer_get_count().wrapping_sub(busy_start) >= timeout_cycles {
                 /* Subscriber never acked the prior message — abandon
                  * this target. The publisher's `delivered` count
                  * correctly excludes this message, distinguishing the
@@ -765,12 +788,20 @@ unsafe fn publish_internal(topic_name: *const u8, data: *const u8, priority: u8)
             continue;
         }
 
+        /* Fresh budget for the ack-wait — the message HAS landed in
+         * the mailbox at this point, and the contract is that
+         * `delivered` counts every target that was both written and
+         * acked. A busy-wait that consumed most of the prior budget
+         * must not cause us to misreport a delivered+acked message
+         * as `delivered=0` (which would mis-credit the NEXT publisher
+         * to the same mailbox on the next round). */
+        let ack_start = timer_get_count();
         loop {
             if mb.ack.load(Ordering::Acquire) != 0 {
                 delivered += 1;
                 break;
             }
-            if timer_get_count().wrapping_sub(start) >= timeout_cycles {
+            if timer_get_count().wrapping_sub(ack_start) >= timeout_cycles {
                 break;
             }
             sched_yield();
@@ -956,7 +987,7 @@ pub extern "C" fn msg_router_receive(
                     continue;
                 }
                 let mb = &TOPICS[i].subs[j].mailbox;
-                if mb.ready.load(Ordering::Acquire) != 0 {
+                if mb.ready.load(Ordering::Acquire) == READY_FULL {
                     let prio = mb.priority.load(Ordering::Acquire) as u8;
                     if best_data.is_null() || prio > best_priority {
                         best_priority = prio;
@@ -978,7 +1009,7 @@ pub extern "C" fn msg_router_receive(
                 continue;
             }
             let mb = &WILDCARD_SUBS[i].mailbox;
-            if mb.ready.load(Ordering::Acquire) != 0 {
+            if mb.ready.load(Ordering::Acquire) == READY_FULL {
                 let prio = mb.priority.load(Ordering::Acquire) as u8;
                 if best_data.is_null() || prio > best_priority {
                     best_priority = prio;
@@ -1029,15 +1060,15 @@ pub extern "C" fn msg_router_ack(component_idx: i32) {
 
         if lr.wildcard_idx >= 0 && (lr.wildcard_idx as usize) < MAX_WILDCARD_SUBS {
             let mb = &mut WILDCARD_SUBS[lr.wildcard_idx as usize].mailbox;
-            if mb.ready.load(Ordering::Acquire) != 0 {
-                mb.ready.store(0, Ordering::Release);
+            if mb.ready.load(Ordering::Acquire) == READY_FULL {
+                mb.ready.store(READY_IDLE, Ordering::Release);
                 mb.ack.store(1, Ordering::Release);
             }
         } else if lr.topic_idx >= 0 && (lr.topic_idx as usize) < MAX_TOPICS
                && lr.sub_idx >= 0 && (lr.sub_idx as usize) < MAX_SUBSCRIBERS {
             let mb = &mut TOPICS[lr.topic_idx as usize].subs[lr.sub_idx as usize].mailbox;
-            if mb.ready.load(Ordering::Acquire) != 0 {
-                mb.ready.store(0, Ordering::Release);
+            if mb.ready.load(Ordering::Acquire) == READY_FULL {
+                mb.ready.store(READY_IDLE, Ordering::Release);
                 mb.ack.store(1, Ordering::Release);
             }
         }


### PR DESCRIPTION
## Summary

Closes #869 via option 2 (reject-when-busy + publisher retry) from the [scope comment](https://github.com/SLM-OS/SLM-Operating-System/issues/869#issuecomment-4468136553).

Pre-fix: two `publish_internal` calls targeting the same mailbox before the subscriber acked the first silently overwrote the first message — both publishers observed the ack and reported `delivered=1`. Lost data, no observable error.

Post-fix: `Mailbox::try_deliver` refuses to overwrite an unacked mailbox. The ack-waiting path (`msg_router_publish` / `_priority`) yields and retries inside the existing `ACK_TIMEOUT_SECS` budget — zero-loss preserved. The nowait path (`msg_router_publish_nowait`) drops and counts — the caller sees the failed delivery in the return value instead of silent loss.

## Changes

**Runtime (`runtime/src/msg_router.rs`)**:
- `Mailbox::deliver` → `Mailbox::try_deliver` returning `bool`.
- `publish_internal`: yield-and-retry on busy mailbox within `ACK_TIMEOUT_SECS`; bumps `FLOW_CONTROL_BUSY_RETRIES`.
- `publish_internal_nowait`: drops on busy mailbox; bumps `FLOW_CONTROL_NOWAIT_DROPS`; failed target excluded from `delivered` return.
- New FFI: `msg_router_flow_control_stats(busy_out, drops_out)` + `msg_router_flow_control_reset()`.

**Tests**:
- `test_msg_router.c::test_publish_nowait_basic_contract` — existing canary, updated. Previously asserted "second nowait publish overwrites the first as #869 documents the limitation"; now asserts "second nowait publish is rejected, `NOWAIT_DROPS` increments, subscriber receives the first message." This is the test the original comment explicitly flagged for update when #869 lands.
- `test_integration.c::test_msg_router_same_mailbox_zero_loss` — NEW. Two publishers on CPUs 1 and 2 emit to the same topic; subscriber on CPU 3 drains. Invariant: subscriber-seen counts == publishers' `delivered` counts.

**Documentation**:
- `runtime/CLAUDE.md` — replaced the "Single-slot mailbox limitation" stub with the new "Mailbox flow control (#869, reject-when-busy)" section. Added "Concurrent-publisher TOCTOU caveat" noting the residual smaller race window (two CPUs both see `ready==0` simultaneously) that only a CAS-loop or queued-mailbox redesign would close.
- `docs/architecture.md` — replaced the "Known limitation" bullet with the new flow-control contract description.

## Test plan

- [x] QEMU virt: `make test` green
- [x] `make kernel PLATFORM=RASPI5`: clean
- [x] `make kernel PLATFORM=JETSON_ORIN_NANO`: clean
- [ ] Hardware revalidation on pi-5-2 or jetson-nano-1 — QEMU's serial TCG hides the publisher race (publishers don't actually run concurrently under TCG), so the new `test_msg_router_same_mailbox_zero_loss` is QEMU-passing-by-accident. Real SMP verification needs hardware. The canary in `test_msg_router.c` does fire on QEMU.

## Notes / out of scope

- A residual TOCTOU window exists where two CPUs racing into `try_deliver` for the same mailbox both observe `ready==0` before either's `ready.store(1)`. The `try_deliver` check closes the larger "deliver-then-deliver-without-yield" window that single-publisher sequential code hits; the smaller cycle-aligned window remains. Closing it requires a CAS-loop redesign (treat `ready` as 0=idle, 2=writing, 1=ready) or the full queued-mailbox option from #869's scope. Both are strictly larger changes; not needed for in-tree workloads today. If a telemetry fan-in or sensor producer trips it on hardware, escalate to one of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)