### PR TITLE
shell: restore bench_xgb_one (PR #910 regression)

### DIFF
--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1133,6 +1133,63 @@ static void bench_policy_one(const char *dev_name,
                  (unsigned long)per_ns, (unsigned long)per_sec);
 }
 
+static void bench_xgb_one(uint32_t iters)
+{
+    /* XGBoost cascade benchmark. Doesn't go through the
+     * inference_device registry — predictions route directly through
+     * the Rust FFI in `runtime/src/sched/xgb.rs`. The cascade must
+     * have been staged + activated via `slm.sched_model_*` before
+     * this bench produces meaningful numbers; otherwise predict()
+     * returns -1 and we report "no cascade active". */
+    if (!rust_sched_xgb_is_active()) {
+        shell_puts("  ai_xgb      (no cascade active — "
+                   "`slm.sched_model_stage('xgboost', path)` first)\r\n");
+        return;
+    }
+
+    /* The Rust predictor uses FP/NEON; mirror the FP context
+     * handling that `sched_xgb.c::ai_xgb_assign_cpu` does so a
+     * timer IRQ that fires mid-loop can't observe an unsaved FP
+     * context. The shell-task dispatcher saves on entry, but a
+     * bench loop running for several seconds widens the window
+     * meaningfully. */
+    FP_CONTEXT_SAVE();
+
+    /* Stash the zero state in a byte buffer rather than `float state[N] =
+     * {0.0f}` because shell_sys.c is compiled under `-mgeneral-regs-only`
+     * — visible FP literals would be rejected by the assembler. The Rust
+     * FFI reinterprets the pointer as `*const f32`; 4-byte alignment is
+     * sufficient and explicit here. */
+    uint8_t state[AI_STATE_DIM * sizeof(float)] __attribute__((aligned(4)));
+    memset(state, 0, sizeof(state));
+    int32_t core = 0, prio = 0, preempt = 0;
+
+    uint64_t t0 = timer_get_count();
+    /* `ok` defends against a mid-bench cascade clear (the early-out
+     * above only catches "active at start"). With a healthy active
+     * cascade the predict FFI always returns 0, so ok == iters in
+     * practice; the per-decision divide below uses ok rather than
+     * iters so an unlikely mid-bench failure doesn't skew the result. */
+    uint32_t ok = 0;
+    for (uint32_t i = 0; i < iters; i++) {
+        if (rust_sched_xgb_predict((const float *)state,
+                                   &core, &prio, &preempt) == 0) {
+            ok++;
+        }
+    }
+    uint64_t t1 = timer_get_count();
+    uint64_t freq = timer_get_frequency();
+    uint64_t total_ns = (t1 - t0) * 1000000000ULL / freq;
+    uint64_t per_ns = ok > 0 ? total_ns / ok : 0;
+    uint64_t per_sec = per_ns > 0 ? 1000000000ULL / per_ns : 0;
+
+    FP_CONTEXT_RESTORE();
+
+    shell_printf("  %-10s  %u/%u ok   %lu ns/decision   %lu decisions/sec\r\n",
+                 "ai_xgb", ok, iters,
+                 (unsigned long)per_ns, (unsigned long)per_sec);
+}
+
 /*
  * Read a corpus file from either FAT (`0:/slmstore/...`) or VFS
  * (`/mnt/files/...`) into a PMM-allocated buffer. Caller frees via
@@ -1342,6 +1399,9 @@ static void bench_sched_policy(void)
     bench_policy_one("cpu-mlp", INF_DTYPE_FP32,
                      AI_STATE_DIM, (uint32_t)AI_SCHED_N_ACTIONS,
                      INF_BUILTIN_HANDLE, 1000);
+
+    /* XGBoost cascade — predict via the Rust FFI directly. */
+    bench_xgb_one(1000);
 
     /* Hailo-8 runs only if a .hef has been loaded (handle != INVALID).
      * The policy stashes the handle via ai_policy_hailo_set_model; we


### PR DESCRIPTION
## Summary

PR #910 (PMU) silently dropped `bench_xgb_one` and its call site inside `bench_sched_policy`. Without it, `bench sched-policy` shows the cpu-mlp row (and hailo-8 if a `.hef` is loaded) but no XGBoost cascade timing — even though the trained cascade is a registered policy and the FFI surface (`rust_sched_xgb_predict`) is intact.

Same class of bug as the `sched_model_kind_id` removal addressed in PR #939: a peripheral xgboost mention got dropped on rebase. PR #939's commit message flagged the `bench_xgb_one` drop as separate scope; this PR closes that gap.

## Two small differences from the pre-#910 form

1. State buffer is now `uint8_t state[AI_STATE_DIM * sizeof(float)] __attribute__((aligned(4)))` + `memset`, not `float state[AI_STATE_DIM]` + `0.0f` loop. `shell_sys.c` is compiled under `-mgeneral-regs-only`, which rejects visible FP literals; the Rust FFI reinterprets the pointer as `*const f32` and 4-byte alignment is explicit. Same behavior, no compiler-flag fight.

2. The `if (rust_sched_xgb_predict(...) == 0) ok++;` is now braced per the kernel style guide; the pre-#910 form was a single-line unbraced `if` which was style-exempt at the time but is cleaner braced now that we're touching the line.

## Test plan

- [x] `make test AI_SCHED=ON` — all 8 `sched_xgb_*` kernel tests PASS, including the `sched_xgb_binary_predict_label` regression from #939. The 8 unrelated test failures are pre-existing on `main` and unchanged.
- [x] `make kernel PLATFORM=RASPI5 AI_SCHED=ON` — clean.
- [x] `make kernel AI_SCHED=ON` — clean (QEMU ARM64).
- [ ] **Hardware sanity check on Pi 5 (deferred)** — pi-5-1 held by Hailo RE Phase 4 (#795), pi-5-2 held by the #61 matrix-capture run. Will verify `bench sched-policy` shows the `ai_xgb` row whenever a board frees up. The bench loop is platform-agnostic; the underlying `rust_sched_xgb_predict` was end-to-end verified on pi-5-2 by PR #939's 1000/1000 `bench xgb-equiv` match, and the FP-context bracketing mirrors `ai_xgb_assign_cpu` which is hardware-tested.

## Related

- PR #910 — regression source
- PR #939 — related companion (restored `sched_model_kind_id` etc.; flagged this drop as out-of-scope)
- #855 — original `ai_xgb` policy
- #58 — XGBoost scheduler umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)