### PR TITLE
eviction: bench xgb-equiv-evict + FFI + mini-corpus regression (consumer side of #932)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -480,6 +480,61 @@ The cascade walker is pure software (no NEON, no FP-tier divergence
 between platforms) so a Jetson run would produce identical numbers;
 not re-run on Jetson for that reason.
 
+#### Eviction equivalence verification (`bench xgb-equiv-evict`)
+
+**Skeleton — consumer side of [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932).** The verb is wired but not yet
+hardware-verified; final shape will depend on
+[#448](https://github.com/SLM-OS/SLM-Operating-System/issues/448)'s
+runtime-blob envelope rework. See `kernel/src/shell_sys.c`'s
+`bench_xgb_equiv_evict` and `runtime/src/lib.rs`'s
+`rust_eviction_xgb_predict_compare` for the in-tree implementations.
+
+The eviction-side analog of the scheduler verb above. The
+`slm-os-page-eviction` exporter emits two corpus files alongside
+`evict.smb`: `test_vectors_xgb_evict.bin` (N × 27 f32 feature vectors)
+and `expected_evict.bin` (N × f32 sigmoid scores from
+`booster.predict()`). Replay the corpus through the active
+on-device XGBoost eviction blob with:
+
+```
+# In the SLM-OS shell, after the eviction blob is staged + activated:
+eviction blob load xgboost 0:/slmstore/evict.smb
+eviction blob activate xgboost
+bench xgb-equiv-evict 0:/slmstore/test_vectors_xgb_evict.bin 0:/slmstore/expected_evict.bin
+```
+
+**Differences from the scheduler verb:**
+
+- **Sigmoid score, not classification triple.** Eviction prediction
+  returns a continuous probability (P(optimal eviction target)) so
+  per-vector comparison uses an absolute tolerance (`1e-4`) rather
+  than integer equality. Tolerance is well above f32 sigmoid
+  round-trip noise (~1e-6) but well below what any structural bug
+  (missed `base_score` fold, wrong tree-walk path) would produce
+  (≥ 0.01).
+- **Bit-pattern comparison wire.** The FFI
+  (`rust_eviction_xgb_predict_compare`) takes `expected_bits` and
+  `tolerance_bits` as raw `uint32_t` IEEE-754 patterns so `shell_sys.c`
+  (compiled under `-mgeneral-regs-only`) never materialises an `f32`
+  in C code. First-mismatch diagnostics print hex patterns; decode with
+  `python3 -c 'import struct;print(struct.unpack("<f", bytes.fromhex("HEX"))[0])'`.
+
+**Hardware verification (deferred):** gated on the consumer-side
+work bundling with #448; corresponding pi-5-2 run will populate the
+result row below the moment the new envelope lands.
+
+| Metric | Value |
+|--------|-------|
+| Match rate | *(deferred — pending #448)* |
+| Per-decision latency | *(deferred)* |
+| First mismatch | *(deferred — expected: none)* |
+
+The `slm-os-page-eviction` PR #3 (merged 2026-05-17) emits the
+`evict.smb` blob and verification corpus in the format this verb
+consumes. The producer side is the canonical source of `.smb` blobs
+for any future "graduate this model into the baked path" workflow
+[(#952)](https://github.com/SLM-OS/SLM-Operating-System/issues/952).
+
 **When to use heuristic scheduling:**
 - Latency-sensitive cooperative workloads
 - Systems with frequent task creation/destruction

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -500,8 +500,8 @@ on-device XGBoost eviction blob with:
 
 ```
 # In the SLM-OS shell, after the eviction blob is staged + activated:
-eviction blob load xgboost 0:/slmstore/evict.smb
-eviction blob activate xgboost
+eviction model load xgboost 0:/slmstore/evict.smb
+eviction model activate xgboost
 bench xgb-equiv-evict 0:/slmstore/test_vectors_xgb_evict.bin 0:/slmstore/expected_evict.bin
 ```
 
@@ -521,17 +521,15 @@ bench xgb-equiv-evict 0:/slmstore/test_vectors_xgb_evict.bin 0:/slmstore/expecte
   in C code. First-mismatch diagnostics print hex patterns; decode with
   `python3 -c 'import struct;print(struct.unpack("<f", bytes.fromhex("HEX"))[0])'`.
 
-**Hardware verification (pending):** consumer-side wiring (FFI,
-shell verb, `eviction blob load/activate`, and host-side mini-corpus
-regression in `rust_run_tests`) is complete; this section will be
-updated with the pi-5-2 result the moment the deploy + replay run
-lands.
+**Pi 5 result (2026-05-17, BCM2712 Cortex-A76 @ 2.4 GHz):**
 
 | Metric | Value |
 |--------|-------|
-| Match rate | *pending pi-5-2 deploy + replay* |
-| Per-decision latency | *pending* |
-| First mismatch | *pending — expected: none (Python's `booster.predict()` ↔ on-device sigmoid agree within `1e-4` per the producer-side parity tests on `slm-os-page-eviction` PR #3)* |
+| Match rate | **100 / 100** |
+| Per-decision latency | **1,429,641 ns (~1.43 ms)** |
+| First mismatch | none |
+
+Closes the on-device side of [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932). The result was captured by exporting an `evict.smb` + 100-vector corpus from `slm-os-page-eviction` (XGBoost model carried from `slm-os-page-sim/data/models/xgb_model.json`), staging both onto pi-5-2 via `labctl sdwire update`, activating the runtime blob via `eviction model load/activate xgboost`, and replaying with `bench xgb-equiv-evict`. The ~1.43 ms/inference is the full 200-tree softmax-sigmoid walk in pure software (no NEON path yet); the scheduler verb's ~240 µs comparison is for the much smaller cascade. Latency-side improvement work is tracked separately under [#108](https://github.com/SLM-OS/SLM-Operating-System/issues/108).
 
 The `slm-os-page-eviction` PR #3 (merged 2026-05-17) emits the
 `evict.smb` blob and verification corpus in the format this verb

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -482,12 +482,14 @@ not re-run on Jetson for that reason.
 
 #### Eviction equivalence verification (`bench xgb-equiv-evict`)
 
-**Skeleton — consumer side of [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932).** The verb is wired but not yet
-hardware-verified; final shape will depend on
-[#448](https://github.com/SLM-OS/SLM-Operating-System/issues/448)'s
-runtime-blob envelope rework. See `kernel/src/shell_sys.c`'s
-`bench_xgb_equiv_evict` and `runtime/src/lib.rs`'s
-`rust_eviction_xgb_predict_compare` for the in-tree implementations.
+Consumer side of [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932),
+bundled into [#448](https://github.com/SLM-OS/SLM-Operating-System/issues/448).
+See `kernel/src/shell_sys.c`'s `bench_xgb_equiv_evict` for the verb,
+`runtime/src/lib.rs`'s `rust_eviction_xgb_predict_compare` for the FFI,
+and the `xgb_equiv_evict_*` checks in `rust_eviction_run_tests` for
+a host-side mini-corpus regression that exercises the same FFI path
+against a Rust-built toy model — this catches plumbing regressions
+in `make test` without needing the producer-side `.smb` on hardware.
 
 The eviction-side analog of the scheduler verb above. The
 `slm-os-page-eviction` exporter emits two corpus files alongside
@@ -519,28 +521,23 @@ bench xgb-equiv-evict 0:/slmstore/test_vectors_xgb_evict.bin 0:/slmstore/expecte
   in C code. First-mismatch diagnostics print hex patterns; decode with
   `python3 -c 'import struct;print(struct.unpack("<f", bytes.fromhex("HEX"))[0])'`.
 
-**Hardware verification (deferred):** gated on the consumer-side
-work bundling with #448; corresponding pi-5-2 run will populate the
-result row below the moment the new envelope lands.
+**Hardware verification (pending):** consumer-side wiring (FFI,
+shell verb, `eviction blob load/activate`, and host-side mini-corpus
+regression in `rust_run_tests`) is complete; this section will be
+updated with the pi-5-2 result the moment the deploy + replay run
+lands.
 
 | Metric | Value |
 |--------|-------|
-| Match rate | *(deferred — pending #448)* |
-| Per-decision latency | *(deferred)* |
-| First mismatch | *(deferred — expected: none)* |
+| Match rate | *pending pi-5-2 deploy + replay* |
+| Per-decision latency | *pending* |
+| First mismatch | *pending — expected: none (Python's `booster.predict()` ↔ on-device sigmoid agree within `1e-4` per the producer-side parity tests on `slm-os-page-eviction` PR #3)* |
 
 The `slm-os-page-eviction` PR #3 (merged 2026-05-17) emits the
 `evict.smb` blob and verification corpus in the format this verb
 consumes. The producer side is the canonical source of `.smb` blobs
 for any future "graduate this model into the baked path" workflow
 [(#952)](https://github.com/SLM-OS/SLM-Operating-System/issues/952).
-
-**When to use heuristic scheduling:**
-- Latency-sensitive cooperative workloads
-- Systems with frequent task creation/destruction
-- Benchmarking and debugging (deterministic behavior)
-
-The latency includes: FP context save, state vector extraction (108 floats from kernel data), 4-layer forward pass (NEON-optimized matvec), action decode and validation, FP context restore. Measured via `test_ai_inference_latency` (100 iterations, average reported by the test).
 
 ---
 

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -453,6 +453,37 @@ extern int32_t rust_sched_xgb_predict(const float *state,
 extern uint32_t rust_eviction_feature_count(void);
 extern size_t rust_eviction_feature_name(uint32_t index, uint8_t *buf, size_t buf_len);
 
+/*
+ * Run the active XGBoost eviction blob's predict_sigmoid against the
+ * supplied 27-feature vector. See `runtime/src/lib.rs` for the full
+ * SAFETY contract and the negative return-code meanings.
+ *
+ * Consumed by `bench xgb-equiv-evict` in shell_sys.c (#932).
+ *
+ * TODO(#448 handoff): the body of this FFI sits on top of the current
+ * eviction blob/policy registry surface. Signature should stay stable
+ * across the #448 envelope rework; only the Rust-side internals need
+ * updating.
+ */
+extern int32_t rust_eviction_xgb_predict(const float *features,
+                                          size_t len,
+                                          float *out_score);
+
+/*
+ * Tolerance-compare variant: returns 0 (match), 1 (mismatch), or
+ * negative (error) without ever exposing an f32 to the caller. Used by
+ * the `bench xgb-equiv-evict` shell verb so shell_sys.c stays
+ * compatible with `-mgeneral-regs-only` (no visible FP literals or
+ * arithmetic). `expected_bits`/`tolerance_bits` are passed as IEEE-754
+ * u32 patterns; `*out_got_bits` is filled with the predicted score's
+ * u32 pattern for diagnostic printing on mismatch.
+ */
+extern int32_t rust_eviction_xgb_predict_compare(const float *features,
+                                                  size_t len,
+                                                  uint32_t expected_bits,
+                                                  uint32_t tolerance_bits,
+                                                  uint32_t *out_got_bits);
+
 /* Workload replay comparison (#117). */
 typedef struct {
     uint8_t  policy_name[32];

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1386,6 +1386,186 @@ cleanup:
     return rc;
 }
 
+/*
+ * `bench xgb-equiv-evict <test-vectors.bin> <expected-evict.bin>`
+ *
+ * Closes #932. Eviction-side analog of `bench xgb-equiv` above.
+ * Replays the slm-os-page-eviction verification corpus
+ * (`test_vectors_xgb_evict.bin` = N × 27 × f32 features,
+ *  `expected_evict.bin`         = N × f32 sigmoid scores from
+ *  `booster.predict()`) through the staged + activated XGBoost
+ * eviction blob and asserts agreement within float tolerance.
+ *
+ * Unlike the scheduler verb, this compares *probabilities* not *labels* —
+ * the on-device f32 sigmoid roundtrip and Python's f64 intermediates
+ * disagree at ~1e-6 noise floor, so the per-vector compare uses an
+ * absolute tolerance well above that. The threshold matters: too tight
+ * and FP rounding causes spurious FAILs; too loose and a real bug
+ * (missed base-margin fold, wrong tree-walk path) can hide. ~1e-4 is
+ * the analog of slm-os-scheduler-ai PR #4's verification posture.
+ *
+ * Exit code:
+ *   0 — all N entries within tolerance
+ *   1 — at least one mismatch (first-mismatch index + delta printed)
+ *   anything else — read / size / staging precondition failure
+ *
+ * TODO(#448 handoff): the no-active-blob precondition check below uses
+ * a per-call `predict` retry that returns -3 when nothing is staged.
+ * Once #448 introduces the structured BlobError reject path described
+ * in its scope, swap to that for an attributable "stage xgboost first"
+ * message instead of the current generic "no active blob" string.
+ */
+#define BENCH_XGB_EQUIV_EVICT_FEATURE_COUNT 27u
+#define BENCH_XGB_EQUIV_EVICT_BYTES_PER_F32 4u
+
+/* IEEE-754 bit pattern for `1.0e-4_f32`. Hardcoded so shell_sys.c
+ * stays under `-mgeneral-regs-only` (no visible float literal).
+ * Recompute with: `python3 -c 'import struct; print(hex(struct.unpack("<I", struct.pack("<f", 1e-4))[0]))'`.
+ * Tolerance picked to be well above f32 sigmoid round-trip noise
+ * (~1e-6) but well below what any structural bug (missed base
+ * margin, wrong tree walk) would produce (≥ 0.01). Mirror of
+ * verify_predictions(tolerance=1e-4) in page-eviction. */
+#define BENCH_XGB_EQUIV_EVICT_TOL_BITS 0x38d1b717u
+
+static int bench_xgb_equiv_evict(const char *vec_path, const char *exp_path)
+{
+    uint8_t *vec_buf = NULL, *exp_buf = NULL;
+    size_t vec_len = 0, exp_len = 0;
+    size_t vec_pages = 0, exp_pages = 0;
+    int rc = -1;
+
+    /* Both corpus files. Same FAT-vs-VFS dispatch as the scheduler
+     * verb above, via the shared `xgb_equiv_read_corpus` helper. */
+    if (xgb_equiv_read_corpus(vec_path, "vectors",
+                              &vec_buf, &vec_len, &vec_pages) != 0) {
+        goto cleanup;
+    }
+    if (xgb_equiv_read_corpus(exp_path, "expected",
+                              &exp_buf, &exp_len, &exp_pages) != 0) {
+        goto cleanup;
+    }
+
+    /* 27 × f32 per input vector; 1 × f32 per expected score. */
+    const size_t vec_stride =
+        (size_t)BENCH_XGB_EQUIV_EVICT_FEATURE_COUNT *
+        BENCH_XGB_EQUIV_EVICT_BYTES_PER_F32;
+    const size_t exp_stride = BENCH_XGB_EQUIV_EVICT_BYTES_PER_F32;
+    if ((vec_len % vec_stride) != 0) {
+        shell_printf("xgb-equiv-evict: '%s' size %u is not a multiple "
+                     "of %u (27-d f32 vectors)\r\n",
+                     vec_path, (unsigned)vec_len, (unsigned)vec_stride);
+        goto cleanup;
+    }
+    if ((exp_len % exp_stride) != 0) {
+        shell_printf("xgb-equiv-evict: '%s' size %u is not a multiple "
+                     "of 4 (f32 scores)\r\n",
+                     exp_path, (unsigned)exp_len);
+        goto cleanup;
+    }
+    size_t n_vec = vec_len / vec_stride;
+    size_t n_exp = exp_len / exp_stride;
+    if (n_vec != n_exp) {
+        shell_printf("xgb-equiv-evict: vector count %u != "
+                     "score count %u\r\n",
+                     (unsigned)n_vec, (unsigned)n_exp);
+        goto cleanup;
+    }
+
+    /* Treat the input buffer as a flat `const float *` (pointer math
+     * only; no FP arithmetic) and the expected buffer as a `const
+     * uint32_t *` of IEEE-754 bit patterns. The Rust FFI handles all
+     * actual FP. */
+    const float *vectors = (const float *)vec_buf;
+    const uint32_t *expected_bits = (const uint32_t *)exp_buf;
+
+    /* The Rust predictor uses FP/NEON inside the FFI; bracket the
+     * loop with FP_CONTEXT_SAVE/RESTORE so a timer IRQ that fires
+     * mid-bench can't observe an unsaved FP context. */
+    FP_CONTEXT_SAVE();
+
+    uint32_t mismatches = 0;
+    int32_t first_idx = -1;
+    uint32_t first_got_bits = 0, first_exp_bits = 0;
+    uint64_t t0 = timer_get_count();
+    int32_t predict_failed_rc = 0;
+    for (size_t i = 0; i < n_vec; i++) {
+        const float *features =
+            &vectors[i * BENCH_XGB_EQUIV_EVICT_FEATURE_COUNT];
+        uint32_t got_bits = 0;
+        int32_t rrc = rust_eviction_xgb_predict_compare(
+            features,
+            BENCH_XGB_EQUIV_EVICT_FEATURE_COUNT,
+            expected_bits[i],
+            BENCH_XGB_EQUIV_EVICT_TOL_BITS,
+            &got_bits);
+        if (rrc < 0) {
+            predict_failed_rc = rrc;
+            mismatches = (uint32_t)(n_vec - i);
+            first_idx = (int32_t)i;
+            break;
+        }
+        if (rrc == 1) {
+            if (first_idx < 0) {
+                first_idx = (int32_t)i;
+                first_got_bits = got_bits;
+                first_exp_bits = expected_bits[i];
+            }
+            mismatches++;
+        }
+    }
+    uint64_t t1 = timer_get_count();
+
+    FP_CONTEXT_RESTORE();
+
+    if (predict_failed_rc != 0) {
+        const char *why =
+            predict_failed_rc == -1 ? "bad arg" :
+            predict_failed_rc == -2 ? "ai_eviction off" :
+            predict_failed_rc == -3 ? "no active XGBoost blob "
+                                       "(stage + activate first via "
+                                       "`eviction blob load xgboost ...`)" :
+            predict_failed_rc == -4 ? "blob parse failed" :
+            "unknown";
+        shell_printf("xgb-equiv-evict: predict FFI failed at i=%d "
+                     "(rc=%d, %s)\r\n",
+                     (int)first_idx, (int)predict_failed_rc, why);
+        goto cleanup;
+    }
+
+    uint64_t freq = timer_get_frequency();
+    uint64_t total_ns = (t1 - t0) * 1000000000ULL / freq;
+    uint64_t per_ns = n_vec > 0 ? total_ns / n_vec : 0;
+
+    shell_printf("xgb-equiv-evict: %u/%u match (tol=1e-4)   "
+                 "%lu ns/predict   %s\r\n",
+                 (unsigned)(n_vec - mismatches), (unsigned)n_vec,
+                 (unsigned long)per_ns,
+                 mismatches == 0 ? "PASS" : "FAIL");
+    if (mismatches > 0) {
+        /* IEEE-754 hex bit-patterns — shell_printf has no %f on every
+         * platform build, and pretty-printing floats from C under
+         * `-mgeneral-regs-only` would require yet more FP boilerplate.
+         * Decode externally with:
+         *   python3 -c 'import struct;print(struct.unpack("<f", bytes.fromhex("HEX"))[0])'
+         */
+        shell_printf("  first mismatch at i=%d: got=0x%08x exp=0x%08x "
+                     "(IEEE-754 f32 bit-patterns)\r\n",
+                     (int)first_idx,
+                     (unsigned)first_got_bits, (unsigned)first_exp_bits);
+    }
+
+    rc = mismatches == 0 ? 0 : 1;
+
+cleanup:
+    if (vec_buf) {
+        pmm_free_pages(vec_buf, vec_pages);
+    }
+    if (exp_buf) {
+        pmm_free_pages(exp_buf, exp_pages);
+    }
+    return rc;
+}
+
 static void bench_sched_policy(void)
 {
     /* CPU-MLP is built-in; use INF_BUILTIN_HANDLE. Hailo needs a
@@ -2249,6 +2429,19 @@ int cmd_bench(int argc, char *argv[])
             return 1;
         }
         return bench_xgb_equiv(argv[2], argv[3]);
+    } else if (strcmp(argv[1], "xgb-equiv-evict") == 0) {
+        if (argc < 4) {
+            shell_puts("Usage: bench xgb-equiv-evict <test-vectors.bin> "
+                       "<expected-evict.bin>\r\n"
+                       "  test-vectors.bin   N x 27 x f32 little-endian\r\n"
+                       "  expected-evict.bin N x f32 sigmoid scores from "
+                       "slm-os-page-eviction's exporter\r\n"
+                       "Stage + activate the eviction blob first via "
+                       "`eviction blob load xgboost <path>` then "
+                       "`eviction blob activate xgboost`.\r\n");
+            return 1;
+        }
+        return bench_xgb_equiv_evict(argv[2], argv[3]);
 #endif
     } else if (strcmp(argv[1], "infer-stress") == 0) {
         /* Concurrent inference stress workload (#860).

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1523,7 +1523,7 @@ static int bench_xgb_equiv_evict(const char *vec_path, const char *exp_path)
             predict_failed_rc == -2 ? "ai_eviction off" :
             predict_failed_rc == -3 ? "no active XGBoost blob "
                                        "(stage + activate first via "
-                                       "`eviction blob load xgboost ...`)" :
+                                       "`eviction model load xgboost ...`)" :
             predict_failed_rc == -4 ? "blob parse failed" :
             "unknown";
         shell_printf("xgb-equiv-evict: predict FFI failed at i=%d "
@@ -2437,8 +2437,8 @@ int cmd_bench(int argc, char *argv[])
                        "  expected-evict.bin N x f32 sigmoid scores from "
                        "slm-os-page-eviction's exporter\r\n"
                        "Stage + activate the eviction blob first via "
-                       "`eviction blob load xgboost <path>` then "
-                       "`eviction blob activate xgboost`.\r\n");
+                       "`eviction model load xgboost <path>` then "
+                       "`eviction model activate xgboost`.\r\n");
             return 1;
         }
         return bench_xgb_equiv_evict(argv[2], argv[3]);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2153,6 +2153,172 @@ pub extern "C" fn rust_eviction_feature_count() -> u32 {
     { 0 }
 }
 
+/// Run the active XGBoost eviction blob's `predict_sigmoid` against the
+/// supplied 27-feature vector. Writes the resulting probability into
+/// `*out_score` and returns 0. Returns negative on failure:
+///
+/// - `-1` : NULL pointer or `len != 27`
+/// - `-2` : ai_eviction feature not compiled in
+/// - `-3` : no active XGBoost eviction blob staged
+/// - `-4` : staged blob failed to parse (corrupt or out-of-sync)
+///
+/// The verb-side caller (`bench xgb-equiv-evict` in
+/// `kernel/src/shell_sys.c`) compares the returned score against a
+/// Python-generated expected corpus within a small tolerance (sigmoid
+/// f32 round-trip; ~1e-4 is conservative).
+///
+/// TODO(#448 handoff): once #448's envelope/policy interface lands, the
+/// "fetch active blob + parse + predict" body below likely collapses to a
+/// single registry call (e.g. `with_active_policy(BlobKind::XGBoost, ...)`).
+/// The FFI signature itself is independent of envelope shape and should
+/// stay stable — only the internals need rework.
+///
+/// SAFETY (caller contract): `features` must point to `len`
+/// contiguous `f32`s, 4-byte aligned (every `float features[N]` on the
+/// C side satisfies this naturally). `out_score` must be non-null and
+/// writable.
+#[no_mangle]
+pub unsafe extern "C" fn rust_eviction_xgb_predict(
+    features: *const f32,
+    len: usize,
+    out_score: *mut f32,
+) -> i32 {
+    #[cfg(not(feature = "ai_eviction"))]
+    {
+        let _ = (features, len, out_score);
+        -2
+    }
+    #[cfg(feature = "ai_eviction")]
+    {
+        if features.is_null() || out_score.is_null() {
+            return -1;
+        }
+        // Hardcoded against `runtime/src/mm/eviction/runtime_xgboost.rs::FEATURE_COUNT`.
+        // A model trained against a different feature schema would parse
+        // successfully against the runtime engine (which only checks
+        // node feature_idx bounds) but predict on the wrong slots —
+        // catching here surfaces the mismatch at the verification verb
+        // rather than as silently-wrong scheduling decisions.
+        if len != 27 {
+            return -1;
+        }
+        // SAFETY: caller contract — `features` points to `len` f32s,
+        // aligned. The fixed-size borrow is safe because `len == 27`
+        // checked above.
+        let slice: &[f32] = core::slice::from_raw_parts(features, 27);
+        let block: mm::eviction::BlockFeatures = match slice.try_into() {
+            Ok(arr) => arr,
+            Err(_) => return -1,
+        };
+
+        // Get the active blob, parse, predict. Parsing per call costs
+        // ~µs for a ~30 KB blob; fine for an equivalence-verb that
+        // runs once-per-vector. The production policy
+        // (`XGBoostPolicy::refresh_runtime_cache`) caches the parsed
+        // model by checksum to avoid this cost on the hot path; the
+        // verb intentionally bypasses that cache so each call goes
+        // straight from on-disk bytes to prediction.
+        let parsed = match mm::eviction::active_blob(
+            mm::eviction::BlobKind::XGBoost,
+        ) {
+            Some(b) => b,
+            None => return -3,
+        };
+        let model = match mm::eviction::runtime_xgboost::parse_payload(
+            &parsed.payload,
+        ) {
+            Ok(m) => m,
+            Err(_) => return -4,
+        };
+        let score = model.predict(&block);
+        *out_score = score;
+        0
+    }
+}
+
+/// Compare the active XGBoost eviction blob's prediction against a
+/// reference score within an absolute tolerance, returning a tristate:
+///
+/// - `0`  : prediction is within `tolerance` of `expected`
+/// - `1`  : prediction is outside tolerance (mismatch)
+/// - `<0` : same negative return codes as `rust_eviction_xgb_predict`
+///
+/// `expected_bits` and `tolerance_bits` are passed as raw u32 IEEE-754
+/// bit patterns so the C caller (`bench xgb-equiv-evict` shell verb,
+/// compiled under `-mgeneral-regs-only`) never has to materialise an
+/// f32 in C code. `out_got_bits` always receives the predicted score's
+/// bit pattern on the success paths (rc 0 or 1) for diagnostic
+/// printing of the first mismatch.
+///
+/// This FFI is the eviction-side counterpart to the scheduler's
+/// `rust_sched_xgb_predict` integer-label compare; eviction prediction
+/// is a continuous sigmoid score so the threshold-versus-tolerance
+/// shape differs.
+///
+/// TODO(#448 handoff): the body shares the per-call parse pattern with
+/// `rust_eviction_xgb_predict`. When that path collapses (or grows a
+/// shared parsed-model cache), this should reuse the same helper.
+///
+/// SAFETY (caller contract): same as `rust_eviction_xgb_predict` plus
+/// `out_got_bits` must be non-null and writable.
+#[no_mangle]
+pub unsafe extern "C" fn rust_eviction_xgb_predict_compare(
+    features: *const f32,
+    len: usize,
+    expected_bits: u32,
+    tolerance_bits: u32,
+    out_got_bits: *mut u32,
+) -> i32 {
+    #[cfg(not(feature = "ai_eviction"))]
+    {
+        let _ = (features, len, expected_bits, tolerance_bits, out_got_bits);
+        -2
+    }
+    #[cfg(feature = "ai_eviction")]
+    {
+        if features.is_null() || out_got_bits.is_null() {
+            return -1;
+        }
+        if len != 27 {
+            return -1;
+        }
+        let slice: &[f32] = core::slice::from_raw_parts(features, 27);
+        let block: mm::eviction::BlockFeatures = match slice.try_into() {
+            Ok(arr) => arr,
+            Err(_) => return -1,
+        };
+        let parsed = match mm::eviction::active_blob(
+            mm::eviction::BlobKind::XGBoost,
+        ) {
+            Some(b) => b,
+            None => return -3,
+        };
+        let model = match mm::eviction::runtime_xgboost::parse_payload(
+            &parsed.payload,
+        ) {
+            Ok(m) => m,
+            Err(_) => return -4,
+        };
+        let score = model.predict(&block);
+        *out_got_bits = score.to_bits();
+
+        let expected = f32::from_bits(expected_bits);
+        let tolerance = f32::from_bits(tolerance_bits);
+        let delta = if score >= expected {
+            score - expected
+        } else {
+            expected - score
+        };
+        // NaN propagates through `>` as false; treat NaN delta as a
+        // mismatch since it can't be within any finite tolerance.
+        if delta.is_nan() || delta > tolerance {
+            1
+        } else {
+            0
+        }
+    }
+}
+
 /// Copy the name of feature `index` into `buf` (NUL-terminated).
 /// Returns bytes written (excl NUL), or 0 if index is out of range
 /// or ai_eviction is off.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3594,6 +3594,117 @@ pub extern "C" fn rust_eviction_run_tests() -> i32 {
             mm::eviction::clear_blob(mm::eviction::BlobKind::XGBoost);
         }
 
+        // Eviction equivalence FFI mini-corpus (#932 / #448 consumer bundle).
+        //
+        // Exercises the exact same active-blob -> FFI -> predict path
+        // the shell verb `bench xgb-equiv-evict` walks on hardware, but
+        // against a Rust-built tiny model so the test runs in QEMU
+        // without producer-side fixtures. The producer corpus
+        // (slm-os-page-eviction PR #3's `test_vectors_xgb_evict.bin`
+        // + `expected_evict.bin`) covers Python equivalence; this
+        // covers FFI plumbing (feature-slice marshaling, blob registry
+        // lookup, sigmoid bit-pattern roundtrip, tolerance comparator)
+        // so a regression there fails in `make test` instead of waiting
+        // for a pi-5-2 deploy.
+        {
+            mm::eviction::clear_blob(mm::eviction::BlobKind::XGBoost);
+            // 1-tree, 3-node split on feature[0] @ 0.5; leaves
+            // -1.5 / +1.5 -> sigmoid ~ 0.182 / 0.818, well clear of
+            // the 0.5 decision boundary.
+            let payload =
+                mm::eviction::runtime_xgboost::build_test_payload_first_feature_split(
+                    0.5, -1.5, 1.5);
+            let blob = mm::eviction::blob::build_test_blob(
+                mm::eviction::BlobKind::XGBoost, &payload);
+            let parsed = mm::eviction::parse_blob(&blob);
+            check!(b"xgb_equiv_evict_mini_corpus_blob_parses\0",
+                   parsed.is_ok());
+            if let Ok(parsed) = parsed {
+                let staged = mm::eviction::stage_parsed(parsed).is_ok();
+                check!(b"xgb_equiv_evict_mini_corpus_blob_stages\0",
+                       staged);
+                let activated = mm::eviction::activate_blob(
+                    mm::eviction::BlobKind::XGBoost).is_ok();
+                check!(b"xgb_equiv_evict_mini_corpus_blob_activates\0",
+                       activated);
+
+                if staged && activated {
+                    // 4 vectors straddling the split threshold.
+                    let mut vectors: [[f32; 27]; 4] = [[0.0; 27]; 4];
+                    vectors[0][0] = 0.0;
+                    vectors[1][0] = 0.4;
+                    vectors[2][0] = 0.6;
+                    vectors[3][0] = 1.0;
+                    // Engine-vs-FFI path is f32-deterministic, so 1e-6
+                    // tolerance catches real divergence while
+                    // tolerating any theoretical 1-ULP rounding from a
+                    // future compiler/libm change.
+                    let tol_bits: u32 = (1.0e-6_f32).to_bits();
+
+                    let model = mm::eviction::runtime_xgboost::parse_payload(
+                        &payload);
+                    let mut compare_all_pass = true;
+                    let mut predict_all_pass = true;
+                    if let Ok(model) = model {
+                        for vec in vectors.iter() {
+                            let expected = model.predict(vec);
+                            let exp_bits = expected.to_bits();
+
+                            // Compare-FFI: tolerance path.
+                            let mut got_bits: u32 = 0;
+                            let cmp_rc = unsafe {
+                                rust_eviction_xgb_predict_compare(
+                                    vec.as_ptr(),
+                                    27,
+                                    exp_bits,
+                                    tol_bits,
+                                    &mut got_bits as *mut u32,
+                                )
+                            };
+                            if cmp_rc != 0 {
+                                compare_all_pass = false;
+                            }
+
+                            // Predict-FFI: bit-exact path.
+                            let mut score: f32 = f32::NAN;
+                            let pred_rc = unsafe {
+                                rust_eviction_xgb_predict(
+                                    vec.as_ptr(),
+                                    27,
+                                    &mut score as *mut f32,
+                                )
+                            };
+                            if pred_rc != 0
+                                || score.to_bits() != exp_bits
+                            {
+                                predict_all_pass = false;
+                            }
+                        }
+                    } else {
+                        compare_all_pass = false;
+                        predict_all_pass = false;
+                    }
+                    check!(b"xgb_equiv_evict_ffi_compare_within_tolerance\0",
+                           compare_all_pass);
+                    check!(b"xgb_equiv_evict_ffi_predict_bit_exact\0",
+                           predict_all_pass);
+
+                    // Bad-arg surface: wrong length -> -1, no UB.
+                    let mut score: f32 = 0.0;
+                    let bad_len_rc = unsafe {
+                        rust_eviction_xgb_predict(
+                            vectors[0].as_ptr(),
+                            26,
+                            &mut score as *mut f32,
+                        )
+                    };
+                    check!(b"xgb_equiv_evict_ffi_rejects_wrong_feature_count\0",
+                           bad_len_rc == -1);
+                }
+            }
+            mm::eviction::clear_blob(mm::eviction::BlobKind::XGBoost);
+        }
+
         // MlpPolicy: same smoke tests.
         {
             let mut p = MlpPolicy::new();


### PR DESCRIPTION
## Summary

Lands the SLM-OS consumer side of [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932) — on-device vs. trainer numerical equivalence for the XGBoost eviction policy. Producer side already shipped in [slm-os-page-eviction PR #3](https://github.com/SLM-OS/slm-os-page-eviction/pull/3).

**Hardware verification: 100/100 PASS on pi-5-2** (2026-05-17, ~1.43 ms/inference). Result populated in `docs/benchmarks.md`. Merging this PR closes #932.

Per scope decision on [#448](https://github.com/SLM-OS/SLM-Operating-System/issues/448#issuecomment-4468731052), this is the "bundle close-out" path — finish the consumer side now, leave the larger envelope generalization (tensor tables, forward-compat policy, platform metadata) open under #448 as a separately-tracked follow-up.

## What's in this PR

- `runtime/src/lib.rs`:
  - `rust_eviction_xgb_predict` and `rust_eviction_xgb_predict_compare` FFIs (behind `ai_eviction`, with no-op stubs when off). Bit-pattern in/out so the kernel side can stay `-mgeneral-regs-only`.
  - `xgb_equiv_evict_*` mini-corpus regression inside `rust_eviction_run_tests` — builds a tiny XGB1 payload, stages+activates it through the same blob registry the FFI consults, walks 4 vectors through both FFIs, asserts bit-exact engine round-trip + tolerance comparator + wrong-length rejection. Runs under default `make test`; no producer-side artifacts needed.
- `kernel/include/slm_ffi.h`: matching extern declarations.
- `kernel/src/shell_sys.c`: `bench xgb-equiv-evict <vec_path> <exp_path>` verb wired into the AI-scheduler shell. Reuses `xgb_equiv_read_corpus` for FAT/VFS path dispatch. Tolerance hardcoded as IEEE-754 bit pattern (`0x38d1b717` ≈ `1e-4_f32`) to avoid float literals in `-mgeneral-regs-only` code. Also: fixed a verb-name typo (`eviction blob load` → `eviction model load`) in the bench-verb usage banner and rc=-3 hint, found during the pi-5-2 verification run.
- `docs/benchmarks.md`: full section for the verb — wire format, tolerance rationale, decode-with-Python snippet, and the pi-5-2 hardware result.

## Verification flow used on pi-5-2

```
# Generate corpus from the trained XGBoost model
python scripts/export_to_slmos.py \
  --xgb-model ~/projects/slm-os-page-sim/data/models/xgb_model.json \
  --output-dir /tmp/evict-export \
  --smb-output-dir /tmp/evict-export --smb-corpus-size 100

# Flash kernel + stage corpus in one shot, reboot
labctl sdwire update pi-5-2 -p 1 \
  -c build/kernel/slmos.bin:kernel_2712.img \
  -c /tmp/evict-export/evict.smb:slmstore/evict.smb \
  -c /tmp/evict-export/test_vectors_xgb_evict.bin:slmstore/test_vectors_xgb_evict.bin \
  -c /tmp/evict-export/expected_evict.bin:slmstore/expected_evict.bin --reboot

# In SLM-OS shell
eviction model load xgboost 0:/slmstore/evict.smb
eviction model activate xgboost
bench xgb-equiv-evict 0:/slmstore/test_vectors_xgb_evict.bin 0:/slmstore/expected_evict.bin
# -> xgb-equiv-evict: 100/100 match (tol=1e-4)   1429641 ns/predict   PASS
```

## What's still open after this PR

- **#448 envelope generalization** — tensor tables, forward-compat policy, platform constraint metadata. Out of scope for this bundle per user decision; #448 stays open as the umbrella tracker. The TODO(#448 handoff) markers in the FFI bodies point at the call sites that should migrate when that work happens.
- **#953 (xgb-as-default decision gate)** — unblocked once this PR merges (since merging closes #932).

## Pre-existing baseline issue surfaced

- [#957](https://github.com/SLM-OS/SLM-Operating-System/issues/957) — `make test EVICTION_MODELS=ON` fails on an unused import in the generated `xgb_policy_generated.rs`. Filed during this work; not blocking (default `make test` is the CLAUDE.md-required path).

## Test plan

- [x] `make test` — green; new `xgb_equiv_evict_*` checks ran under the `ai_eviction` feature (default-on)
- [x] `make kernel PLATFORM=RASPI5` — clean build, deployed to pi-5-2
- [x] Hardware verification on pi-5-2 — 100/100 PASS, ~1.43 ms/inference
- [x] No new warnings

## Related

- Closes #932
- #448 — consumer-side scope absorbed here; envelope generalization remains open
- #957 — pre-existing `EVICTION_MODELS=ON` build break (separate)
- [slm-os-page-eviction PR #3](https://github.com/SLM-OS/slm-os-page-eviction/pull/3) — producer side, already merged
- #952 — xgb model graduation pathway (downstream of equivalence passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)