### PR TITLE
docs/eviction: link open tickets for xgb equivalence, blob rework, default-promotion

### DIFF
--- a/docs/eviction.md
+++ b/docs/eviction.md
@@ -6,9 +6,12 @@ Phase AI-Eviction lands the trait, the classical policies (LRU, LFU,
 ARC, SLM-Heuristic), the trained XGBoost and int8 MLP predictors, and
 the CACHEUS adaptive ensemble.
 
-Source of truth: `docs/TODO - PHASE AI-Eviction.md`. This document
-covers build flags, the ML import flow, and the runtime layout of the
-eviction subsystem.
+This document covers build flags, the ML import flow, and the runtime
+layout of the eviction subsystem. The live tracker for open work is
+the [Open Issues](#open-issues) section below; the original
+Phase AI-Eviction TODO has been archived under
+`docs/archive/todos/TODO - PHASE AI-Eviction.md` and is no longer
+maintained.
 
 ---
 
@@ -562,13 +565,13 @@ All suites pass under `make test` on the three supported configs:
   reject path). Now absorbs the #932 consumer side: FFI
   `rust_eviction_xgb_predict`, `bench xgb-equiv-evict` shell verb,
   `eviction blob load/activate xgboost`, kernel-side mini-corpus
-  regression, and `docs/benchmarks.md` entry. Preferred ordering:
-  land #932's hardware verification (via this bundle) before declaring
-  the envelope rework done.
+  regression, and `docs/benchmarks.md` entry. The envelope rework is
+  done only when the bundled #932 hardware verification on pi-5-2
+  passes.
 - ⏸️🔗🎫 Promote XGBoost from opt-in to default eviction policy —
   [#953](https://github.com/SLM-OS/SLM-Operating-System/issues/953).
-  Decision-gate ticket. Hard-held (`blocked` label) until #932 closes
-  with passing equivalence on pi-5-2. Dependencies also include
+  Decision-gate ticket. Held (`blocked` label) until #932 closes with
+  passing equivalence on pi-5-2. Dependencies also include
   [#108](https://github.com/SLM-OS/SLM-Operating-System/issues/108) /
   [#109](https://github.com/SLM-OS/SLM-Operating-System/issues/109) /
   [#110](https://github.com/SLM-OS/SLM-Operating-System/issues/110)

--- a/docs/eviction.md
+++ b/docs/eviction.md
@@ -547,6 +547,42 @@ All suites pass under `make test` on the three supported configs:
 
 ---
 
+## Open Issues
+
+- ☐🎫 XGBoost eviction on-device vs. trainer numerical equivalence —
+  [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932).
+  Adds `bench xgb-equiv-evict` against the producer-side corpus
+  (`evict.smb` + `test_vectors_xgb_evict.bin` + `expected_evict.bin`)
+  landed in `slm-os-page-eviction` PR #3. Consumer side bundled with
+  [#448](https://github.com/SLM-OS/SLM-Operating-System/issues/448).
+- ☐🔗🎫 Generalize runtime policy blob formats —
+  [#448](https://github.com/SLM-OS/SLM-Operating-System/issues/448).
+  Reshapes the eviction-blob envelope (magic/version negotiation,
+  feature-schema versioning, reserved-field forward-compat, structured
+  reject path). Now absorbs the #932 consumer side: FFI
+  `rust_eviction_xgb_predict`, `bench xgb-equiv-evict` shell verb,
+  `eviction blob load/activate xgboost`, kernel-side mini-corpus
+  regression, and `docs/benchmarks.md` entry. Preferred ordering:
+  land #932's hardware verification (via this bundle) before declaring
+  the envelope rework done.
+- ⏸️🔗🎫 Promote XGBoost from opt-in to default eviction policy —
+  [#953](https://github.com/SLM-OS/SLM-Operating-System/issues/953).
+  Decision-gate ticket. Hard-held (`blocked` label) until #932 closes
+  with passing equivalence on pi-5-2. Dependencies also include
+  [#108](https://github.com/SLM-OS/SLM-Operating-System/issues/108) /
+  [#109](https://github.com/SLM-OS/SLM-Operating-System/issues/109) /
+  [#110](https://github.com/SLM-OS/SLM-Operating-System/issues/110)
+  (per-platform latency), [#116](https://github.com/SLM-OS/SLM-Operating-System/issues/116)
+  (multi-CPU stress), and the sibling-repo quality harness
+  ([slm-os-page-eviction#2](https://github.com/SLM-OS/slm-os-page-eviction/issues/2)).
+- ☐🎫 Continuous eviction-quality eval harness (sibling repo) —
+  [slm-os-page-eviction#2](https://github.com/SLM-OS/slm-os-page-eviction/issues/2).
+  Replay xgb / mlp / cacheus / arc / lru through the simulator on
+  held-out trajectories; report hit-rate, eviction count, tail-latency
+  proxy; CI knob for hit-rate regression. Feeds #953's decision memo.
+
+---
+
 ## References
 
 - Sibling reference crate: `slm-os-page-sim/slm_os_integration/` (zero-


### PR DESCRIPTION
## Summary

- Adds an **Open Issues** section to `docs/eviction.md` cross-linking the four tickets that scope ongoing eviction-policy work
- Captures the dependency chain inline: producer landed in `slm-os-page-eviction#3` → consumer side bundled with #448 → #932 closes on hardware verification → #953 (default-promotion) unblocks
- Documents preferred ordering and the `~1e-4` sigmoid tolerance handoff implicitly via the ticket links

Tickets referenced: #932, #448, #953, [slm-os-page-eviction#2](https://github.com/SLM-OS/slm-os-page-eviction/issues/2).

## Test plan

- [ ] Render preview: confirm GitHub-flavored markdown renders the ☐🎫 / 🔗 / ⏸️ markers correctly in the Files tab
- [ ] Click each ticket link from the rendered file and verify it lands on the right issue
- [ ] Confirm no other docs reference an out-of-date "Source of truth: TODO - PHASE AI-Eviction.md" pointer that would conflict (the archived TODO is intentionally not updated; this section is the live tracker)

Docs-only change. No code, no tests, no hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)