### PR TITLE
eviction: pi-5-2 1000-vector hardware verification + remove #448 TODOs

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -482,8 +482,7 @@ not re-run on Jetson for that reason.
 
 #### Eviction equivalence verification (`bench xgb-equiv-evict`)
 
-Consumer side of [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932),
-bundled into [#448](https://github.com/SLM-OS/SLM-Operating-System/issues/448).
+Closes [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932).
 See `kernel/src/shell_sys.c`'s `bench_xgb_equiv_evict` for the verb,
 `runtime/src/lib.rs`'s `rust_eviction_xgb_predict_compare` for the FFI,
 and the `xgb_equiv_evict_*` checks in `rust_eviction_run_tests` for
@@ -525,11 +524,23 @@ bench xgb-equiv-evict 0:/slmstore/test_vectors_xgb_evict.bin 0:/slmstore/expecte
 
 | Metric | Value |
 |--------|-------|
-| Match rate | **100 / 100** |
-| Per-decision latency | **1,429,641 ns (~1.43 ms)** |
+| Match rate | **1000 / 1000** (tol = 1e-4) |
+| Per-decision latency | **1,407,823 ns (~1.41 ms)** |
 | First mismatch | none |
 
-Closes the on-device side of [#932](https://github.com/SLM-OS/SLM-Operating-System/issues/932). The result was captured by exporting an `evict.smb` + 100-vector corpus from `slm-os-page-eviction` (XGBoost model carried from `slm-os-page-sim/data/models/xgb_model.json`), staging both onto pi-5-2 via `labctl sdwire update`, activating the runtime blob via `eviction model load/activate xgboost`, and replaying with `bench xgb-equiv-evict`. The ~1.43 ms/inference is the full 200-tree softmax-sigmoid walk in pure software (no NEON path yet); the scheduler verb's ~240 µs comparison is for the much smaller cascade. Latency-side improvement work is tracked separately under [#108](https://github.com/SLM-OS/SLM-Operating-System/issues/108).
+Captured by exporting an `evict.smb` + 1000-vector corpus from
+`slm-os-page-eviction` (XGBoost model carried from
+`slm-os-page-sim/data/models/xgb_model.json`), staging both onto
+pi-5-2 via `labctl sdwire update`, activating the runtime blob via
+`eviction model load/activate xgboost`, and replaying with
+`bench xgb-equiv-evict`. A prior 100-vector run during #955's
+landing produced 100/100 at 1.43 ms; this 10× larger corpus run
+is the closing artifact for #932. The ~1.41 ms/inference is the
+full 200-tree softmax-sigmoid walk in pure software (no NEON path
+yet) plus a blob re-parse on every FFI call (parsed model is
+not cached in the registry); latency-side improvement work is
+tracked separately under
+[#108](https://github.com/SLM-OS/SLM-Operating-System/issues/108).
 
 The `slm-os-page-eviction` PR #3 (merged 2026-05-17) emits the
 `evict.smb` blob and verification corpus in the format this verb

--- a/kernel/include/slm_ffi.h
+++ b/kernel/include/slm_ffi.h
@@ -459,11 +459,6 @@ extern size_t rust_eviction_feature_name(uint32_t index, uint8_t *buf, size_t bu
  * SAFETY contract and the negative return-code meanings.
  *
  * Consumed by `bench xgb-equiv-evict` in shell_sys.c (#932).
- *
- * TODO(#448 handoff): the body of this FFI sits on top of the current
- * eviction blob/policy registry surface. Signature should stay stable
- * across the #448 envelope rework; only the Rust-side internals need
- * updating.
  */
 extern int32_t rust_eviction_xgb_predict(const float *features,
                                           size_t len,

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -1408,12 +1408,6 @@ cleanup:
  *   0 — all N entries within tolerance
  *   1 — at least one mismatch (first-mismatch index + delta printed)
  *   anything else — read / size / staging precondition failure
- *
- * TODO(#448 handoff): the no-active-blob precondition check below uses
- * a per-call `predict` retry that returns -3 when nothing is staged.
- * Once #448 introduces the structured BlobError reject path described
- * in its scope, swap to that for an attributable "stage xgboost first"
- * message instead of the current generic "no active blob" string.
  */
 #define BENCH_XGB_EQUIV_EVICT_FEATURE_COUNT 27u
 #define BENCH_XGB_EQUIV_EVICT_BYTES_PER_F32 4u

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2167,12 +2167,6 @@ pub extern "C" fn rust_eviction_feature_count() -> u32 {
 /// Python-generated expected corpus within a small tolerance (sigmoid
 /// f32 round-trip; ~1e-4 is conservative).
 ///
-/// TODO(#448 handoff): once #448's envelope/policy interface lands, the
-/// "fetch active blob + parse + predict" body below likely collapses to a
-/// single registry call (e.g. `with_active_policy(BlobKind::XGBoost, ...)`).
-/// The FFI signature itself is independent of envelope shape and should
-/// stay stable — only the internals need rework.
-///
 /// SAFETY (caller contract): `features` must point to `len`
 /// contiguous `f32`s, 4-byte aligned (every `float features[N]` on the
 /// C side satisfies this naturally). `out_score` must be non-null and
@@ -2254,10 +2248,6 @@ pub unsafe extern "C" fn rust_eviction_xgb_predict(
 /// `rust_sched_xgb_predict` integer-label compare; eviction prediction
 /// is a continuous sigmoid score so the threshold-versus-tolerance
 /// shape differs.
-///
-/// TODO(#448 handoff): the body shares the per-call parse pattern with
-/// `rust_eviction_xgb_predict`. When that path collapses (or grows a
-/// shared parsed-model cache), this should reuse the same helper.
 ///
 /// SAFETY (caller contract): same as `rust_eviction_xgb_predict` plus
 /// `out_got_bits` must be non-null and writable.


### PR DESCRIPTION
## Summary

- Hardware verification on pi-5-2 (BCM2712 Cortex-A76 @ 2.4 GHz): **1000/1000 match @ 1.41 ms/predict** against the producer-side `evict.smb` from slm-os-page-eviction PR #3, replayed via `bench xgb-equiv-evict`. Independently confirms the 100-vector run that landed inline with #955.
- Removes the four \`TODO(#448 handoff)\` markers carried over from the #955 skeleton. #448 closed without those refactors landing — the current per-call active-blob + parse + predict pattern works correctly. The parse-per-call latency overhead is now noted as latency context in \`docs/benchmarks.md\` rather than as a TODO; file fresh if it ever becomes load-bearing.
- Updates \`docs/benchmarks.md\` result row: 100/100 → 1000/1000 and refreshes the surrounding text (no more "bundled into #448" language).

## Closing #932

#932 was reopened earlier today because its closing criterion (N/N hardware match PASS on pi-5-2) had been met by the 100-vector run but not commented on the issue. This PR's 1000-vector run is the closing artifact; will comment + close once merged.

## Test plan

- [x] \`make kernel AI_SCHED=ON\` (QEMU ARM64) — clean
- [x] \`make kernel PLATFORM=RASPI5 AI_SCHED=ON\` — clean (built for the hardware run)
- [x] pi-5-2 hardware: 1000/1000 PASS, 1.41 ms/predict, no first-mismatch
- [x] All \`git grep "TODO(#448\` / \`bundled into #448\` / \`pending #448\` sites cleaned

## Related

- Closes #932 (on merge)
- #448 (closed — envelope rework)
- slm-os-page-eviction PR #3 (merged — producer side)
- PR #955 (merged — consumer side scaffold this PR completes the cleanup of)

🤖 Generated with [Claude Code](https://claude.com/claude-code)