### PR TITLE
runtime/eviction: fix EVICTION_MODELS=ON unused-import build break (closes #957)

### DIFF
--- a/runtime/src/mm/eviction/generated/xgb_policy_generated.rs
+++ b/runtime/src/mm/eviction/generated/xgb_policy_generated.rs
@@ -5,7 +5,7 @@
 use crate::mm::eviction::policy::BlockFeatures;
 
 /// XGBoost prediction: returns P(optimal eviction target)
-pub fn xgb_predict(features: &[f32; 27]) -> f32 {
+pub fn xgb_predict(features: &BlockFeatures) -> f32 {
     let mut sum = 0.0_f32;
 
     // Tree 0


### PR DESCRIPTION
## Summary

One-line fix to the generated XGBoost eviction predictor signature so the runtime crate's `-D warnings` doesn't reject the build on `EVICTION_MODELS=ON`.

Before:
\`\`\`rust
use crate::mm::eviction::policy::BlockFeatures;  // unused -> error under -D warnings
pub fn xgb_predict(features: &[f32; 27]) -> f32 { ... }
\`\`\`

After:
\`\`\`rust
use crate::mm::eviction::policy::BlockFeatures;
pub fn xgb_predict(features: &BlockFeatures) -> f32 { ... }
\`\`\`

The two types are equivalent (\`BlockFeatures = [f32; 27]\` in \`runtime/src/mm/eviction/policy.rs:45\`) so this is mechanical. The matching upstream fix in \`slm-os-page-sim/src/export/xgb_to_rust.py\` (pending separate PR) keeps the next \`scripts/import_eviction_weights.sh\` run from re-introducing the bug.

## Test plan

- [x] \`make test EVICTION_MODELS=ON\` — clean build, all tests pass
- [x] Default \`make test\` (stub path) — unaffected, still passes
- [x] \`git grep "features: &\[f32; 27\]" runtime/src/mm/eviction/generated\` — only the stub variant remains; stub already uses \`&BlockFeatures\`

## Related

- Closes #957
- Upstream generator fix: slm-os-page-sim PR (to follow)
- Sibling generator fix: slm-os-page-eviction PR (to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)