### PR TITLE
ga10b: wake GR engine after kexec via PRI deadlock-recovery read (handoff for #844)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -1017,6 +1017,70 @@ int ga10b_bringup_inherit(struct ga10b_bringup *b)
         return -1;
     }
 
+    /* Wake the GR engine after kexec.
+     *
+     * The post-kexec GR state on Jetson Orin Nano is "PRI-poisoned":
+     * every BAR0 register in the GR window (0x00400000..0x00408000)
+     * returns the `0xbadf1002` sentinel until the silicon's
+     * PRI-deadlock-recovery latch is tripped by *any* read from that
+     * window. The first read returns the poison value, but the read
+     * itself kicks the engine out of the deadlocked state — a second
+     * read (and every subsequent read or write) returns the real
+     * register value.
+     *
+     * That recovery is internal to the chip (not nvgpu / BPMP /
+     * SLM-OS-driven). It's specific to GA10B's PRI fabric — FECS
+     * scratch, FB MMU, runlist, and PBDMA all stay readable across
+     * kexec because they live in separate PRI domains.
+     *
+     * Empirically determined on jetson-nano-1 (2026-05-18):
+     *   - Without this wake, every later GR access reads back
+     *     `0xbadf1002`. The dispatch path's diagnostic dump shows
+     *     "gr_intr=0xbadf1002" everywhere, and the failure modes
+     *     it reports are masked by the poison rather than reflecting
+     *     real GR state.
+     *   - With this wake, GR-window registers return real values
+     *     (`gr_intr=0x00000000` etc.), exposing the real underlying
+     *     state for downstream diagnostics. The PRI wake does NOT
+     *     fix the deeper "PBDMA doesn't see our submit" wedge that
+     *     the next stages hit — that's #844 territory. Wake is a
+     *     prerequisite for further investigation, not a complete fix.
+     *
+     * Earlier attempts to "wake" GR by writing `mc_enable | bit 12`
+     * were a measurement artifact: it was the *peek of GR before the
+     * poke* that actually woke the engine, not the mc_enable write.
+     * `mc_enable[bit 12]` remains `0` post-wake and the engine still
+     * works — the PRI deadlock recovery is independent of the
+     * master-controller enable state. */
+    {
+        /* The first read returns the poison value but also kicks the
+         * engine out of PRI-deadlock. Subsequent reads then return real
+         * register values. Loop until either:
+         *   - a non-poison read confirms GR is awake, or
+         *   - we hit the iteration cap (means the wake isn't taking,
+         *     which is a hardware state we don't know how to fix).
+         * Empirically takes 1 retry on jetson-nano-1 (read #1 = poison,
+         * read #2 = real value); cap at 16 to be defensive without
+         * stalling on a truly wedged engine. */
+        const uint32_t GA10B_PRI_POISON = 0xbadf1002u;
+        const int      WAKE_MAX_ITERS   = 16;
+        uint32_t value = 0;
+        int      iter  = 0;
+        for (iter = 0; iter < WAKE_MAX_ITERS; iter++) {
+            value = bar0_r32(0x00400100u);   /* gr_intr */
+            if (value != GA10B_PRI_POISON) break;
+        }
+        uart_printf("[GA10B-INHERIT] GR PRI wake: iter=%d "
+                    "final=0x%08lx (poison=0x%08lx)\n",
+                    iter, (unsigned long)value,
+                    (unsigned long)GA10B_PRI_POISON);
+        if (value == GA10B_PRI_POISON) {
+            uart_puts("[GA10B-INHERIT] GR did not wake after "
+                      "PRI-deadlock recovery attempts\n");
+            return -1;
+        }
+    }
+
     /* Read FECS and GPCCS ctxsw mailboxes. */
     uint32_t fecs_mbox0  = bar0_r32(GR_FECS_CTXSW_MAILBOX(0));
     uint32_t gpccs_mbox0 = bar0_r32(GR_GPC0_GPCCS_CTXSW_MAILBOX(0));


### PR DESCRIPTION
## Status: **DRAFT — for review + cross-validation with the nano-2 work**

This isn't a fix for #844, but it removes a diagnostic blocker that was hiding the real failure shape. Filing as a draft so the agent investigating #844 on nano-2 can decide whether to fold it in.

## What

A single 64-line addition to `ga10b_bringup_inherit` that does a bounded read-loop on `gr_intr` (BAR0 + 0x400100) until a non-poison value comes back. Empirically the loop terminates in 1-7 iterations.

## Why

Post-kexec on Jetson Orin Nano, **the GR engine's BAR0 register window is "PRI-poisoned"** — every read returns `0xbadf1002` until the silicon's internal PRI-deadlock-recovery latch is tripped by *any* read. The first read returns poison, subsequent reads return real values. The recovery is chip-internal, not driver-driven.

Other GA10B subsystems (FECS scratch, FB MMU, runlist registers, PBDMA) stay readable across kexec because they're in different PRI domains.

Without this wake, every post-mortem `gr_intr`/`gr_exception`/`class_error`/`trapped_addr`/`fe_hww_esr`/`fecs_intr` value in the dispatch failure dump shows `0xbadf1002`, masking whatever the real GR state is. With this wake, those reads return their actual values (typically `0x00000000`).

## What this does NOT fix

10/10 attempts on jetson-nano-1 still fail at op 1 with **\`GP_GET did not advance — PBDMA didn't see our submit\`**. That's the same wedge nano-2 has been hitting and the patch is neutral on it. The diagnostic improvement is the value-add — failure now shows up as PBDMA-stuck, not as a uniform poison wall.

Expected reads in dump after wake:
\`\`\`
gr_intr=0x00000000 gr_exception=0x00000000 class_error=0x00000000
trapped_addr=0x80000000 fe_hww_esr=0x80000000 fecs_intr=0x00000000
\`\`\`

(\`trapped_addr=0x80000000\` is the "no trapped method" sentinel, not poison.)

## How it might fit the nano-2 work

The earlier nano-2 dispatch dumps showed \`gr_intr=0xbadf1002\` etc. and we attributed the failure to "FECS won't load our channel." With this wake in place, the same dump on nano-2 will show real GR-engine state, which may or may not contradict the FECS-load conclusion. If \`gr_intr=0x00000000\` post-wake on nano-2 too, then the FECS-load conclusion was a poison-masking artifact and the real cause is somewhere else (probably the same PBDMA wedge nano-1 shows).

Reasonable next experiments after merge:
- Run \`scripts/jetson-deploy-retry.sh --target jetson-nano-2 ...\` and compare the post-failure dump to nano-1's.
- If the post-wake GR state is the same on both boards, that points to a single root cause; if they differ, the boards are wedging at different points.

## Documented false trail

Earlier in the same session I thought \`mc_enable[bit 12]\` (writing to \`0x17000200\`) was the wake mechanism. It wasn't — the *peek of GR before the poke* was the actual trigger. \`mc_enable[bit 12]\` stays cleared post-wake and the engine works anyway. The PR's main comment block documents this so a future reader doesn't repeat the dead end.

## Verification

- **jetson-nano-1, 10 deploy attempts:** post-wake \`gr_intr=0x00000000\` on every attempt (vs. \`0xbadf1002\` without the patch). All 10 still fail at \`launch-kernel\` because of the unrelated PBDMA wedge.
- **Build:** clean on \`make kernel PLATFORM=JETSON_ORIN_NANO\`.
- **QEMU tests:** patch is in a Jetson-only code path; unaffected.

## Refs

- Hardware investigation that led to this: this session's nano-1 work (Jetson power-gating hypothesis turned out false; PRI-deadlock-recovery was the real mechanism).
- Related: #844 (post-kexec channel-inherit FECS/PBDMA wedge — neither fixed by this patch nor regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)