### PR TITLE
eviction: warn when a runtime blob shadows the compiled-in model (#983)

### DIFF
--- a/docs/eviction.md
+++ b/docs/eviction.md
@@ -525,17 +525,24 @@ amortizes and the MLP is marginal at small block sizes (see
 `docs/design/gpu-policy-models.md` for the GPU path).
 
 **Deployment gotcha + residuals:**
-- **The real compiled-in xgboost is shadowed by an autoloaded toy runtime
-  blob (#983).** `eviction-xgboost.blob` (90 B — a 1-tree/3-node
-  `parse_single` toy) autoloads at boot and `XGBoostPolicy::score_row`
-  *unconditionally* prefers a runtime blob over the compiled-in ensemble
-  (`generated::MODELS_AVAILABLE` is not consulted); the toy predicts a
-  near-constant → ties → degenerates to `first_candidate`. Run
-  `eviction model clear xgboost` to engage the real model — the numbers
-  above are post-clear. The same shadow class affects `cacheus`'s
-  XGBoost expert and its `eviction-cacheus_config.blob`; clear both for
-  the compiled-in result. Fix options (precedence gate vs. deployment +
-  warning) are tracked in #983.
+- **A runtime model blob shadows the compiled-in predictor (#983).** A
+  runtime blob takes precedence over the compiled-in model
+  (`XGBoostPolicy`/`MlpPolicy::score_row` prefer the runtime cache;
+  CACHEUS loads its config the same way). A stale/placeholder autoload
+  blob — e.g. the 90-byte 1-tree/3-node `parse_single` toy
+  `eviction-xgboost.blob` — therefore silently degrades the policy toward
+  `first_candidate`. **Resolution (#983, option B — keep OTA, make it
+  loud):** `store::activate` now emits a `log_warn` whenever a runtime
+  XGBoost / MLP / CACHEUS blob is activated while real models are
+  compiled in (`MODELS_AVAILABLE`), at the single activation chokepoint
+  that both boot autoload and the shell route through. Runtime OTA model
+  replacement is intentionally preserved (no precedence change), so the
+  override is a logged event, not a silent one. **Deployment:** the toy
+  blobs are not part of the shipped image — they are leftover card state
+  (staged at runtime, persisted into `0:/slmstore/autoload/` +
+  `blob_autoload.conf`). Remove them from any card that has them; the
+  numbers above are with `eviction model clear xgboost` +
+  `... cacheus_config` so the compiled-in models are authoritative.
 - **CACHEUS instability — FIXED (#981).** Earlier the adversarial cell
   swung 6%→93% across back-to-back runs because the harness reset only
   residency per scenario, leaving the global `EvictedContentTracker`

--- a/runtime/src/mm/eviction/store.rs
+++ b/runtime/src/mm/eviction/store.rs
@@ -163,13 +163,41 @@ pub fn stage_parsed(parsed: ParsedBlob) -> Result<BlobKind, StoreError> {
 }
 
 pub fn activate(kind: BlobKind) -> Result<(), StoreError> {
-    let _g = SpinGuard::new();
-    unsafe {
-        let store = &mut *store_mut(kind);
-        let staged = store.staged.take().ok_or(StoreError::NoStagedBlob)?;
-        store.rollback = store.active.take();
-        store.active = Some(staged);
-        store.state = SlotState::Active;
+    {
+        let _g = SpinGuard::new();
+        // SAFETY: _g held — exclusive access to this kind's store slot.
+        unsafe {
+            let store = &mut *store_mut(kind);
+            let staged = store.staged.take().ok_or(StoreError::NoStagedBlob)?;
+            store.rollback = store.active.take();
+            store.active = Some(staged);
+            store.state = SlotState::Active;
+        }
+    }
+
+    // Visibility (#983): a runtime model blob takes precedence over the
+    // compiled-in predictor — `XGBoostPolicy`/`MlpPolicy::score_row` prefer
+    // the runtime cache, and CACHEUS loads its config the same way. When
+    // real models are compiled in (`MODELS_AVAILABLE`), a stale or
+    // placeholder autoload blob would otherwise silently shadow the real
+    // ensemble (the #983 incident: a 90-byte toy XGBoost blob degraded the
+    // policy to `first_candidate`). Announce the override so it is never
+    // silent; clear an unintended one with `eviction model clear <kind>`.
+    // Emitted OUTSIDE the store lock — `log_warn` is UART I/O and must not
+    // run under a spinlock. This is the only activation chokepoint (both
+    // boot autoload and the shell route through here).
+    if super::generated::MODELS_AVAILABLE {
+        match kind {
+            BlobKind::XGBoost => crate::log::log_warn(
+                b"eviction: runtime XGBoost blob active, overriding compiled-in model (clear: eviction model clear xgboost)\n\0",
+            ),
+            BlobKind::Mlp => crate::log::log_warn(
+                b"eviction: runtime MLP blob active, overriding compiled-in model (clear: eviction model clear mlp)\n\0",
+            ),
+            BlobKind::CacheusConfig => crate::log::log_warn(
+                b"eviction: runtime CACHEUS config active, overriding compiled-in ensemble (clear: eviction model clear cacheus_config)\n\0",
+            ),
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
Fixes #983 (option B — keep OTA, make it loud). A runtime model blob takes precedence over the compiled-in predictor (`XGBoostPolicy`/`MlpPolicy::score_row` prefer the runtime cache; CACHEUS loads its config the same way). A stale or placeholder autoload blob — e.g. the 90-byte toy `eviction-xgboost.blob` found on pi-5-2 — therefore *silently* degraded the policy toward `first_candidate`, requiring a manual `eviction model clear` to even notice.

`store::activate` now emits a `log_warn` whenever an XGBoost / MLP / CACHEUS_config blob is activated while real models are compiled in (`MODELS_AVAILABLE`). This is the single activation chokepoint that **both boot autoload and the shell** route through, so every override is announced.

Deliberately **not** a precedence change: runtime OTA model replacement is preserved — the override is now a logged event, not a silent one. (The precedence-gate alternative, which would drop OTA, is option A in #983.)

## Why outside the lock
`log_warn` is UART I/O, so the warning is emitted after the store `SpinGuard` is dropped (no spinlock-across-I/O). The `?` early-return on a failed activation drops the guard and returns before any warning.

## Verification
- Verified end-to-end on the test kernel (`EVICTION_MODELS=ON`): the warning prints immediately before each `blob_autoload: activated eviction …` line, for all three kinds.
- `make test EVICTION_MODELS=ON` green.
- Deployment side (the leftover toy blobs are card state, not shipped): pi-5-2 cleaned via `eviction model autoload clear xgboost` + `... cacheus_config`, reboot-verified to boot with no autoload and no shadow.

## Test plan
- [x] `make test EVICTION_MODELS=ON` passes
- [x] Warning fires at the autoload chokepoint for xgboost/mlp/cacheus_config (test-kernel serial)
- [x] No warning in models-off builds (`MODELS_AVAILABLE` gate)
- [x] pi-5-2 boots clean after deregistering the stale autoload blobs

Closes #983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)