### PR TITLE
ga10b: post-kexec GPU channel-inherit recovery + diagnostics (#844, #978)

### DIFF
--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -225,6 +225,10 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 #define GR_FECS_CPUCTL_ALIAS        0x00409130u
 #define GR_FECS_CTXSW_MAILBOX(i)    (0x00409800u + (i) * 4u)
 #define GR_FECS_CTXSW_MAILBOX_COUNT 18u
+/* FECS ctxsw arbiter ctx pointers (nvgpu gr_fecs_current_ctx_r /
+ * gr_fecs_new_ctx_r). */
+#define GR_FECS_CURRENT_CTX         0x00409b00u
+#define GR_FECS_NEW_CTX             0x00409b04u
 
 /* GR top-level status registers (nvgpu gr_intr_r / gr_exception_r). */
 #define GR_INTR_R                   0x00400100u
@@ -1964,7 +1968,7 @@ static void dump_fecs_state(const char *tag)
                 tag,
                 (unsigned long)bar0_r32(0x00409c18u),
                 (unsigned long)bar0_r32(0x00409818u),
-                (unsigned long)bar0_r32(0x00409b00u),
+                (unsigned long)bar0_r32(GR_FECS_CURRENT_CTX),
                 (unsigned long)bar0_r32(0x00409040u),
                 (unsigned long)bar0_r32(0x00409044u));
     /* Mailbox 6 carries error codes for ctxsw_intr0; the others
@@ -2261,11 +2265,11 @@ int ga10b_fecs_set_new_ctx(uint64_t inst_block_phys)
     uint32_t new_ctx = inst_ptr_u32 | (3u << 28) | (1u << 31);
 
     /* Latch current value for comparison + diagnostics. */
-    uint32_t before = bar0_r32(0x00409b04u);
-    bar0_w32(0x00409b04u, new_ctx);
+    uint32_t before = bar0_r32(GR_FECS_NEW_CTX);
+    bar0_w32(GR_FECS_NEW_CTX, new_ctx);
     gsp_platform->mb();
-    uint32_t after = bar0_r32(0x00409b04u);
-    uint32_t current_ctx = bar0_r32(0x00409b00u);
+    uint32_t after = bar0_r32(GR_FECS_NEW_CTX);
+    uint32_t current_ctx = bar0_r32(GR_FECS_CURRENT_CTX);
 
     uart_printf("[fecs-newctx] new_ctx_r(0x409b04): 0x%08lx -> 0x%08lx "
                 "(want 0x%08x for inst=0x%lx)\n",
@@ -2288,16 +2292,16 @@ int ga10b_fecs_force_current_ctx(uint64_t inst_block_phys)
     uint32_t inst_ptr_u32 = (uint32_t)(inst_block_phys >> 12);
     uint32_t ctx_val = inst_ptr_u32 | (3u << 28) | (1u << 31);
 
-    uint32_t before_cur = bar0_r32(0x00409b00u);
-    uint32_t before_new = bar0_r32(0x00409b04u);
+    uint32_t before_cur = bar0_r32(GR_FECS_CURRENT_CTX);
+    uint32_t before_new = bar0_r32(GR_FECS_NEW_CTX);
     uint32_t status_1   = bar0_r32(0x00409400u);
 
-    bar0_w32(0x00409b04u, ctx_val);
-    bar0_w32(0x00409b00u, ctx_val);
+    bar0_w32(GR_FECS_NEW_CTX, ctx_val);
+    bar0_w32(GR_FECS_CURRENT_CTX, ctx_val);
     gsp_platform->mb();
 
-    uint32_t after_cur = bar0_r32(0x00409b00u);
-    uint32_t after_new = bar0_r32(0x00409b04u);
+    uint32_t after_cur = bar0_r32(GR_FECS_CURRENT_CTX);
+    uint32_t after_new = bar0_r32(GR_FECS_NEW_CTX);
 
     uart_printf("[fecs-forcectx] arb_busy=%u (status_1=0x%08lx)\n",
                 (unsigned)((status_1 >> 12) & 0x1u),
@@ -2322,7 +2326,7 @@ void ga10b_dump_inst_blocks_atomic(const char *tag)
 {
     /* Atomic latch phase — read everything we need in one tight
      * window, before the slow per-byte dump starts. */
-    uint32_t current_ctx = bar0_r32(0x00409b00u);
+    uint32_t current_ctx = bar0_r32(GR_FECS_CURRENT_CTX);
     uint32_t fault_inst_lo = bar0_r32(0x00100e54u);
     uint32_t fault_inst_hi = bar0_r32(0x00100e58u);
     uint32_t fault_addr_lo = bar0_r32(0x00100e4cu);
@@ -2466,9 +2470,13 @@ static void dump_gpc_tpc_sm(const char *tag, uint32_t gr_exception)
             /* warp_esr error code is the low 16 bits
              * (gr_..._hww_warp_esr_error_v = (r>>0)&0xffff), NOT the low
              * byte. 0x20 = error_mmu_nack (a GMMU NACK on a warp memory
-             * access — stale TLB), distinct from the <=0xf shader-bug
-             * codes (0x5 misaligned_pc, 0x9 illegal_instr, 0xe oor_addr).
-             * #844 fix is the pre-launch tlb_invalidate above. */
+             * access — stale inherited TLB), distinct from the <=0xf
+             * shader-bug codes (0x5 misaligned_pc, 0x9 illegal_instr,
+             * 0xe oor_addr). mmu_nack is a known-unresolved #844 mode:
+             * a pre-launch all-VA TLB invalidate was tried and REVERTED
+             * (it cut mmu_nack but re-introduced the on_pbdma=0 stall —
+             * see the #844 NOTE in ga10b_dispatch_v7_pipeline_inline).
+             * This decode is observability only. */
             uint32_t warp_err = sm_warp & 0xffffu;
             const char *errname =
                 (warp_err == 0x20u) ? "mmu_nack" :
@@ -2863,8 +2871,8 @@ int ga10b_bringup_smoke_test_compute(struct ga10b_bringup *b)
  * did the opposite (wrote valid=TRUE), which still triggered a save. */
 static void ga10b_fecs_set_current_ctx_invalid(void)
 {
-    uint32_t before = bar0_r32(0x00409b00u);
-    bar0_w32(0x00409b00u, 0u);
+    uint32_t before = bar0_r32(GR_FECS_CURRENT_CTX);
+    bar0_w32(GR_FECS_CURRENT_CTX, 0u);
     gsp_platform->mb();
     uart_printf("[GA10B-P8-v7] FECS current_ctx invalidated: "
                 "0x%08lx -> 0x00000000 (#844 skip stale-ctx save)\n",

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2826,6 +2826,31 @@ int ga10b_bringup_smoke_test_compute(struct ga10b_bringup *b)
  * take handoff + slot counter as parameters and a stub-submit
  * function pointer).
  */
+/* #844: invalidate FECS current_ctx before the first post-kexec ctxsw.
+ *
+ * Mirrors nvgpu's `gm20b_gr_falcon_set_current_ctx_invalid`
+ * (~/slmos-ref/nvidia/nvgpu-gr-falcon-gm20b-fusa.c:672-676): write
+ * `gr_fecs_current_ctx_r()` (0x00409b00) with valid=false (the whole
+ * register = 0 = `gr_fecs_current_ctx_valid_false_f()`).
+ *
+ * Post-kexec, FECS_CURRENT_CTX holds Linux's stale inst pointer (often
+ * PDB=0). On the first ctxsw, FECS SAVES that "old" context before
+ * loading ours — and the save checksum-fails with ctxsw mailbox6=0x21
+ * (gr_fecs_ctxsw_mailbox_value_ctxsw_checksum_mismatch_v, hw_gr_ga10b.h
+ * :577). Clearing the valid bit tells FECS "there is no old context to
+ * save", so the save phase is skipped and only the LOAD of our channel
+ * runs. This is the canonical nvgpu recovery; SLM-OS's `fecs-forcectx`
+ * did the opposite (wrote valid=TRUE), which still triggered a save. */
+static void ga10b_fecs_set_current_ctx_invalid(void)
+{
+    uint32_t before = bar0_r32(0x00409b00u);
+    bar0_w32(0x00409b00u, 0u);
+    gsp_platform->mb();
+    uart_printf("[GA10B-P8-v7] FECS current_ctx invalidated: "
+                "0x%08lx -> 0x00000000 (#844 skip stale-ctx save)\n",
+                (unsigned long)before);
+}
+
 /* Internal worker — fires N v7 ops + 1 trailing semaphore release
  * through g_handoff's QMD pool + pushbuf + GPFIFO + semaphore.
  *
@@ -2907,6 +2932,16 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
         b->last_error_phase = 8;
         return -1;
     }
+
+    /* #844: canonical post-kexec ctxsw recovery (nvgpu sequence),
+     * run before the first GR submit below:
+     *   1. set_current_ctx_invalid → FECS skips SAVING the stale
+     *      current_ctx (the save checksum-fails, mb6=0x21).
+     *   2. force_ctx_reload (CHRAM 0x200) → the upcoming dispatch's
+     *      ctxsw does a fresh LOAD of our channel instead of trusting
+     *      resident state. */
+    ga10b_fecs_set_current_ctx_invalid();
+    ga10b_gmmu_force_ctx_reload(&g_handoff);
 
     /* CPU-physical → identity-mapped CPU VA on Jetson. Same
      * contract as the v3 dispatch fields: the helper allocates

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -3325,6 +3325,17 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
                     "poll=0x%lx)\n",
                     (unsigned long)final_gp_get,
                     (unsigned long)poll_val);
+        /* #844: triage the channel-not-scheduled mode — is our channel
+         * enabled in CHRAM? on the runlist (on_pbdma/on_eng)? is the
+         * runlist submit pending? */
+        ga10b_gmmu_dump_chram_runlist(&g_handoff);
+        timer_busy_wait_us(8000u);
+        uart_printf("[GA10B-P8-v7]   submit ptrs: gp_put=%lu gp_get=%lu "
+                    "token=0x%lx userd_phys=0x%lx\n",
+                    (unsigned long)g_handoff.initial_gp_put,
+                    (unsigned long)final_gp_get,
+                    (unsigned long)g_handoff.work_submit_token,
+                    (unsigned long)g_handoff.userd_phys);
     } else if (poll_val == 0u) {
         uart_printf("[GA10B-P8-v7] BULK poll timeout — PBDMA "
                     "advanced (GP_GET %lu → %lu) but NEITHER sema "

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -226,6 +226,10 @@ int ga10b_firmware_get(enum ga10b_firmware_kind kind,
 #define GR_FECS_CTXSW_MAILBOX(i)    (0x00409800u + (i) * 4u)
 #define GR_FECS_CTXSW_MAILBOX_COUNT 18u
 
+/* GR top-level status registers (nvgpu gr_intr_r / gr_exception_r). */
+#define GR_INTR_R                   0x00400100u
+#define GR_EXCEPTION_R              0x00400108u
+
 #define GR_GPCCS_CPUCTL             0x0041a100u
 #define GR_GPCCS_DMACTL             0x0041a10cu
 #define GR_GPC0_GPCCS_CTXSW_MAILBOX(i) (0x00502800u + (i) * 4u)
@@ -1077,11 +1081,14 @@ int ga10b_bringup_inherit(struct ga10b_bringup *b)
          * dead engine); the success path exits at ~2 ms. */
         const uint32_t GA10B_PRI_POISON = 0xbadf1002u;
         const int      WAKE_MAX_ITERS   = 200;
-        uint32_t value = 0;
-        int      iter  = 0;
+        /* Seed with the poison value so a zero-iteration loop (cap ever
+         * set to 0) takes the not-woken failure path rather than a false
+         * success. */
+        uint32_t value = GA10B_PRI_POISON;
+        int      iter;
         for (iter = 0; iter < WAKE_MAX_ITERS; iter++) {
             timer_busy_wait_us(1000u);       /* 1 ms settle per attempt */
-            value = bar0_r32(0x00400100u);   /* gr_intr */
+            value = bar0_r32(GR_INTR_R);
             if (value != GA10B_PRI_POISON) break;
         }
         uart_printf("[GA10B-INHERIT] GR PRI wake: iter=%d "
@@ -1937,8 +1944,8 @@ static void dump_gr_top_level(const char *tag)
                 "class_error=0x%08lx trapped_addr=0x%08lx fe_hww_esr=0x%08lx "
                 "fecs_intr=0x%08lx\n",
                 tag,
-                (unsigned long)bar0_r32(0x00400100u),
-                (unsigned long)bar0_r32(0x00400108u),
+                (unsigned long)bar0_r32(GR_INTR_R),
+                (unsigned long)bar0_r32(GR_EXCEPTION_R),
                 (unsigned long)bar0_r32(0x00400110u),
                 (unsigned long)bar0_r32(0x00400704u),
                 (unsigned long)bar0_r32(0x00404000u),
@@ -2484,7 +2491,7 @@ static void ga10b_dump_gr_state(const char *tag)
     dump_gr_top_level(tag);
     /* GR exception register again — re-read so the GPC drill-down
      * sees the same snapshot the top-level dump just printed. */
-    dump_gpc_tpc_sm(tag, bar0_r32(0x00400108u));
+    dump_gpc_tpc_sm(tag, bar0_r32(GR_EXCEPTION_R));
     dump_fecs_state(tag);
     dump_mmu_fault(tag);
     dump_pbdma_state(tag);

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2253,6 +2253,37 @@ int ga10b_fecs_set_new_ctx(uint64_t inst_block_phys)
     return 0;
 }
 
+int ga10b_fecs_force_current_ctx(uint64_t inst_block_phys)
+{
+    if (inst_block_phys == 0) return -1;
+    if ((inst_block_phys & 0xFFFu) != 0) return -1;
+
+    uint32_t inst_ptr_u32 = (uint32_t)(inst_block_phys >> 12);
+    uint32_t ctx_val = inst_ptr_u32 | (3u << 28) | (1u << 31);
+
+    uint32_t before_cur = bar0_r32(0x00409b00u);
+    uint32_t before_new = bar0_r32(0x00409b04u);
+    uint32_t status_1   = bar0_r32(0x00409400u);
+
+    bar0_w32(0x00409b04u, ctx_val);
+    bar0_w32(0x00409b00u, ctx_val);
+    gsp_platform->mb();
+
+    uint32_t after_cur = bar0_r32(0x00409b00u);
+    uint32_t after_new = bar0_r32(0x00409b04u);
+
+    uart_printf("[fecs-forcectx] arb_busy=%u (status_1=0x%08lx)\n",
+                (unsigned)((status_1 >> 12) & 0x1u),
+                (unsigned long)status_1);
+    uart_printf("[fecs-forcectx] new_ctx(0x409b04):     0x%08lx -> 0x%08lx\n",
+                (unsigned long)before_new, (unsigned long)after_new);
+    uart_printf("[fecs-forcectx] current_ctx(0x409b00): 0x%08lx -> 0x%08lx "
+                "(want 0x%08x for inst=0x%lx)\n",
+                (unsigned long)before_cur, (unsigned long)after_cur,
+                (unsigned)ctx_val, (unsigned long)inst_block_phys);
+    return 0;
+}
+
 /* Decode FECS_CURRENT_CTX and fb_mmu_fault_inst into 40-bit
  * physical addresses and dump both inst blocks atomically — i.e.
  * latch every relevant register up-front before the slow DRAM

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -2456,12 +2456,25 @@ static void dump_gpc_tpc_sm(const char *tag, uint32_t gr_exception)
             uint32_t sm_warp   = bar0_r32(0x00504730u);
             uint32_t pc_lo     = bar0_r32(0x00504738u);
             uint32_t pc_hi     = bar0_r32(0x0050473cu);
+            /* warp_esr error code is the low 16 bits
+             * (gr_..._hww_warp_esr_error_v = (r>>0)&0xffff), NOT the low
+             * byte. 0x20 = error_mmu_nack (a GMMU NACK on a warp memory
+             * access — stale TLB), distinct from the <=0xf shader-bug
+             * codes (0x5 misaligned_pc, 0x9 illegal_instr, 0xe oor_addr).
+             * #844 fix is the pre-launch tlb_invalidate above. */
+            uint32_t warp_err = sm_warp & 0xffffu;
+            const char *errname =
+                (warp_err == 0x20u) ? "mmu_nack" :
+                (warp_err == 0x0u)  ? "none" :
+                (warp_err == 0x5u)  ? "misaligned_pc" :
+                (warp_err == 0x9u)  ? "illegal_instr_encoding" :
+                (warp_err == 0xeu)  ? "oor_addr" : "other";
             uart_printf("[%s]   sm0_global_esr=0x%08lx sm0_warp_esr=0x%08lx "
-                        "warp_pc=0x%08lx_%08lx (error_code=0x%02x)\n",
+                        "warp_pc=0x%08lx_%08lx (error=0x%04x %s)\n",
                         tag, (unsigned long)sm_global,
                         (unsigned long)sm_warp,
                         (unsigned long)pc_hi, (unsigned long)pc_lo,
-                        (unsigned)(sm_warp & 0xffu));
+                        (unsigned)warp_err, errname);
         }
     }
 }
@@ -2939,7 +2952,18 @@ int ga10b_dispatch_v7_pipeline_inline(struct ga10b_bringup *b,
      *      current_ctx (the save checksum-fails, mb6=0x21).
      *   2. force_ctx_reload (CHRAM 0x200) → the upcoming dispatch's
      *      ctxsw does a fresh LOAD of our channel instead of trusting
-     *      resident state. */
+     *      resident state.
+     *
+     * #844 NOTE: a pre-launch all-VA tlb_invalidate(our PDB) was tried
+     * here to fix the intermittent SM mmu_nack fault (warp_esr=0x20 —
+     * the compute "hang"). It DID cut mmu_nack but re-introduced Mode-A
+     * (on_pbdma=0 GP_GET-stuck, 0→5/30, pass 83%→60%): the all-VA
+     * invalidate nukes the host's GPFIFO/pushbuffer translations too, so
+     * PBDMA's fetch is disrupted. This is the THIRD dispatch-time global
+     * GPU op (after runlist-resubmit and STOP_CTXSW) to knock the
+     * inherited channel off PBDMA — the inherited channel is fragile to
+     * any dispatch-time perturbation. Reverted; the clean minimal-
+     * perturbation path is the best (~83%). */
     ga10b_fecs_set_current_ctx_invalid();
     ga10b_gmmu_force_ctx_reload(&g_handoff);
 

--- a/kernel/gpu/nvidia/ga10b_bringup.c
+++ b/kernel/gpu/nvidia/ga10b_bringup.c
@@ -15,6 +15,7 @@
 #include "gsp.h"
 #include "falcon.h"
 #include "../../include/uart.h"
+#include "../../include/timer.h"
 
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -1053,20 +1054,33 @@ int ga10b_bringup_inherit(struct ga10b_bringup *b)
      * works — the PRI deadlock recovery is independent of the
      * master-controller enable state. */
     {
-        /* The first read returns the poison value but also kicks the
-         * engine out of PRI-deadlock. Subsequent reads then return real
-         * register values. Loop until either:
-         *   - a non-poison read confirms GR is awake, or
-         *   - we hit the iteration cap (means the wake isn't taking,
-         *     which is a hardware state we don't know how to fix).
-         * Empirically takes 1 retry on jetson-nano-1 (read #1 = poison,
-         * read #2 = real value); cap at 16 to be defensive without
-         * stalling on a truly wedged engine. */
+        /* GR's PRI domain needs wall-clock settle time to ungate after
+         * kexec — poll gr_intr with a 1 ms delay per attempt until it
+         * returns a real value instead of the poison sentinel.
+         *
+         * Why a delay (not just a read count) — #978: GA10B's GR rail/
+         * clock is BPMP-gated, and nvpmodel governs how aggressively.
+         * slmos-kexec force-restores the GPU clock just before kexec,
+         * but the GR PRI fabric takes a few ms to come back after the
+         * clock returns. In nvpmodel 15W the domain happens to recover
+         * almost immediately (the original tight 16-read loop, spanning
+         * only a few µs, caught it). In 25W (the Super default) it takes
+         * ~1-2 ms, so the tight loop always saw poison and inherit
+         * failed 100% of the time. A real per-attempt delay fixes both:
+         * verified GR wakes on iter=1 (~2 ms) for 10/10 boots at 25W
+         * and still recovers immediately at 15W. The settle time is a
+         * BPMP/clock-domain property, not a read side effect — an
+         * earlier "the first read kicks the deadlock latch" reading was
+         * a measurement artifact of the un-delayed loop.
+         *
+         * 200 ms cap is generous insurance on the failure path (a truly
+         * dead engine); the success path exits at ~2 ms. */
         const uint32_t GA10B_PRI_POISON = 0xbadf1002u;
-        const int      WAKE_MAX_ITERS   = 16;
+        const int      WAKE_MAX_ITERS   = 200;
         uint32_t value = 0;
         int      iter  = 0;
         for (iter = 0; iter < WAKE_MAX_ITERS; iter++) {
+            timer_busy_wait_us(1000u);       /* 1 ms settle per attempt */
             value = bar0_r32(0x00400100u);   /* gr_intr */
             if (value != GA10B_PRI_POISON) break;
         }
@@ -1075,8 +1089,14 @@ int ga10b_bringup_inherit(struct ga10b_bringup *b)
                     iter, (unsigned long)value,
                     (unsigned long)GA10B_PRI_POISON);
         if (value == GA10B_PRI_POISON) {
-            uart_puts("[GA10B-INHERIT] GR did not wake after "
-                      "PRI-deadlock recovery attempts\n");
+            /* Diagnostics: is the GPU itself powered (NV_PMC_BOOT_0
+             * returns chip id ~0x172...) or is the whole GPU gated? */
+            uint32_t boot0 = bar0_r32(0x00000000u);
+            uint32_t mc_en = bar0_r32(0x00000200u);  /* NV_PMC_ENABLE */
+            uart_printf("[GA10B-INHERIT] GR did not wake after %d ms "
+                        "(boot0=0x%08lx mc_enable=0x%08lx)\n",
+                        WAKE_MAX_ITERS, (unsigned long)boot0,
+                        (unsigned long)mc_en);
             return -1;
         }
     }

--- a/kernel/gpu/nvidia/ga10b_bringup.h
+++ b/kernel/gpu/nvidia/ga10b_bringup.h
@@ -262,6 +262,26 @@ void ga10b_dump_inst_block_at(const char *tag, uint64_t inst_phys);
  * page-aligned. */
 int ga10b_fecs_set_new_ctx(uint64_t inst_block_phys);
 
+/* #844 probe: force `gr_fecs_current_ctx_r()` (0x00409b00) to point
+ * at our inherited channel's inst block, displacing whatever Linux
+ * left there pre-kexec. Hypothesis: the per-boot variance of
+ * mb6=0x21 / mb6=0x5a on first compute ctxsw comes from FECS trying
+ * to *save* the stale Linux current-ctx before loading ours; if we
+ * tell FECS "your current ctx is already OUR channel", the save
+ * phase is a no-op and only the load phase runs.
+ *
+ * Differs from `ga10b_fecs_set_new_ctx` in writing 0x409b00
+ * (CURRENT_CTX) directly rather than 0x409b04 (NEW_CTX) — gm20b's
+ * `bind_instblk` sequence (`~/slmos-ref/nvidia/nvgpu-gr-falcon-
+ * gm20b-fusa.c:145-200`) writes both, but the arbiter dance between
+ * the two doesn't have ga10b register equivalents in nvgpu
+ * (`bind_instblk = NULL` on ga10b — `~/slmos-ref/nvidia/nvgpu-hal-
+ * init-hal_ga10b.c:792`), so we just write current_ctx directly.
+ *
+ * Returns 0 on success, -1 if `inst_block_phys` is zero or not
+ * page-aligned. Companion shell verb: `nvgpu fecs-forcectx`. */
+int ga10b_fecs_force_current_ctx(uint64_t inst_block_phys);
+
 /* #834: submit a FECS method via the standard data+push protocol.
  * Clears mailbox 0, writes method data + push address, polls mb0
  * for `expected_mb0` (typically `gr_fecs_ctxsw_mailbox_value_pass_v`

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1807,6 +1807,49 @@ int ga10b_gmmu_force_ctx_reload(const struct ga10b_channel_handoff *h)
     return 0;
 }
 
+/* #844 GP_GET-stuck diagnostic: dump the inherited channel's CHRAM
+ * state + the GR runlist scheduling registers, so a "PBDMA didn't see
+ * our submit" failure can be triaged into:
+ *   - channel not enabled in CHRAM (enable=0)               → CHRAM bug
+ *   - enabled but not on_pbdma/on_eng                       → not on runlist
+ *   - on_pbdma=1 but GP_GET stuck                           → USERD/doorbell
+ *   - runlist submit_info pending bit stuck                 → host wedged
+ * Read-only; safe to call from the failure path. */
+void ga10b_gmmu_dump_chram_runlist(const struct ga10b_channel_handoff *h)
+{
+    if (h == NULL) return;
+    /* The Jetson UARTC TX FIFO drops lines emitted in a tight burst
+     * (the failure dump that precedes this call). Drain it before, and
+     * space our own prints, so the diagnostic actually reaches the
+     * captured serial log. The dispatch already timed out, so the
+     * added ~30 ms is irrelevant. */
+    timer_busy_wait_us(20000u);
+    uint64_t rl = discover_gr_runlist_pri_base();
+    if (rl == 0u) { uart_puts("[chram-diag] no runlist topology\n"); return; }
+    uint32_t hw_chid = h->work_submit_token;
+    uint32_t channel_config = bar0_read32(rl + GA10B_RL_REG_CHANNEL_CONFIG);
+    uint32_t chram_off = ((channel_config >> 4) & 0x0fffffffu) << 4;
+    uint32_t ch = *(volatile uint32_t *)(uintptr_t)
+        (GA10B_BAR0_BASE + (uint64_t)chram_off + (uint64_t)hw_chid * 4ull);
+    uart_printf("[chram-diag] CHRAM[chid=%u]=0x%08x enable=%u next=%u "
+                "busy=%u eng_faulted=%u on_pbdma=%u on_eng=%u\n",
+                (unsigned)hw_chid, (unsigned)ch,
+                (unsigned)((ch >> 1) & 1u), (unsigned)((ch >> 2) & 1u),
+                (unsigned)((ch >> 3) & 1u), (unsigned)((ch >> 5) & 1u),
+                (unsigned)((ch >> 6) & 1u), (unsigned)((ch >> 7) & 1u));
+    timer_busy_wait_us(8000u);
+    uint32_t sb_lo = bar0_read32(rl + GA10B_RL_REG_SUBMIT_BASE_LO);
+    uint32_t sb_hi = bar0_read32(rl + GA10B_RL_REG_SUBMIT_BASE_HI);
+    uint32_t submit = bar0_read32(rl + GA10B_RL_REG_SUBMIT);
+    uint32_t info = bar0_read32(rl + GA10B_RL_REG_SUBMIT_INFO);
+    uint32_t sched = bar0_read32(rl + GA10B_RL_REG_SCHED_DISABLE);
+    uart_printf("[chram-diag] runlist base=0x%02x%08x submit=0x%08x "
+                "info=0x%08x(pending=%u) sched_disable=0x%08x\n",
+                (unsigned)(sb_hi & 0xffu), (unsigned)sb_lo,
+                (unsigned)submit, (unsigned)info,
+                (unsigned)((info >> 15) & 1u), (unsigned)sched);
+}
+
 static void install_fresh_runlist_and_chram(
                                 const struct ga10b_channel_handoff *h)
 {

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1761,6 +1761,52 @@ static void chram_enable_and_preempt(uint64_t gr_rl_pri_base,
                 (unsigned)info_after);
 }
 
+/* #844: standalone CHRAM enable + force_ctx_reload for our inherited
+ * channel — WITHOUT the runlist preempt or fresh-runlist rebuild that
+ * `chram_enable_and_preempt` / `install_fresh_runlist_and_chram` do.
+ *
+ * Pairs with FECS `set_current_ctx_invalid` (in ga10b_bringup.c): the
+ * invalidate makes FECS skip SAVING the stale post-kexec current_ctx;
+ * this sets the per-channel force_ctx_reload bit so that when the
+ * upcoming dispatch schedules our channel, FECS does a fresh LOAD of
+ * our context image rather than trusting resident state. No separate
+ * preempt is needed — the dispatch's doorbell is the runlist event
+ * that acts on the pending reload. Deliberately does NOT preempt or
+ * rewrite the runlist (that path leaves the channel preempted and
+ * breaks direct submit — see install_fresh_runlist_and_chram).
+ *
+ * Returns 0 on success, -1 if the runlist topology can't be walked. */
+int ga10b_gmmu_force_ctx_reload(const struct ga10b_channel_handoff *h)
+{
+    if (h == NULL) return -1;
+    uint64_t gr_rl_pri_base = discover_gr_runlist_pri_base();
+    if (gr_rl_pri_base == 0u) {
+        uart_puts("[fecs-reload] no runlist topology — "
+                  "force_ctx_reload skipped\n");
+        return -1;
+    }
+    uint32_t hw_chid = h->work_submit_token;
+    uint32_t channel_config = bar0_read32(gr_rl_pri_base +
+                                          GA10B_RL_REG_CHANNEL_CONFIG);
+    uint32_t chram_bar0_offset =
+        ((channel_config >> 4) & 0x0fffffffu) << 4;
+    uint64_t chram_chan_addr =
+        GA10B_BAR0_BASE + (uint64_t)chram_bar0_offset +
+        (uint64_t)hw_chid * 4ull;
+    volatile uint32_t *chram =
+        (volatile uint32_t *)(uintptr_t)chram_chan_addr;
+
+    *chram = 0x00000002u;   /* enable_channel */
+    __asm__ volatile("dsb sy" ::: "memory");
+    *chram = 0x00000200u;   /* force_ctx_reload */
+    __asm__ volatile("dsb sy" ::: "memory");
+    uart_printf("[fecs-reload] CHRAM[hw_chid=%u]@0x%lx "
+                "enable+force_ctx_reload (chram_bar0=0x%x)\n",
+                (unsigned)hw_chid, (unsigned long)chram_chan_addr,
+                (unsigned)chram_bar0_offset);
+    return 0;
+}
+
 static void install_fresh_runlist_and_chram(
                                 const struct ga10b_channel_handoff *h)
 {

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1850,6 +1850,79 @@ void ga10b_gmmu_dump_chram_runlist(const struct ga10b_channel_handoff *h)
                 (unsigned)((info >> 15) & 1u), (unsigned)sched);
 }
 
+/* #844 PBDMA-binding: decode Linux's LIVE runlist to learn the exact
+ * GA10B entry word-layout from a known-good entry (the cached headers
+ * give field shifts but not word assignment). Maps Linux's runlist,
+ * dumps up to 24 entries raw (4 words each), and cross-references each
+ * word against the inherited channel's expected encoded values
+ * (chid, inst_phys>>12, userd_phys>>8) so the operator can see which
+ * word holds which field. Read-only. */
+void ga10b_gmmu_dump_runlist_full(const struct ga10b_channel_handoff *h)
+{
+    if (h == NULL) return;
+    uint64_t rl_pri = discover_gr_runlist_pri_base();
+    if (rl_pri == 0u) { uart_puts("[rl-decode] no runlist topology\n"); return; }
+
+    uint32_t hw_chid = h->work_submit_token;
+    uint64_t inst_p = h->inst_block_phys;
+    uint64_t userd_p = h->userd_phys;
+    uart_printf("[rl-decode] OUR channel: chid=%u(0x%x) inst_phys=0x%lx "
+                "userd_phys=0x%lx  expect inst>>12=0x%lx userd>>8=0x%lx\n",
+                (unsigned)hw_chid, (unsigned)hw_chid,
+                (unsigned long)inst_p, (unsigned long)userd_p,
+                (unsigned long)(inst_p >> 12), (unsigned long)(userd_p >> 8));
+
+    uint32_t rl_lo = bar0_read32(rl_pri + GA10B_RL_REG_SUBMIT_BASE_LO);
+    uint32_t rl_hi = bar0_read32(rl_pri + GA10B_RL_REG_SUBMIT_BASE_HI);
+    uint32_t submit = bar0_read32(rl_pri + GA10B_RL_REG_SUBMIT);
+    uint64_t rl_phys = ((uint64_t)(rl_lo & 0xfffffc00u)) |
+                       ((uint64_t)(rl_hi & 0xffu) << 32);
+    uint32_t n_entries = submit & 0xffffu;   /* length field = entry count */
+    if (n_entries == 0u || n_entries > 24u) n_entries = 24u;
+    uart_printf("[rl-decode] runlist phys=0x%lx submit=0x%08x "
+                "(n_entries=%u)\n",
+                (unsigned long)rl_phys, (unsigned)submit, (unsigned)n_entries);
+
+    const uint64_t BLOCK_2M = 0x200000ull;
+    uint64_t rl_block = rl_phys & ~(BLOCK_2M - 1ull);
+    /* Linux allocates the runlist in upper DRAM that SLM-OS's PMM
+     * region list (what phys_in_dram checks) doesn't cover, so use the
+     * full Jetson DRAM window [0x8000_0000, 0x2_8000_0000) here. */
+    if (rl_block < 0x80000000ull ||
+        (rl_block + BLOCK_2M) > 0x280000000ull) {
+        uart_printf("[rl-decode] runlist phys=0x%lx outside DRAM window "
+                    "— skip\n", (unsigned long)rl_phys);
+        return;
+    }
+    if (vmm_ensure_kernel_l2_table(rl_block) != 0 ||
+        vmm_map_region(rl_block, rl_block, BLOCK_2M,
+                       VMM_FLAG_READ | VMM_FLAG_WRITE) != 0) {
+        uart_printf("[rl-decode] map failed — skip\n");
+        return;
+    }
+
+    volatile uint32_t *rl = (volatile uint32_t *)(uintptr_t)rl_phys;
+    uint32_t exp_inst_lo = (uint32_t)((inst_p >> 12) & 0xfffffu);
+    for (uint32_t e = 0; e < n_entries; e++) {
+        uint32_t w0 = rl[e*4+0], w1 = rl[e*4+1],
+                 w2 = rl[e*4+2], w3 = rl[e*4+3];
+        /* flag the entry that references OUR channel: chid in low 12
+         * bits of some word, or inst_ptr_lo in bits[31:12]. */
+        const char *mark = "";
+        if ((w0 & 0xfffu) == hw_chid || (w1 & 0xfffu) == hw_chid ||
+            (w2 & 0xfffu) == hw_chid)
+            mark = " <- chid match";
+        if (((w0 >> 12) & 0xfffffu) == exp_inst_lo ||
+            ((w1 >> 12) & 0xfffffu) == exp_inst_lo ||
+            ((w2 >> 12) & 0xfffffu) == exp_inst_lo)
+            mark = " <- inst_ptr match";
+        uart_printf("[rl-decode] e%-2u 0x%08x 0x%08x 0x%08x 0x%08x%s\n",
+                    (unsigned)e, (unsigned)w0, (unsigned)w1,
+                    (unsigned)w2, (unsigned)w3, mark);
+        timer_busy_wait_us(3000u);   /* avoid UARTC FIFO drop on the burst */
+    }
+}
+
 static void install_fresh_runlist_and_chram(
                                 const struct ga10b_channel_handoff *h)
 {

--- a/kernel/gpu/nvidia/ga10b_gmmu.c
+++ b/kernel/gpu/nvidia/ga10b_gmmu.c
@@ -1894,9 +1894,11 @@ void ga10b_gmmu_dump_runlist_full(const struct ga10b_channel_handoff *h)
                     "— skip\n", (unsigned long)rl_phys);
         return;
     }
+    /* Read-only: this is a diagnostic dump of Linux's runlist; never
+     * write through this mapping. */
     if (vmm_ensure_kernel_l2_table(rl_block) != 0 ||
         vmm_map_region(rl_block, rl_block, BLOCK_2M,
-                       VMM_FLAG_READ | VMM_FLAG_WRITE) != 0) {
+                       VMM_FLAG_READ) != 0) {
         uart_printf("[rl-decode] map failed — skip\n");
         return;
     }
@@ -1910,17 +1912,22 @@ void ga10b_gmmu_dump_runlist_full(const struct ga10b_channel_handoff *h)
          * bits of some word, or inst_ptr_lo in bits[31:12]. */
         const char *mark = "";
         if ((w0 & 0xfffu) == hw_chid || (w1 & 0xfffu) == hw_chid ||
-            (w2 & 0xfffu) == hw_chid)
+            (w2 & 0xfffu) == hw_chid) {
             mark = " <- chid match";
+        }
         if (((w0 >> 12) & 0xfffffu) == exp_inst_lo ||
             ((w1 >> 12) & 0xfffffu) == exp_inst_lo ||
-            ((w2 >> 12) & 0xfffffu) == exp_inst_lo)
+            ((w2 >> 12) & 0xfffffu) == exp_inst_lo) {
             mark = " <- inst_ptr match";
+        }
         uart_printf("[rl-decode] e%-2u 0x%08x 0x%08x 0x%08x 0x%08x%s\n",
                     (unsigned)e, (unsigned)w0, (unsigned)w1,
                     (unsigned)w2, (unsigned)w3, mark);
         timer_busy_wait_us(3000u);   /* avoid UARTC FIFO drop on the burst */
     }
+
+    /* Tear down the diagnostic mapping (single 2 MB block). */
+    vmm_unmap_block(rl_block);
 }
 
 static void install_fresh_runlist_and_chram(

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -469,6 +469,11 @@ int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
  * the runlist topology can't be walked. */
 int ga10b_gmmu_force_ctx_reload(const struct ga10b_channel_handoff *h);
 
+/* #844 diagnostic: dump the inherited channel's CHRAM state + GR
+ * runlist scheduling registers (read-only) to triage a GP_GET-stuck
+ * "PBDMA didn't see our submit" failure. */
+void ga10b_gmmu_dump_chram_runlist(const struct ga10b_channel_handoff *h);
+
 /* Discover the inherited channel's inst block by walking DRAM and
  * cross-checking each candidate against a known (gpu_va, leaf_phys)
  * pair from the channel handoff. Used as a fallback when

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -474,6 +474,11 @@ int ga10b_gmmu_force_ctx_reload(const struct ga10b_channel_handoff *h);
  * "PBDMA didn't see our submit" failure. */
 void ga10b_gmmu_dump_chram_runlist(const struct ga10b_channel_handoff *h);
 
+/* #844 PBDMA-binding: dump Linux's live runlist (raw entries) with
+ * cross-reference to the inherited channel's chid/inst/userd, to learn
+ * the exact GA10B entry word-layout. Read-only. */
+void ga10b_gmmu_dump_runlist_full(const struct ga10b_channel_handoff *h);
+
 /* Discover the inherited channel's inst block by walking DRAM and
  * cross-checking each candidate against a known (gpu_va, leaf_phys)
  * pair from the channel handoff. Used as a fallback when

--- a/kernel/gpu/nvidia/ga10b_gmmu.h
+++ b/kernel/gpu/nvidia/ga10b_gmmu.h
@@ -462,6 +462,13 @@ struct ga10b_channel_handoff;
 int ga10b_gmmu_rebuild_for_handoff(uint64_t inst_block_phys,
                                    const struct ga10b_channel_handoff *h);
 
+/* #844: CHRAM enable + force_ctx_reload for the inherited channel only
+ * (no preempt / no fresh-runlist rebuild). Pairs with FECS
+ * set_current_ctx_invalid so the first post-kexec ctxsw skips the
+ * stale-ctx save and does a fresh load. Returns 0 on success, -1 if
+ * the runlist topology can't be walked. */
+int ga10b_gmmu_force_ctx_reload(const struct ga10b_channel_handoff *h);
+
 /* Discover the inherited channel's inst block by walking DRAM and
  * cross-checking each candidate against a known (gpu_va, leaf_phys)
  * pair from the channel handoff. Used as a fallback when

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5773,6 +5773,27 @@ int cmd_nvgpu(int argc, char *argv[])
         shell_printf("fecs-newctx: rc=%d\r\n", rc);
         return rc;
     }
+    if (strcmp(argv[1], "fecs-forcectx") == 0) {
+        /* #844 probe: write `gr_fecs_current_ctx_r()` (0x00409b00)
+         * directly with our channel's inst phys, displacing whatever
+         * stale Linux value is left there post-kexec. If FECS's
+         * first compute ctxsw is failing because the save-old phase
+         * dereferences Linux's stale current_ctx, this should turn
+         * mb6=0x21 (or mb6=0x5a on non-v10 helpers) into rc=0 on
+         * subsequent `nvgpu submit-compute`.
+         *
+         * Requires `nvgpu inherit` + `nvgpu channel` first. */
+        const struct ga10b_channel_handoff *h3 =
+            ga10b_bringup_handoff();
+        if (h3 == NULL || h3->inst_block_phys == 0) {
+            shell_puts("fecs-forcectx: no handoff loaded "
+                       "(run nvgpu channel first)\r\n");
+            return -1;
+        }
+        int rc = ga10b_fecs_force_current_ctx(h3->inst_block_phys);
+        shell_printf("fecs-forcectx: rc=%d\r\n", rc);
+        return rc;
+    }
     if (strcmp(argv[1], "submit-compute") == 0) {
         /* Phase 7 (compute): COMPUTE_B SEMAPHORE_RELEASE smoke test.
          * Requires `nvgpu inherit` + `nvgpu channel` first (same as
@@ -7584,6 +7605,7 @@ oplib_stage_call:
 
     shell_puts("usage: nvgpu [info | prepare | inherit | acr | test | "
               "channel | engine-status | engine-clear | "
+              "fecs-newctx | fecs-forcectx | fecs-stop-restart | "
               "submit | submit-compute | launch-kernel | "
               "run-mnist | fecs | gpccs | pmu | run | "
               "gmmu <pushbuf | walk | walk-raw | "

--- a/kernel/src/shell_sys.c
+++ b/kernel/src/shell_sys.c
@@ -5717,6 +5717,18 @@ int cmd_nvgpu(int argc, char *argv[])
     if (strcmp(argv[1], "rebuild-gmmu") == 0) {
         return cmd_nvgpu_rebuild_gmmu();
     }
+    if (strcmp(argv[1], "runlist-dump") == 0) {
+        /* #844 PBDMA-binding: decode Linux's live runlist word-layout.
+         * Run after `nvgpu inherit` + `nvgpu channel`. */
+        const struct ga10b_channel_handoff *hd = ga10b_bringup_handoff();
+        if (hd == NULL || hd->magic != GA10B_CHANNEL_HANDOFF_MAGIC) {
+            shell_puts("runlist-dump: handoff not loaded — "
+                       "run `nvgpu channel` first\r\n");
+            return -1;
+        }
+        ga10b_gmmu_dump_runlist_full(hd);
+        return 0;
+    }
     if (strcmp(argv[1], "engine-clear") == 0) {
         return cmd_nvgpu_engine_clear();
     }

--- a/scripts/gpu-kernel-mnist.c
+++ b/scripts/gpu-kernel-mnist.c
@@ -64,6 +64,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <signal.h>
 #include <errno.h>
@@ -1004,6 +1005,50 @@ int main(int argc, char **argv)
     }
     printf("[mnist]   final logits at phys 0x%llx (10 fp32 = 40 B)\n",
            (unsigned long long)ops[7].output.phys);
+
+    /* #844 probe: idle FECS w.r.t. our TSG before going to sleep.
+     *
+     * The 8-op MNIST pipeline completion is signaled via sentinel
+     * cells the kernels write to. Sentinel non-zero = kernel done +
+     * output written, but does NOT guarantee FECS has finished its
+     * ctxsw-out save. Without an explicit save-completion barrier
+     * here, FECS may still be mid-save (writing checksum bytes,
+     * golden-context maintenance, etc.) when the user runs
+     * slmos-kexec moments later.
+     *
+     * SLM-OS then inherits whatever in-flight FECS state existed at
+     * the kexec moment. On the first SLM-OS compute submit-compute,
+     * FECS attempts a ctxsw-in: it reads gr_ctx, computes the
+     * checksum, compares to its in-DMEM expected value. If FECS
+     * hadn't fully written the checksum bytes pre-kexec (or had
+     * been doing other internal bookkeeping that left expected-vs-
+     * stored slightly out of sync), the mismatch fires
+     * (CTXSW_CHECKSUM_MISMATCH, mb6=0x21). Per-boot deterministic
+     * because the mismatch state is fixed once kexec freezes
+     * everything.
+     *
+     * TSG_PREEMPT is a synchronous fifo-preempt: nvgpu writes
+     * `fifo_preempt_r() = preempt_id_f(tsgid) | preempt_type_tsg_f()`
+     * and polls `pending_true_f()` to clear before returning. The
+     * preempt forces FECS to complete the save of the currently-
+     * loaded ctx (ours, post-MNIST) and then go idle for this TSG.
+     * After this ioctl returns, gr_ctx contents in DRAM are
+     * complete and FECS-DMEM has a clean "no current ctx" state
+     * for the TSG.
+     *
+     * Reference: nvgpu's gk20a_fifo_preempt_tsg (kept under
+     * nvgpu-gk20a-fifo_gk20a-tx2.c:2499) — same path the kernel
+     * itself uses on channel-disable / TSG-shutdown to provably
+     * idle FECS. */
+    if (ioctl(ctx.tsg_fd, NVGPU_IOCTL_TSG_PREEMPT) == 0) {
+        printf("[mnist] TSG_PREEMPT issued — FECS idled, "
+               "gr_ctx save complete\n");
+    } else {
+        fprintf(stderr,
+                "[mnist] TSG_PREEMPT failed (errno=%d) — kexec may hit "
+                "per-boot FECS variance\n", errno);
+    }
+
     printf("[mnist] Sleeping up to %d s — kexec now.\n", timeout_secs);
 
     for (int remaining = timeout_secs; remaining > 0 && !g_shutdown; ) {

--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -1123,6 +1123,46 @@ if [[ -d "$GPU_POWER" && -d "$BPMP" ]]; then
         fi
     done
 
+    # Pin GPU devfreq to its max before kexec (#844 follow-up).
+    #
+    # The BPMP writes above keep the GPU clock *domain* enabled but
+    # don't constrain devfreq's frequency choice — at the kexec
+    # moment, the GPU is typically at the idle frequency (306 MHz on
+    # both Super and non-Super Orin Nano) because the helper has
+    # been sleeping with no GR work. Empirical 8-boot probe on
+    # jetson-nano-1 (non-Super, GPU max = 624.75 MHz):
+    #
+    #   - Without pin: 0/8 PASS post-kexec submit-compute
+    #     (every boot wedges at "PBDMA didn't see our submit",
+    #     GR registers PRI-poisoned).
+    #   - With pin to 624.75 MHz: 4/8 PASS.
+    #
+    # Pinning min_freq = max_freq forces devfreq to hold the GPU
+    # at its peak so the post-kexec channel-inherit path doesn't
+    # race a frequency-down transition. Doesn't fully close the
+    # gap to jetson-nano-2's 7/8 (Super, max = 1020 MHz) — there's
+    # a separate DT-level Super-vs-non-Super factor — but it's a
+    # board-agnostic improvement that the kexec script can apply
+    # unconditionally with no permanent state change (devfreq
+    # settings reset on power-cycle).
+    GPU_DEVFREQ=/sys/class/devfreq/17000000.gpu
+    if [[ -d "$GPU_DEVFREQ" ]]; then
+        gpu_max="$(cat "$GPU_DEVFREQ/max_freq" 2>/dev/null || echo '')"
+        if [[ -n "$gpu_max" && "$gpu_max" != "0" ]]; then
+            # Order matters: bump max first if we're raising, then
+            # min; lower min first if we're shrinking, then max.
+            # Setting both to the same value is safe in either
+            # order, but always write min last so a stale lower-
+            # max-than-min state can't briefly trip devfreq.
+            echo "$gpu_max" > "$GPU_DEVFREQ/min_freq" 2>/dev/null || \
+                echo "       min_freq write failed" >&2
+            gpu_cur="$(cat "$GPU_DEVFREQ/cur_freq" 2>/dev/null || echo '?')"
+            echo "       pinned GPU devfreq: cur=$gpu_cur min=max=$gpu_max"
+        else
+            echo "       devfreq max_freq unreadable — skipping pin"
+        fi
+    fi
+
     # Verify by reading NV_PMC_BOOT_0 via /dev/mem. This is the
     # same register SLM-OS reads to identify the GPU; if Linux
     # reads 0xB7B000A1 here and SLM-OS reads 0xFFFFFFFF post-

--- a/scripts/jetson-kexec-slmos.sh
+++ b/scripts/jetson-kexec-slmos.sh
@@ -1149,11 +1149,9 @@ if [[ -d "$GPU_POWER" && -d "$BPMP" ]]; then
     if [[ -d "$GPU_DEVFREQ" ]]; then
         gpu_max="$(cat "$GPU_DEVFREQ/max_freq" 2>/dev/null || echo '')"
         if [[ -n "$gpu_max" && "$gpu_max" != "0" ]]; then
-            # Order matters: bump max first if we're raising, then
-            # min; lower min first if we're shrinking, then max.
-            # Setting both to the same value is safe in either
-            # order, but always write min last so a stale lower-
-            # max-than-min state can't briefly trip devfreq.
+            # Raise min_freq to the existing max so devfreq holds the
+            # GPU at its ceiling. max_freq already == gpu_max, so this
+            # single write pins min==max.
             echo "$gpu_max" > "$GPU_DEVFREQ/min_freq" 2>/dev/null || \
                 echo "       min_freq write failed" >&2
             gpu_cur="$(cat "$GPU_DEVFREQ/cur_freq" 2>/dev/null || echo '?')"


### PR DESCRIPTION
## Summary

Post-kexec GPU channel inheritance work on Jetson GA10B, stacked on the GR PRI-wake fix merged in #975. This bundle adds the **source-justified recovery steps** and the **diagnostics** that the #844 investigation produced, plus the #978 nvpmodel-25W fix.

**Honest framing up front:** post-kexec channel inheritance is ~65% reliable (±~15% per 30-boot batch), and that is the practical ceiling of the *passive-inherit* approach — see #844 for the full analysis. The recovery commits here are kept because they are **source-correct** (mirror nvgpu's canonical sequences) and the #978 fix is a clear hard-signature win; they are **not** claimed as measurement-proven pass-rate gains, because the effect sizes sit below the noise floor at feasible boot counts (n=30). Diagnostics are pure observability.

## What's in it

**Fixes / recovery (source-justified):**
- **#978 — settle-delay GR PRI wake to tolerate nvpmodel 25W** (`30cdbf62`). Builds directly on #975's wake loop: adds a 1 ms settle per attempt (cap 200) so the GR PRI fabric has time to ungate at 25W. At MAXN/25W the bare #975 loop fails ~100%; with the settle it recovers (~2 ms typical). **This is the commit that makes #975's wake loop sufficient at 25W** — recommend landing close behind #975.
- **canonical FECS ctxsw recovery before first post-kexec dispatch** (`1ccca996`). `set_current_ctx_invalid` + per-channel `force_ctx_reload`, mirroring nvgpu's `gm20b_gr_falcon_set_current_ctx_invalid`. Reduces the `mb6=0x21` CTXSW_CHECKSUM_MISMATCH save-race.
- **jetson-kexec-slmos: pin GPU devfreq to max before kexec** (`1149ac3d`).
- **gpu-kernel-mnist: TSG_PREEMPT pre-kexec** (`5a90a4e9`) — synchronous fifo-preempt so FECS completes its ctx save before kexec freezes state.
- **nvgpu fecs-forcectx probe** (`ddb3630f`).

**Code hygiene (addresses the slmos-review of #975):**
- **GR_INTR_R / GR_EXCEPTION_R named constants + wake-loop init hygiene** (`d36887a1`). Replaces repeated `0x00400100`/`0x00400108` literals; seeds the wake loop's `value` with the poison sentinel so a zero-iteration loop fails safe.

**Diagnostics (read-only observability for #844):**
- **correct SM warp_esr decode** (`84e3363b`) — decodes the full 16-bit warp error field; names `mmu_nack (0x20)` vs shader-bug codes. (The compute-"hang" failure mode is an SM `mmu_nack` = stale inherited GMMU TLB.)
- **nvgpu runlist-dump diagnostic** (`a4415527`) — decodes the live GA10B runlist entry word-layout.
- **CHRAM + runlist diagnostics for the GP_GET-stuck failure** (`850120e7`).

## Test plan

- [x] Jetson kernel builds clean (`PLATFORM=JETSON_ORIN_NANO JETSON_HW_TICK=ON SECONDARY_PREEMPT=ON COOP_PREEMPT=OFF`)
- [x] QEMU test suite green (`make test`) — one observed `test_msg_router_same_mailbox_zero_loss` flake, passed on re-run; unrelated to these GA10B-only changes
- [x] Hardware: exercised across many 30-boot batches on jetson-nano-2 during the #844 investigation; #978 settle-delay verified at 25W (GR wakes ~iter 1, ~2 ms)
- [ ] Reviewer note: the recovery commits are source-correct, not pass-rate-proven (effects below the n=30 noise floor — see #844)

## Notes

- **Stacked on #975** (already merged). The #978 commit depends on #975's wake loop; main currently has the wake loop *without* the 25W settle until this lands.
- GPU-only / Jetson-only paths; no cross-platform behavior change (QEMU/Pi 5/x86-64 unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)