### PR TITLE
sshd 199b: Ed25519 host-key generation + VFS persistence (#892)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1019,6 +1019,9 @@ set(TEST_SOURCES
     # adds an #if defined(NET_SSHD) around the suite call so non-SSH
     # builds keep linking.
     $<$<AND:$<BOOL:${ENABLE_NETWORKING}>,$<BOOL:${NET_SSHD}>,$<NOT:$<STREQUAL:${PLATFORM},X86_64>>>:kernel/tests/test_sshd.c>
+    # SSH host-key persistence tests (#199b / #892). Gated on
+    # NET_SSHD at the source level (whole TU is #if NET_SSHD).
+    kernel/tests/test_host_key.c
     # DTB is ARM64 only (x86-64 doesn't build kernel/src/dtb.c)
     $<$<NOT:$<STREQUAL:${PLATFORM},X86_64>>:kernel/tests/test_dtb.c>
     # FDT general-purpose reader (kernel/lib/fdt) — ARM64 only for
@@ -1915,11 +1918,12 @@ if(ENABLE_NETWORKING AND NET_SSHD AND NOT PLATFORM STREQUAL "X86_64")
     target_link_libraries(wolfssh PRIVATE wolfcrypt)
 
     # SLM-OS-side glue: time, RNG seed, lwIP IO callbacks, listener,
-    # accept loop, shell verb.
+    # accept loop, host-key persistence, shell verb.
     target_sources(slmos.elf PRIVATE
         kernel/net/ssh/wolf_os.c
         kernel/net/ssh/sshd.c
         kernel/net/ssh/sshd_shell.c
+        kernel/net/ssh/host_key.c
     )
     target_include_directories(slmos.elf PRIVATE
         ${CMAKE_SOURCE_DIR}/kernel/net/ssh)

--- a/kernel/lib/wolfcrypt/user_settings.h
+++ b/kernel/lib/wolfcrypt/user_settings.h
@@ -95,10 +95,12 @@ extern "C" {
 #define HAVE_HKDF
 #define HAVE_CURVE25519
 #define HAVE_ED25519
+#define HAVE_ED25519_MAKE_KEY    /* required for wc_ed25519_make_key (#199b host key) */
 #define HAVE_ED25519_SIGN
 #define HAVE_ED25519_VERIFY
 #define HAVE_ED25519_KEY_IMPORT
 #define HAVE_ED25519_KEY_EXPORT
+#define WOLFSSL_KEY_GEN          /* enables wc_*_make_key paths across algorithms */
 /* wolfSSH 1.4.18's signing-algorithm gate requires all four of
  * HAVE_ED25519, _SIGN, _VERIFY, _KEY_IMPORT, _KEY_EXPORT AND
  * WOLFSSL_ED25519_STREAMING_VERIFY. Without the streaming flag,

--- a/kernel/net/ssh/host_key.c
+++ b/kernel/net/ssh/host_key.c
@@ -1,0 +1,337 @@
+/*
+ * host_key.c - Ed25519 host-key generation + persistence.
+ *
+ * Sits between sshd.c and the littlefs VFS mounted at /mnt/files.
+ * Mirrors the read/write pattern in blob_autoload.c (atomic .tmp +
+ * rename). See `host_key.h` for the API contract.
+ */
+
+#include "host_key.h"
+
+#include "littlefs_slm.h"
+#include "sha256.h"
+#include "string.h"
+#include "uart.h"
+#include "vfs.h"
+
+#include <wolfssl/wolfcrypt/ed25519.h>
+#include <wolfssl/wolfcrypt/random.h>
+
+/* All host-key state lives under /mnt/files/etc/ssh/.
+ *
+ * The VFS prefix "/mnt/files" is stripped by vfs_get_mount_ctx — the
+ * paths we hand to littlefs_* are mount-relative (e.g. "/etc/ssh/...").
+ */
+#define HOSTKEY_MNT_PREFIX        "/mnt/files"
+#define HOSTKEY_DIR_LFS           "/etc"
+#define HOSTKEY_SUBDIR_LFS        "/etc/ssh"
+#define HOSTKEY_FILE_LFS          "/etc/ssh/host_ed25519_key"
+#define HOSTKEY_TMP_LFS           "/etc/ssh/host_ed25519_key.tmp"
+#define HOSTKEY_PUB_LFS           "/etc/ssh/host_ed25519_key.pub"
+#define HOSTKEY_PUB_TMP_LFS       "/etc/ssh/host_ed25519_key.pub.tmp"
+
+/* ---------------------------------------------------------------- */
+/* Base64 encoder (no padding, URL-safe variant disabled)            */
+/* ---------------------------------------------------------------- */
+
+static const char kBase64Alphabet[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/* Encode `len` bytes from `in` into `out`. Returns the number of
+ * output chars written (NOT including a trailing NUL). The caller
+ * must size `out` to at least 4 * ((len + 2) / 3) + padding bytes.
+ *
+ * `pad` controls whether the output is padded with '=' to a 4-byte
+ * boundary (true = OpenSSH .pub format, false = SHA256 fingerprint
+ * format which strips '=' per OpenSSH convention).
+ */
+static size_t b64_encode(const uint8_t *in, size_t len, char *out, bool pad)
+{
+    size_t oi = 0;
+    size_t i  = 0;
+    while (i + 3u <= len) {
+        uint32_t v = ((uint32_t)in[i] << 16) | ((uint32_t)in[i + 1] << 8)
+                     | (uint32_t)in[i + 2];
+        out[oi++] = kBase64Alphabet[(v >> 18) & 0x3Fu];
+        out[oi++] = kBase64Alphabet[(v >> 12) & 0x3Fu];
+        out[oi++] = kBase64Alphabet[(v >> 6) & 0x3Fu];
+        out[oi++] = kBase64Alphabet[v & 0x3Fu];
+        i += 3u;
+    }
+    size_t tail = len - i;
+    if (tail == 1u) {
+        uint32_t v = (uint32_t)in[i] << 16;
+        out[oi++] = kBase64Alphabet[(v >> 18) & 0x3Fu];
+        out[oi++] = kBase64Alphabet[(v >> 12) & 0x3Fu];
+        if (pad) { out[oi++] = '='; out[oi++] = '='; }
+    } else if (tail == 2u) {
+        uint32_t v = ((uint32_t)in[i] << 16) | ((uint32_t)in[i + 1] << 8);
+        out[oi++] = kBase64Alphabet[(v >> 18) & 0x3Fu];
+        out[oi++] = kBase64Alphabet[(v >> 12) & 0x3Fu];
+        out[oi++] = kBase64Alphabet[(v >> 6) & 0x3Fu];
+        if (pad) { out[oi++] = '='; }
+    }
+    return oi;
+}
+
+/* ---------------------------------------------------------------- */
+/* RFC 4253 "ssh-ed25519" blob construction                          */
+/* ---------------------------------------------------------------- */
+
+/*
+ * Pack the public key into the RFC 4253 ssh-ed25519 wire format:
+ *
+ *   uint32 BE length=11; "ssh-ed25519"
+ *   uint32 BE length=32; <32 bytes pubkey>
+ *
+ * Total = 4 + 11 + 4 + 32 = 51 bytes.
+ */
+#define HOSTKEY_RFC4253_BLOB_LEN  51u
+
+static void pack_rfc4253(const uint8_t pub[HOST_KEY_PUB_LEN],
+                         uint8_t out[HOSTKEY_RFC4253_BLOB_LEN])
+{
+    static const char prefix[] = "ssh-ed25519";
+    size_t plen = sizeof(prefix) - 1u;   /* 11 */
+    size_t pos  = 0;
+    out[pos++] = 0; out[pos++] = 0; out[pos++] = 0; out[pos++] = (uint8_t)plen;
+    for (size_t i = 0; i < plen; i++) out[pos++] = (uint8_t)prefix[i];
+    out[pos++] = 0; out[pos++] = 0; out[pos++] = 0; out[pos++] = (uint8_t)HOST_KEY_PUB_LEN;
+    for (size_t i = 0; i < HOST_KEY_PUB_LEN; i++) out[pos++] = pub[i];
+}
+
+/* ---------------------------------------------------------------- */
+/* VFS helpers                                                       */
+/* ---------------------------------------------------------------- */
+
+static struct lfs_mount *resolve_mount(void)
+{
+    const char *subpath = NULL;
+    return (struct lfs_mount *)vfs_get_mount_ctx(HOSTKEY_MNT_PREFIX, &subpath);
+}
+
+static int ensure_dirs(struct lfs_mount *mnt)
+{
+    /* Create /etc and /etc/ssh — ignore errors if they already exist
+     * (littlefs returns LFS_ERR_EXIST in that case; littlefs_mkdir
+     * returns 0 on existing too on this codebase). */
+    (void)littlefs_mkdir(mnt, HOSTKEY_DIR_LFS);
+    (void)littlefs_mkdir(mnt, HOSTKEY_SUBDIR_LFS);
+    return 0;
+}
+
+static int read_full(struct lfs_mount *mnt, const char *path,
+                     uint8_t *buf, size_t want)
+{
+    int fd = littlefs_file_open(mnt, path, LFS_O_RDONLY);
+    if (fd < 0) return -1;
+    int n = littlefs_file_read(mnt, fd, buf, want);
+    littlefs_file_close(mnt, fd);
+    return (n == (int)want) ? 0 : -1;
+}
+
+static int write_atomic(struct lfs_mount *mnt,
+                        const char *final_path, const char *tmp_path,
+                        const uint8_t *buf, size_t len)
+{
+    int fd = littlefs_file_open(mnt, tmp_path,
+                                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC);
+    if (fd < 0) return -1;
+    int n = littlefs_file_write(mnt, fd, buf, len);
+    (void)littlefs_file_sync(mnt, fd);
+    littlefs_file_close(mnt, fd);
+    if (n != (int)len) {
+        (void)littlefs_remove(mnt, tmp_path);
+        return -1;
+    }
+    /* Remove the existing final (if any) before rename — littlefs
+     * doesn't atomic-replace on rename. */
+    (void)littlefs_remove(mnt, final_path);
+    if (littlefs_rename(mnt, tmp_path, final_path) != 0) {
+        (void)littlefs_remove(mnt, tmp_path);
+        return -1;
+    }
+    return 0;
+}
+
+/* ---------------------------------------------------------------- */
+/* Generation                                                        */
+/* ---------------------------------------------------------------- */
+
+/*
+ * Generate a fresh keypair and pack it into the 64-byte SLM-OS
+ * persistence layout: 32-byte seed (private) || 32-byte pub.
+ *
+ * wolfSSL's `wc_ed25519_export_key` returns a 64-byte private side
+ * (the seed CONCATENATED with the public key — RFC 8032 §5.1.5
+ * "expanded private key"). We don't want that layout on disk —
+ * OpenSSH and every other tool stores the 32-byte seed alone — so
+ * we use `wc_ed25519_export_private_only` + `wc_ed25519_export_public`
+ * to get the two halves explicitly.
+ */
+static int generate_keypair(uint8_t out[HOST_KEY_RAW_BUF_LEN])
+{
+    WC_RNG      rng;
+    ed25519_key key;
+
+    int rc = wc_InitRng(&rng);
+    if (rc != 0) return -1;
+    rc = wc_ed25519_init(&key);
+    if (rc != 0) { wc_FreeRng(&rng); return -1; }
+
+    rc = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (rc != 0) goto out;
+
+    uint32_t plen = HOST_KEY_PRIV_LEN;
+    rc = wc_ed25519_export_private_only(&key, out, &plen);
+    if (rc != 0 || plen != HOST_KEY_PRIV_LEN) { rc = -1; goto out; }
+
+    uint32_t ulen = HOST_KEY_PUB_LEN;
+    rc = wc_ed25519_export_public(&key, out + HOST_KEY_PRIV_LEN, &ulen);
+    if (rc != 0 || ulen != HOST_KEY_PUB_LEN) { rc = -1; goto out; }
+
+    rc = 0;
+out:
+    wc_ed25519_free(&key);
+    wc_FreeRng(&rng);
+    return rc;
+}
+
+/* ---------------------------------------------------------------- */
+/* Public-key file formatting                                        */
+/* ---------------------------------------------------------------- */
+
+/*
+ * Build the .pub line "ssh-ed25519 <base64> SLM-OS\n".
+ * Returns the byte length (no NUL).
+ */
+static size_t format_pub_line(const uint8_t pub[HOST_KEY_PUB_LEN],
+                              char *out, size_t cap)
+{
+    static const char k_prefix[]  = "ssh-ed25519 ";
+    static const char k_comment[] = " SLM-OS\n";
+
+    size_t pos = 0;
+    for (size_t i = 0; i < sizeof(k_prefix) - 1u; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = k_prefix[i];
+    }
+
+    uint8_t blob[HOSTKEY_RFC4253_BLOB_LEN];
+    pack_rfc4253(pub, blob);
+
+    /* Worst-case base64 length: 4 * ((51 + 2) / 3) = 72 chars + 3 pad. */
+    char b64[80];
+    size_t b64len = b64_encode(blob, sizeof(blob), b64, /* pad */ true);
+    if (pos + b64len > cap) return 0;
+    for (size_t i = 0; i < b64len; i++) out[pos++] = b64[i];
+
+    for (size_t i = 0; i < sizeof(k_comment) - 1u; i++) {
+        if (pos >= cap) return 0;
+        out[pos++] = k_comment[i];
+    }
+    return pos;
+}
+
+/* ---------------------------------------------------------------- */
+/* Public API                                                        */
+/* ---------------------------------------------------------------- */
+
+static int persist_pair(struct lfs_mount *mnt,
+                        const uint8_t priv_pub[HOST_KEY_RAW_BUF_LEN])
+{
+    if (ensure_dirs(mnt) != 0) return HOST_KEY_E_PERSIST;
+
+    /* Private key first (the load-time check looks for this). */
+    if (write_atomic(mnt, HOSTKEY_FILE_LFS, HOSTKEY_TMP_LFS,
+                     priv_pub, HOST_KEY_RAW_BUF_LEN) != 0) {
+        return HOST_KEY_E_PERSIST;
+    }
+
+    /* .pub line. */
+    char pub_line[160];
+    size_t pub_len = format_pub_line(priv_pub + HOST_KEY_PRIV_LEN,
+                                      pub_line, sizeof(pub_line));
+    if (pub_len == 0u) return HOST_KEY_E_PERSIST;
+
+    if (write_atomic(mnt, HOSTKEY_PUB_LFS, HOSTKEY_PUB_TMP_LFS,
+                     (const uint8_t *)pub_line, pub_len) != 0) {
+        return HOST_KEY_E_PERSIST;
+    }
+    return HOST_KEY_OK;
+}
+
+int host_key_load_or_generate(uint8_t priv_pub_out[HOST_KEY_RAW_BUF_LEN])
+{
+    if (!priv_pub_out) return HOST_KEY_E_BAD_ARG;
+
+    struct lfs_mount *mnt = resolve_mount();
+    if (!mnt) {
+        /* No /mnt/files. Fall back to ephemeral (in-memory) key —
+         * the caller (sshd_start) gets a valid keypair but it won't
+         * survive a reboot. Returning OK here is the contract: a
+         * boot without a persistent FS still gets a working sshd. */
+        if (generate_keypair(priv_pub_out) != 0) return HOST_KEY_E_GENERATE;
+        uart_printf("[SSHD] host key: ephemeral (no /mnt/files mount)\r\n");
+        return HOST_KEY_OK;
+    }
+
+    if (read_full(mnt, HOSTKEY_FILE_LFS, priv_pub_out,
+                  HOST_KEY_RAW_BUF_LEN) == 0) {
+        uart_printf("[SSHD] host key: loaded from %s%s\r\n",
+                    HOSTKEY_MNT_PREFIX, HOSTKEY_FILE_LFS);
+        return HOST_KEY_OK;
+    }
+
+    /* Not present — first boot. Generate + persist. */
+    if (generate_keypair(priv_pub_out) != 0) return HOST_KEY_E_GENERATE;
+    int rc = persist_pair(mnt, priv_pub_out);
+    if (rc == HOST_KEY_OK) {
+        uart_printf("[SSHD] host key: generated + persisted to %s%s\r\n",
+                    HOSTKEY_MNT_PREFIX, HOSTKEY_FILE_LFS);
+    } else {
+        uart_printf("[SSHD] host key: persist failed (%d) — using ephemeral\r\n", rc);
+        /* Don't fail the boot; the in-memory key is still usable. */
+        rc = HOST_KEY_OK;
+    }
+    return rc;
+}
+
+int host_key_regenerate(uint8_t priv_pub_out[HOST_KEY_RAW_BUF_LEN])
+{
+    if (!priv_pub_out) return HOST_KEY_E_BAD_ARG;
+
+    struct lfs_mount *mnt = resolve_mount();
+    if (mnt) {
+        (void)littlefs_remove(mnt, HOSTKEY_FILE_LFS);
+        (void)littlefs_remove(mnt, HOSTKEY_PUB_LFS);
+    }
+    /* Re-run the "no file → generate" path. */
+    return host_key_load_or_generate(priv_pub_out);
+}
+
+int host_key_fingerprint(const uint8_t pub[HOST_KEY_PUB_LEN],
+                         char *out, size_t cap)
+{
+    if (!pub || !out || cap < HOST_KEY_FINGERPRINT_MAX) return HOST_KEY_E_BAD_ARG;
+
+    uint8_t blob[HOSTKEY_RFC4253_BLOB_LEN];
+    pack_rfc4253(pub, blob);
+
+    uint8_t digest[SHA256_DIGEST_LEN];
+    struct sha256_ctx ctx;
+    sha256_init(&ctx);
+    sha256_update(&ctx, blob, sizeof(blob));
+    sha256_final(&ctx, digest);
+
+    /* "SHA256:" prefix + base64-without-padding of the 32-byte digest. */
+    static const char k_pfx[] = "SHA256:";
+    size_t pos = 0;
+    for (size_t i = 0; i < sizeof(k_pfx) - 1u && pos < cap - 1u; i++) {
+        out[pos++] = k_pfx[i];
+    }
+    pos += b64_encode(digest, sizeof(digest), out + pos, /* pad */ false);
+    if (pos >= cap) return HOST_KEY_E_BAD_ARG;
+    out[pos] = '\0';
+    return HOST_KEY_OK;
+}

--- a/kernel/net/ssh/host_key.c
+++ b/kernel/net/ssh/host_key.c
@@ -14,8 +14,18 @@
 #include "uart.h"
 #include "vfs.h"
 
+#include "lfs.h"   /* LFS_ERR_EXIST for ensure_dirs error filtering */
+
 #include <wolfssl/wolfcrypt/ed25519.h>
 #include <wolfssl/wolfcrypt/random.h>
+
+/* Pin the SLM-OS on-disk layout to wolfSSL's constant. If a future
+ * wolfSSL version were to change ED25519_KEY_SIZE the build would
+ * trip here instead of silently mis-sizing the persisted seed. */
+_Static_assert(ED25519_KEY_SIZE == HOST_KEY_PRIV_LEN,
+               "wolfSSL Ed25519 seed size diverged from SLM-OS layout");
+_Static_assert(ED25519_PUB_KEY_SIZE == HOST_KEY_PUB_LEN,
+               "wolfSSL Ed25519 public-key size diverged from SLM-OS layout");
 
 /* All host-key state lives under /mnt/files/etc/ssh/.
  *
@@ -95,9 +105,10 @@ static void pack_rfc4253(const uint8_t pub[HOST_KEY_PUB_LEN],
     size_t plen = sizeof(prefix) - 1u;   /* 11 */
     size_t pos  = 0;
     out[pos++] = 0; out[pos++] = 0; out[pos++] = 0; out[pos++] = (uint8_t)plen;
-    for (size_t i = 0; i < plen; i++) out[pos++] = (uint8_t)prefix[i];
+    memcpy(out + pos, prefix, plen);
+    pos += plen;
     out[pos++] = 0; out[pos++] = 0; out[pos++] = 0; out[pos++] = (uint8_t)HOST_KEY_PUB_LEN;
-    for (size_t i = 0; i < HOST_KEY_PUB_LEN; i++) out[pos++] = pub[i];
+    memcpy(out + pos, pub, HOST_KEY_PUB_LEN);
 }
 
 /* ---------------------------------------------------------------- */
@@ -112,11 +123,15 @@ static struct lfs_mount *resolve_mount(void)
 
 static int ensure_dirs(struct lfs_mount *mnt)
 {
-    /* Create /etc and /etc/ssh — ignore errors if they already exist
-     * (littlefs returns LFS_ERR_EXIST in that case; littlefs_mkdir
-     * returns 0 on existing too on this codebase). */
-    (void)littlefs_mkdir(mnt, HOSTKEY_DIR_LFS);
-    (void)littlefs_mkdir(mnt, HOSTKEY_SUBDIR_LFS);
+    /* Create /etc and /etc/ssh. LFS_ERR_EXIST means the dir is
+     * already there and we proceed; any other negative return is a
+     * real failure (NOMEM / IO / NOSPC) that the caller needs to see
+     * so it can return HOST_KEY_E_PERSIST with a meaningful cause
+     * rather than letting `write_atomic` blow up later. */
+    int rc = littlefs_mkdir(mnt, HOSTKEY_DIR_LFS);
+    if (rc != 0 && rc != LFS_ERR_EXIST) return rc;
+    rc = littlefs_mkdir(mnt, HOSTKEY_SUBDIR_LFS);
+    if (rc != 0 && rc != LFS_ERR_EXIST) return rc;
     return 0;
 }
 
@@ -127,7 +142,9 @@ static int read_full(struct lfs_mount *mnt, const char *path,
     if (fd < 0) return -1;
     int n = littlefs_file_read(mnt, fd, buf, want);
     littlefs_file_close(mnt, fd);
-    return (n == (int)want) ? 0 : -1;
+    /* Treat any negative `n` (read error) as failure; the cast in the
+     * size-equality comparison only runs once `n` is non-negative. */
+    return (n >= 0 && (size_t)n == want) ? 0 : -1;
 }
 
 static int write_atomic(struct lfs_mount *mnt,
@@ -224,7 +241,8 @@ static size_t format_pub_line(const uint8_t pub[HOST_KEY_PUB_LEN],
     char b64[80];
     size_t b64len = b64_encode(blob, sizeof(blob), b64, /* pad */ true);
     if (pos + b64len > cap) return 0;
-    for (size_t i = 0; i < b64len; i++) out[pos++] = b64[i];
+    memcpy(out + pos, b64, b64len);
+    pos += b64len;
 
     for (size_t i = 0; i < sizeof(k_comment) - 1u; i++) {
         if (pos >= cap) return 0;

--- a/kernel/net/ssh/host_key.h
+++ b/kernel/net/ssh/host_key.h
@@ -1,0 +1,83 @@
+/*
+ * host_key.h - Ed25519 host-key generation + persistence.
+ *
+ * On first boot of an `NET_SSHD=ON` kernel, generates an Ed25519
+ * keypair and persists it under `/mnt/files/etc/ssh/`. On subsequent
+ * boots, loads the existing keypair so the SSH host-key fingerprint
+ * is stable across reboots.
+ *
+ * File layout under `/mnt/files/etc/ssh/`:
+ *
+ *   host_ed25519_key      32-byte raw Ed25519 seed (private)
+ *   host_ed25519_key.pub  "ssh-ed25519 <base64-of-rfc4253-blob> SLM-OS\n"
+ *
+ * Atomic persist: write to `host_ed25519_key.tmp`, then `rename` to
+ * the final path. A power loss mid-write therefore leaves either the
+ * pre-existing key or the new key — never a torn half.
+ *
+ * The private-key format is intentionally a 32-byte raw seed and NOT
+ * OpenSSH's PEM-wrapped `BEGIN OPENSSH PRIVATE KEY` envelope. SLM-OS
+ * doesn't need PEM compatibility — only the kernel reads this file.
+ * The public-key file IS OpenSSH-compatible so an operator can
+ * `cat host_ed25519_key.pub >> ~/.ssh/known_hosts` directly.
+ *
+ * #199b (this sub-ticket). #199c will replace the ephemeral key in
+ * sshd_start with a call to host_key_load_or_generate.
+ */
+
+#ifndef SLMOS_HOST_KEY_H
+#define SLMOS_HOST_KEY_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#define HOST_KEY_PRIV_LEN          32u   /* Ed25519 seed */
+#define HOST_KEY_PUB_LEN           32u   /* Ed25519 public key */
+#define HOST_KEY_RAW_BUF_LEN       (HOST_KEY_PRIV_LEN + HOST_KEY_PUB_LEN)
+
+/* SHA-256 fingerprint, base64-encoded without padding, plus the
+ * "SHA256:" prefix. 32 raw bytes → 43 base64 chars. */
+#define HOST_KEY_FINGERPRINT_MAX   64u
+
+enum host_key_result {
+    HOST_KEY_OK              = 0,
+    HOST_KEY_E_NO_MOUNT      = -1,   /* /mnt/files not available */
+    HOST_KEY_E_GENERATE      = -2,   /* wc_ed25519_make_key failed */
+    HOST_KEY_E_PERSIST       = -3,   /* file write / rename failed */
+    HOST_KEY_E_LOAD          = -4,   /* file present but malformed */
+    HOST_KEY_E_BAD_ARG       = -5,
+};
+
+/*
+ * Load the host key from `/mnt/files/etc/ssh/host_ed25519_key`. If
+ * absent, generates a new keypair and persists it before returning.
+ *
+ * `priv_pub_out` must be at least HOST_KEY_RAW_BUF_LEN bytes; on
+ * success it's populated with [32-byte private seed][32-byte public].
+ * Returns 0 on success.
+ *
+ * Concurrency: callers must serialize among themselves; the function
+ * does not take a mount-level lock. In practice sshd_start is the
+ * only caller and runs once per boot.
+ */
+int host_key_load_or_generate(uint8_t priv_pub_out[HOST_KEY_RAW_BUF_LEN]);
+
+/*
+ * Force regeneration: removes any existing key files and generates a
+ * new pair. Useful for compromise recovery / testing via the
+ * `sshd regenerate-host-key` shell verb.
+ */
+int host_key_regenerate(uint8_t priv_pub_out[HOST_KEY_RAW_BUF_LEN]);
+
+/*
+ * Compute the OpenSSH-compatible SHA-256 fingerprint of the current
+ * (or supplied) public key. Format: "SHA256:<base64-without-padding>".
+ *
+ * `out` must be at least HOST_KEY_FINGERPRINT_MAX bytes. On success
+ * the buffer is NUL-terminated.
+ */
+int host_key_fingerprint(const uint8_t pub[HOST_KEY_PUB_LEN],
+                         char *out, size_t cap);
+
+#endif /* SLMOS_HOST_KEY_H */

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -19,12 +19,16 @@
  *     when empty (wolfSSH yield-loops on this); `wolf_io_send`
  *     `tcp_write` + `tcp_output` on the pcb.
  *
- * Host key (#199a interim):
+ * Host key:
  *
- *   - Ephemeral Ed25519 keypair generated at `sshd_start` time via
- *     `wc_ed25519_make_key` seeded by the kernel RNG.
- *   - #199b replaces this with a persisted key in
- *     `/mnt/files/etc/ssh/host_ed25519_key`.
+ *   - Ed25519 keypair persisted under
+ *     `/mnt/files/etc/ssh/host_ed25519_key` — see
+ *     kernel/net/ssh/host_key.c for the read/generate/persist flow.
+ *   - `sshd_start` calls `host_key_load_or_generate` once, caches the
+ *     [seed||pub] layout in `g_hostkey_raw`, and re-materialises a
+ *     PKCS#8 DER form for `wolfSSH_CTX_UsePrivateKey_buffer` on each
+ *     start (wolfSSH copies it internally). The cached buffer is
+ *     wiped via `sshd_invalidate_hostkey` so the next start re-loads.
  */
 
 #include "sshd.h"
@@ -119,9 +123,7 @@ void sshd_invalidate_hostkey(void)
      * re-runs the load path. Also tears down the cached CTX so its
      * cached PrivateKey is dropped. */
     irq_flags_t flags = spin_lock_irqsave(&g_mod_lock);
-    for (size_t i = 0; i < HOST_KEY_RAW_BUF_LEN; i++) {
-        g_hostkey_raw[i] = 0u;
-    }
+    secure_zero(g_hostkey_raw, sizeof(g_hostkey_raw));
     g_hostkey_raw_len = 0u;
     if (g_ctx) {
         wolfSSH_CTX_free(g_ctx);
@@ -511,18 +513,24 @@ int sshd_start(uint16_t port)
 
         /* DER form for Ed25519 PKCS#8 is at most ~85 bytes; 128 gives
          * a safe margin. wc_Ed25519PrivateKeyToDer returns the length
-         * actually written. */
+         * actually written. The buffer carries the full private seed
+         * on the stack — wipe it on every exit path (secure_zero
+         * defeats dead-store-elim; the stack frame is reclaimed by
+         * the scheduler when sshd_start's caller task returns). */
         uint8_t der[128];
         int der_len = wc_Ed25519PrivateKeyToDer(&tmp_key, der, (uint32_t)sizeof(der));
         wc_ed25519_free(&tmp_key);
         if (der_len <= 0) {
+            secure_zero(der, sizeof(der));
             wolfSSH_CTX_free(g_ctx); g_ctx = NULL; return SSHD_E_NO_HOSTKEY;
         }
 
-        if (wolfSSH_CTX_UsePrivateKey_buffer(g_ctx,
-                                             der,
-                                             (uint32_t)der_len,
-                                             WOLFSSH_FORMAT_RAW) != WS_SUCCESS) {
+        int use_rc = wolfSSH_CTX_UsePrivateKey_buffer(g_ctx,
+                                                     der,
+                                                     (uint32_t)der_len,
+                                                     WOLFSSH_FORMAT_RAW);
+        secure_zero(der, sizeof(der));
+        if (use_rc != WS_SUCCESS) {
             wolfSSH_CTX_free(g_ctx);
             g_ctx = NULL;
             return SSHD_E_NO_HOSTKEY;

--- a/kernel/net/ssh/sshd.c
+++ b/kernel/net/ssh/sshd.c
@@ -30,6 +30,7 @@
 #include "sshd.h"
 
 #include "config.h"
+#include "host_key.h"
 #include "rng.h"
 #include "sched.h"
 #include "spinlock.h"
@@ -48,6 +49,7 @@
 #include <wolfssh/ssh.h>
 #include <wolfssh/error.h>
 #include <wolfssh/internal.h>
+#include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/ed25519.h>
 #include <wolfssl/wolfcrypt/random.h>
 
@@ -95,42 +97,37 @@ static volatile uint32_t   g_kex_failed;
 static volatile uint32_t   g_active;
 
 /* ---------------------------------------------------------------- */
-/* Ephemeral host key (#199a interim — replaced by #199b)            */
+/* Host key — VFS-persisted via kernel/net/ssh/host_key.c            */
 /* ---------------------------------------------------------------- */
 
-/* Ed25519 keypair encoded as the 64-byte "private+public" buffer
- * wolfSSH's UsePrivateKey_buffer expects for `WOLFSSH_FORMAT_RAW`.
- * Filled by `generate_ephemeral_hostkey`. */
-static uint8_t  g_hostkey_raw[ED25519_KEY_SIZE + ED25519_PUB_KEY_SIZE];
+/* Cached keypair held resident for the daemon's lifetime. Loaded
+ * from `/mnt/files/etc/ssh/host_ed25519_key` (or generated +
+ * persisted on first boot). Layout is [32-byte private seed][32-byte
+ * public key] — matches wolfSSH's WOLFSSH_FORMAT_RAW expectation. */
+static uint8_t  g_hostkey_raw[HOST_KEY_RAW_BUF_LEN];
 static uint32_t g_hostkey_raw_len;
 
-static int generate_ephemeral_hostkey(void)
+const uint8_t *sshd_internal_public_key(void)
 {
-    WC_RNG    rng;
-    ed25519_key key;
-    int rc = wc_InitRng(&rng);
-    if (rc != 0) return SSHD_E_NO_HOSTKEY;
+    if (g_hostkey_raw_len == 0u) return NULL;
+    return g_hostkey_raw + HOST_KEY_PRIV_LEN;
+}
 
-    rc = wc_ed25519_init(&key);
-    if (rc != 0) { wc_FreeRng(&rng); return SSHD_E_NO_HOSTKEY; }
-
-    rc = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
-    if (rc != 0) goto out;
-
-    /* Export private + public side-by-side for wolfSSH's raw-format
-     * importer. */
-    uint32_t priv_len = ED25519_KEY_SIZE;
-    uint32_t pub_len  = ED25519_PUB_KEY_SIZE;
-    rc = wc_ed25519_export_key(&key,
-                               g_hostkey_raw,                          &priv_len,
-                               g_hostkey_raw + ED25519_KEY_SIZE,       &pub_len);
-    if (rc == 0) {
-        g_hostkey_raw_len = priv_len + pub_len;
+void sshd_invalidate_hostkey(void)
+{
+    /* Wipe the cached private+public buffer so the next sshd_start
+     * re-runs the load path. Also tears down the cached CTX so its
+     * cached PrivateKey is dropped. */
+    irq_flags_t flags = spin_lock_irqsave(&g_mod_lock);
+    for (size_t i = 0; i < HOST_KEY_RAW_BUF_LEN; i++) {
+        g_hostkey_raw[i] = 0u;
     }
-out:
-    wc_ed25519_free(&key);
-    wc_FreeRng(&rng);
-    return (rc == 0) ? SSHD_OK : SSHD_E_NO_HOSTKEY;
+    g_hostkey_raw_len = 0u;
+    if (g_ctx) {
+        wolfSSH_CTX_free(g_ctx);
+        g_ctx = NULL;
+    }
+    spin_unlock_irqrestore(&g_mod_lock, flags);
 }
 
 /* ---------------------------------------------------------------- */
@@ -475,11 +472,14 @@ int sshd_start(uint16_t port)
         return SSHD_E_WOLF_INIT;
     }
 
-    /* Generate the ephemeral host key (#199b replaces with a
-     * persisted key). */
+    /* Load (or first-boot-generate-and-persist) the Ed25519 host
+     * keypair under /mnt/files/etc/ssh/. See kernel/net/ssh/host_key.c.
+     * Re-loaded across sshd_stop/start cycles in case the operator
+     * regenerated the key. */
     if (g_hostkey_raw_len == 0u) {
-        int rc = generate_ephemeral_hostkey();
-        if (rc != SSHD_OK) return rc;
+        int rc = host_key_load_or_generate(g_hostkey_raw);
+        if (rc != HOST_KEY_OK) return SSHD_E_NO_HOSTKEY;
+        g_hostkey_raw_len = HOST_KEY_RAW_BUF_LEN;
     }
 
     /* Create the shared SERVER context. */
@@ -490,9 +490,38 @@ int sshd_start(uint16_t port)
         wolfSSH_SetIORecv(g_ctx, wolf_io_recv);
         wolfSSH_SetIOSend(g_ctx, wolf_io_send);
 
+        /* Convert the SLM-OS-native (seed || pub) layout into the
+         * PKCS#8 DER form wolfSSH's WOLFSSH_FORMAT_RAW importer
+         * actually expects (it requires bytes starting with 0x30,
+         * the ASN.1 SEQUENCE tag — "RAW" in wolfSSH terminology is
+         * "DER without PEM wrapper"). We materialise the DER each
+         * sshd_start so the cached host-key buffer remains the
+         * compact 64-byte seed||pub format on disk. */
+        ed25519_key tmp_key;
+        if (wc_ed25519_init(&tmp_key) != 0) {
+            wolfSSH_CTX_free(g_ctx); g_ctx = NULL; return SSHD_E_NO_HOSTKEY;
+        }
+        if (wc_ed25519_import_private_key(g_hostkey_raw, HOST_KEY_PRIV_LEN,
+                                          g_hostkey_raw + HOST_KEY_PRIV_LEN,
+                                          HOST_KEY_PUB_LEN,
+                                          &tmp_key) != 0) {
+            wc_ed25519_free(&tmp_key);
+            wolfSSH_CTX_free(g_ctx); g_ctx = NULL; return SSHD_E_NO_HOSTKEY;
+        }
+
+        /* DER form for Ed25519 PKCS#8 is at most ~85 bytes; 128 gives
+         * a safe margin. wc_Ed25519PrivateKeyToDer returns the length
+         * actually written. */
+        uint8_t der[128];
+        int der_len = wc_Ed25519PrivateKeyToDer(&tmp_key, der, (uint32_t)sizeof(der));
+        wc_ed25519_free(&tmp_key);
+        if (der_len <= 0) {
+            wolfSSH_CTX_free(g_ctx); g_ctx = NULL; return SSHD_E_NO_HOSTKEY;
+        }
+
         if (wolfSSH_CTX_UsePrivateKey_buffer(g_ctx,
-                                             g_hostkey_raw,
-                                             g_hostkey_raw_len,
+                                             der,
+                                             (uint32_t)der_len,
                                              WOLFSSH_FORMAT_RAW) != WS_SUCCESS) {
             wolfSSH_CTX_free(g_ctx);
             g_ctx = NULL;

--- a/kernel/net/ssh/sshd.h
+++ b/kernel/net/ssh/sshd.h
@@ -52,4 +52,14 @@ int sshd_stop(void);
 /* Fill `out` with current stats. Always succeeds when `out != NULL`. */
 void sshd_get_stats(struct sshd_stats *out);
 
+/* Internal accessor used by the `sshd fingerprint` shell verb to
+ * compute the SHA-256 of the live public key. Returns NULL if no
+ * host key has been loaded yet (sshd_start hasn't run). */
+const uint8_t *sshd_internal_public_key(void);
+
+/* Tell sshd to forget the cached host key so the next sshd_start
+ * call re-reads it from disk (or regenerates if removed). Used by
+ * `sshd regenerate-host-key`. */
+void sshd_invalidate_hostkey(void);
+
 #endif /* SSHD_H */

--- a/kernel/net/ssh/sshd_shell.c
+++ b/kernel/net/ssh/sshd_shell.c
@@ -3,10 +3,12 @@
  *
  * Subcommands:
  *
- *   sshd                    -> status (alias of `sshd status`)
- *   sshd status             -> running state, port, KEX counters
- *   sshd start [port]       -> bring up the listener; default port 2222
- *   sshd stop               -> tear down the listener + open sessions
+ *   sshd                          -> status (alias of `sshd status`)
+ *   sshd status                   -> running state, port, KEX counters
+ *   sshd start [port]             -> bring up the listener; default port 2222
+ *   sshd stop                     -> tear down the listener + open sessions
+ *   sshd fingerprint              -> SHA-256 of the host public key
+ *   sshd regenerate-host-key      -> remove + recreate the host keypair
  *
  * `sshd_autostart.c` (added in #199c) wraps `sshd_start` behind a
  * config-file driven boot hook parallel to `telnetd_autostart`.
@@ -103,8 +105,10 @@ static int do_regenerate(void)
 {
     uint8_t buf[HOST_KEY_RAW_BUF_LEN];
     int rc = host_key_regenerate(buf);
-    /* Wipe the local stack copy regardless of result. */
-    for (size_t i = 0; i < sizeof(buf); i++) buf[i] = 0u;
+    /* Wipe the local stack copy regardless of result — secure_zero
+     * defeats dead-store elimination, which would otherwise drop the
+     * write since `buf` is dead after the function returns. */
+    secure_zero(buf, sizeof(buf));
     if (rc != HOST_KEY_OK) {
         uart_printf("sshd: regenerate failed (rc=%d)\r\n", rc);
         return rc;

--- a/kernel/net/ssh/sshd_shell.c
+++ b/kernel/net/ssh/sshd_shell.c
@@ -15,6 +15,7 @@
 
 #include "sshd.h"
 
+#include "host_key.h"
 #include "net.h"
 #include "shell.h"
 #include "shell_internal.h"
@@ -82,6 +83,41 @@ static int do_start(int argc, char **argv)
     return rc;
 }
 
+static int do_fingerprint(void)
+{
+    const uint8_t *pub = sshd_internal_public_key();
+    if (!pub) {
+        uart_printf("sshd: no host key loaded — run `sshd start` first\r\n");
+        return -1;
+    }
+    char fp[HOST_KEY_FINGERPRINT_MAX];
+    if (host_key_fingerprint(pub, fp, sizeof(fp)) != HOST_KEY_OK) {
+        uart_printf("sshd: fingerprint computation failed\r\n");
+        return -1;
+    }
+    uart_printf("%s\r\n", fp);
+    return 0;
+}
+
+static int do_regenerate(void)
+{
+    uint8_t buf[HOST_KEY_RAW_BUF_LEN];
+    int rc = host_key_regenerate(buf);
+    /* Wipe the local stack copy regardless of result. */
+    for (size_t i = 0; i < sizeof(buf); i++) buf[i] = 0u;
+    if (rc != HOST_KEY_OK) {
+        uart_printf("sshd: regenerate failed (rc=%d)\r\n", rc);
+        return rc;
+    }
+    /* Tear down the cached sshd state so the next sshd start picks up
+     * the new key. If the listener is currently up, stop it first. */
+    sshd_stop();
+    sshd_invalidate_hostkey();
+    uart_printf("sshd: host key regenerated; run `sshd start` to bring "
+                "the listener back up\r\n");
+    return 0;
+}
+
 int cmd_sshd(int argc, char **argv)
 {
     if (argc < 2 || strcmp(argv[1], "status") == 0) {
@@ -94,6 +130,13 @@ int cmd_sshd(int argc, char **argv)
     if (strcmp(argv[1], "stop") == 0) {
         return sshd_stop();
     }
-    uart_printf("usage: sshd [status|start [port]|stop]\r\n");
+    if (strcmp(argv[1], "fingerprint") == 0) {
+        return do_fingerprint();
+    }
+    if (strcmp(argv[1], "regenerate-host-key") == 0) {
+        return do_regenerate();
+    }
+    uart_printf("usage: sshd [status|start [port]|stop|fingerprint|"
+                "regenerate-host-key]\r\n");
     return -1;
 }

--- a/kernel/src/help.c
+++ b/kernel/src/help.c
@@ -436,6 +436,30 @@ static const struct help_entry help_entries[] = {
         "  - Buddy allocator state\n"
     ),
 
+#if defined(NET_SSHD)
+    HELP_TEXT("sshd",
+        "sshd - SSH daemon (port 22 / 2222)\n"
+        "\n"
+        "Usage:\n"
+        "  sshd                          Show status (alias of `sshd status`)\n"
+        "  sshd status                   Running state, port, KEX counters\n"
+        "  sshd start [port]             Bring up the listener (default 2222)\n"
+        "  sshd stop                     Tear down the listener + active sessions\n"
+        "  sshd fingerprint              SHA-256 fingerprint of the host public key\n"
+        "  sshd regenerate-host-key      Remove + recreate the host keypair (rare)\n"
+        "\n"
+        "Wired against the vendored wolfSSH (v1.4.18-stable) + wolfCrypt\n"
+        "(v5.7.4-stable) on top of the kernel's lwIP raw TCP API. KEX:\n"
+        "curve25519-sha256. Cipher: AES-256-GCM. Host key: Ed25519,\n"
+        "persisted to /mnt/files/etc/ssh/host_ed25519_key. The .pub file\n"
+        "is OpenSSH-compatible — `cat .pub >> ~/.ssh/known_hosts` works.\n"
+        "\n"
+        "#199c lands the shell-channel binding (today the daemon refuses\n"
+        "shell channels after KEX); #199d adds real password auth; #199e\n"
+        "flips the autostart default to ON behind the bootstrap gate.\n"
+    ),
+#endif
+
     HELP_TEXT("rng",
         "rng - Crypto-quality random number generator\n"
         "\n"

--- a/kernel/src/net_shell.c
+++ b/kernel/src/net_shell.c
@@ -628,7 +628,7 @@ static const shell_cmd_t net_commands[] = {
     {"netstat",  cmd_netstat,  "Network statistics",                                   false, SHELL_CAT_NETWORK},
     {"ping",     cmd_ping,     "Send ICMP echo request",                               true,  SHELL_CAT_NETWORK},
 #if defined(NET_SSHD)
-    {"sshd",     cmd_sshd,     "SSH daemon (start [port]|stop|status)",                true,  SHELL_CAT_NETWORK},
+    {"sshd",     cmd_sshd,     "SSH daemon (start|stop|status|fingerprint|regenerate-host-key)", true, SHELL_CAT_NETWORK},
 #endif
     {"tcpsh",    cmd_telnetd,  "Alias for telnetd (legacy name)",                      true,  SHELL_CAT_NETWORK},
     {"telnetd",  cmd_telnetd,  "Telnet shell daemon (start|stop|status|sessions|kick)", true,  SHELL_CAT_NETWORK},

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -218,7 +218,12 @@ const shell_cmd_t builtin_commands[] = {
 const int NUM_BUILTIN_COMMANDS = sizeof(builtin_commands) / sizeof(builtin_commands[0]);
 
 /* External command slots for runtime registration */
-#define MAX_EXTERNAL_COMMANDS 16
+/* External command slots — sized to cover every production registration
+ * (net_shell, kernel_cmd, nvidia_gpu_register_shell_commands, etc.) plus
+ * a handful of test fixtures registered at runtime. Bumped from 16 in
+ * #199a / #893 to absorb the new `sshd` verb alongside the existing
+ * net verbs without crowding out test-time fixtures. */
+#define MAX_EXTERNAL_COMMANDS 24
 shell_cmd_t external_commands[MAX_EXTERNAL_COMMANDS];
 int num_external_commands = 0;
 

--- a/kernel/tests/test_harness.c
+++ b/kernel/tests/test_harness.c
@@ -193,6 +193,9 @@ int test_harness_run_all(void)
 #if defined(NET_SSHD)
     /* SSH daemon — public API + per-conn ring (#199a / #893). */
     total_failures += test_suite_sshd();
+    /* SSH host-key persistence (#199b / #892). The TU only compiles
+     * when NET_SSHD is on, so it stays inside the same gate. */
+    total_failures += test_suite_host_key();
 #endif
     /* `kernel` admin command surface (also relies on sdhci-pci). */
     total_failures += test_suite_kernel_cmd();

--- a/kernel/tests/test_harness.h
+++ b/kernel/tests/test_harness.h
@@ -221,6 +221,11 @@ int test_suite_rng(void);
 /* SSH daemon (#199a / #893) — sshd_get_stats public API + per-conn
  * RX ring round-trip / capacity / wrap / pool-cap behaviour. */
 int test_suite_sshd(void);
+
+/* SSH host-key persistence tests (#199b / #892). Same NET_SSHD gate
+ * as the daemon itself; the TU only compiles when the host_key
+ * module does. */
+int test_suite_host_key(void);
 #endif
 
 /* General-purpose FDT reader tests (kernel/lib/fdt) */

--- a/kernel/tests/test_host_key.c
+++ b/kernel/tests/test_host_key.c
@@ -38,10 +38,12 @@ static void test_load_or_generate_produces_keypair(void)
     /* Private + public should both be non-zero with overwhelming
      * probability for a real Ed25519 keypair. */
     int priv_nz = 0, pub_nz = 0;
-    for (size_t i = 0; i < HOST_KEY_PRIV_LEN; i++)
+    for (size_t i = 0; i < HOST_KEY_PRIV_LEN; i++) {
         if (buf[i] != 0u) { priv_nz = 1; break; }
-    for (size_t i = 0; i < HOST_KEY_PUB_LEN; i++)
+    }
+    for (size_t i = 0; i < HOST_KEY_PUB_LEN; i++) {
         if (buf[HOST_KEY_PRIV_LEN + i] != 0u) { pub_nz = 1; break; }
+    }
     TEST_ASSERT_EQUAL_INT(1, priv_nz);
     TEST_ASSERT_EQUAL_INT(1, pub_nz);
 }

--- a/kernel/tests/test_host_key.c
+++ b/kernel/tests/test_host_key.c
@@ -1,0 +1,146 @@
+/*
+ * test_host_key.c — Ed25519 host-key persistence coverage.
+ *
+ * Verifies the read/generate/persist contract documented in
+ * `kernel/net/ssh/host_key.h`:
+ *
+ *   - First call generates + persists; subsequent calls return the
+ *     same bytes (read path).
+ *   - Fingerprint is stable for the same public key and deterministic
+ *     across calls.
+ *   - Different public keys produce different fingerprints.
+ *
+ * The "persist across reboots" claim is verifiable on hardware (#199e)
+ * but inside a QEMU test run we can only check that two same-boot
+ * calls return identical bytes — the littlefs mount is reused between
+ * them, which is the same code path as a fresh load post-reboot.
+ *
+ * Gated on NET_SSHD so the test only compiles when the daemon is
+ * enabled (the host_key module is only built then). #199b / #892.
+ */
+
+#if defined(NET_SSHD)
+
+#include "host_key.h"
+#include "unity.h"
+
+#include <stdint.h>
+#include <string.h>
+
+static void test_load_or_generate_produces_keypair(void)
+{
+    uint8_t buf[HOST_KEY_RAW_BUF_LEN];
+    memset(buf, 0, sizeof(buf));
+
+    int rc = host_key_load_or_generate(buf);
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK, rc);
+
+    /* Private + public should both be non-zero with overwhelming
+     * probability for a real Ed25519 keypair. */
+    int priv_nz = 0, pub_nz = 0;
+    for (size_t i = 0; i < HOST_KEY_PRIV_LEN; i++)
+        if (buf[i] != 0u) { priv_nz = 1; break; }
+    for (size_t i = 0; i < HOST_KEY_PUB_LEN; i++)
+        if (buf[HOST_KEY_PRIV_LEN + i] != 0u) { pub_nz = 1; break; }
+    TEST_ASSERT_EQUAL_INT(1, priv_nz);
+    TEST_ASSERT_EQUAL_INT(1, pub_nz);
+}
+
+static void test_load_after_generate_matches(void)
+{
+    uint8_t a[HOST_KEY_RAW_BUF_LEN];
+    uint8_t b[HOST_KEY_RAW_BUF_LEN];
+    memset(a, 0, sizeof(a));
+    memset(b, 0, sizeof(b));
+
+    /* First call generates + persists (or loads if a prior test
+     * already did). */
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK, host_key_load_or_generate(a));
+    /* Second call exercises the load path — bytes must match. */
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK, host_key_load_or_generate(b));
+    TEST_ASSERT_EQUAL_MEMORY(a, b, HOST_KEY_RAW_BUF_LEN);
+}
+
+static void test_fingerprint_is_stable(void)
+{
+    uint8_t buf[HOST_KEY_RAW_BUF_LEN];
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK, host_key_load_or_generate(buf));
+
+    char fp_a[HOST_KEY_FINGERPRINT_MAX];
+    char fp_b[HOST_KEY_FINGERPRINT_MAX];
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK,
+        host_key_fingerprint(buf + HOST_KEY_PRIV_LEN, fp_a, sizeof(fp_a)));
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK,
+        host_key_fingerprint(buf + HOST_KEY_PRIV_LEN, fp_b, sizeof(fp_b)));
+    TEST_ASSERT_EQUAL_STRING(fp_a, fp_b);
+
+    /* Must start with the OpenSSH "SHA256:" prefix. */
+    TEST_ASSERT_EQUAL_INT(0, strncmp(fp_a, "SHA256:", 7));
+    /* "SHA256:" + 43 base64 chars (no padding) = 50 chars. */
+    TEST_ASSERT_EQUAL_INT(50, (int)strlen(fp_a));
+}
+
+static void test_fingerprint_differs_for_different_keys(void)
+{
+    /* Build two synthetic public keys with all-A vs all-B bytes —
+     * SHA-256 of their RFC 4253 blobs must differ. */
+    uint8_t pub_a[HOST_KEY_PUB_LEN];
+    uint8_t pub_b[HOST_KEY_PUB_LEN];
+    memset(pub_a, 0xAAu, sizeof(pub_a));
+    memset(pub_b, 0xBBu, sizeof(pub_b));
+
+    char fp_a[HOST_KEY_FINGERPRINT_MAX];
+    char fp_b[HOST_KEY_FINGERPRINT_MAX];
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK,
+        host_key_fingerprint(pub_a, fp_a, sizeof(fp_a)));
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK,
+        host_key_fingerprint(pub_b, fp_b, sizeof(fp_b)));
+    TEST_ASSERT_NOT_EQUAL(0, strcmp(fp_a, fp_b));
+}
+
+static void test_regenerate_produces_new_key(void)
+{
+    uint8_t before[HOST_KEY_RAW_BUF_LEN];
+    uint8_t after[HOST_KEY_RAW_BUF_LEN];
+
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK, host_key_load_or_generate(before));
+    TEST_ASSERT_EQUAL_INT(HOST_KEY_OK, host_key_regenerate(after));
+
+    /* Equal bytes after regenerate would imply the regenerate code
+     * path read the file rather than removing + recreating. */
+    int differ = (memcmp(before, after, HOST_KEY_RAW_BUF_LEN) != 0);
+    TEST_ASSERT_EQUAL_INT(1, differ);
+}
+
+static void test_fingerprint_buf_too_small(void)
+{
+    uint8_t pub[HOST_KEY_PUB_LEN];
+    memset(pub, 0x55u, sizeof(pub));
+    char tiny[8];
+    int rc = host_key_fingerprint(pub, tiny, sizeof(tiny));
+    TEST_ASSERT_NOT_EQUAL(0, rc);
+}
+
+int test_suite_host_key(void)
+{
+    UnityBegin("SSH host key (Ed25519, VFS-persisted)");
+
+    RUN_TEST(test_load_or_generate_produces_keypair);
+    RUN_TEST(test_load_after_generate_matches);
+    RUN_TEST(test_fingerprint_is_stable);
+    RUN_TEST(test_fingerprint_differs_for_different_keys);
+    RUN_TEST(test_regenerate_produces_new_key);
+    RUN_TEST(test_fingerprint_buf_too_small);
+
+    return UnityEnd();
+}
+
+#else  /* !NET_SSHD */
+
+/* Keep the TU non-empty so -Wpedantic stays happy when NET_SSHD is
+ * off. The test_suite_host_key() symbol is only referenced from
+ * test_harness.c inside an #if defined(NET_SSHD) guard, so this
+ * stub never runs in the OFF build. */
+typedef int test_host_key_placeholder_t;
+
+#endif /* NET_SSHD */


### PR DESCRIPTION
## Summary

Implements #892 (sub-ticket 199b) on top of #902's RNG floor + wolfSSH integration. Adds a persisted Ed25519 host key under `/mnt/files/etc/ssh/host_ed25519_key`; subsequent boots load the existing key so the SSH host-key fingerprint is stable across reboots.

Rebased onto the post-#902 main tip after #902's squash merge into `358d6358`. Replaces the prior 199b PR (#914), which was closed when #902 merged.

## What's in this PR

- **`kernel/net/ssh/host_key.{h,c}`** — `host_key_load_or_generate` (reads existing key or generates + persists atomically via `.tmp + rename`), `host_key_regenerate`, `host_key_fingerprint` (SHA-256 of the RFC 4253 ssh-ed25519 blob, formatted to match OpenSSH 6.8+).
- **`kernel/net/ssh/sshd.c`** — `sshd_start` now calls `host_key_load_or_generate` instead of the ephemeral keypair from #199a. Wraps the on-disk seed||pub into a PKCS#8 DER blob via `wc_Ed25519PrivateKeyToDer` for wolfSSH (which expects DER under `WOLFSSH_FORMAT_RAW`).
- **`sshd fingerprint`** + **`sshd regenerate-host-key`** shell subcommands.
- **`kernel/tests/test_host_key.c`** (6 tests, NET_SSHD-gated): nonzero output, load-path round-trip, fingerprint stability, fingerprint differs for different keys, regenerate produces a new key, fingerprint-buf-too-small handling.
- **`user_settings.h`** — adds `HAVE_ED25519_MAKE_KEY` + `WOLFSSL_KEY_GEN` so `wc_ed25519_make_key` doesn't silently fail with -132.
- **`shell.c`** — `MAX_EXTERNAL_COMMANDS` 16 → 24 (room for new `sshd` subcommands + test fixtures).

## Build matrix

| Target | NET_SSHD=OFF | NET_SSHD=ON |
|---|---|---|
| QEMU_VIRT | clean | clean (test_host_key 6/6 + test_sshd 7/7) |
| RASPI5 | clean | clean |
| JETSON_ORIN_NANO | clean | clean |

## Out of scope

- wolfSSH FILE * hooks against the VFS (WOPEN/WREAD/WFCLOSE) — SLM-OS doesn't route any wolfSSH path through `FILE *`; keys move via `wolfSSH_CTX_UsePrivateKey_buffer`.
- Hardware verification of cross-reboot persistence — same-boot round-trip is covered by the test suite; cross-reboot validation lands under #895's hardware budget alongside the #199c demo.

## Test plan

- [x] `make test` (default, NET_SSHD=OFF): PASS
- [x] `make test NET_SSHD=ON`: PASS — test_host_key (6 cases) + test_sshd (7 cases) all green
- [ ] Hardware smoke once the rest of the chain is rebased + the lab is available (#199c demo path)

Refs: #199, #892, supersedes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)