### PR TITLE
hailo-re: native-flow boundary-trace diff tool (#795, toward #682 reopen)

### DIFF
--- a/host-tools/hailo-re-driver/bin/hailo-re-native-diff
+++ b/host-tools/hailo-re-driver/bin/hailo-re-native-diff
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Direct-run shim. `pip install -e .` also installs this as a console script."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from hailo_re_driver.cli import native_diff_main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(native_diff_main())

--- a/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
@@ -1,0 +1,111 @@
+"""Parse Hailo boundary-trace lines into corpus-comparable BAR ops.
+
+The kernel emits one line per instrumented operation when the
+boundary-trace toolkit is armed (`hailo trace phase=... mech=mmio` +
+PR #780 framework). Format from `kernel/ai_accel/hailo/hailo_trace.c`:
+
+    [trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x12345678
+    [trc] phase=link       mech=MMIO RD32 bar=4 off=0x0640 val=0x00000000
+
+(`phase=%-10s mech=%-4s` — column-padded; widths vary as the framework
+adds phases.) This module extracts the MMIO subset of those lines —
+the operations that match the corpus's op-shape `(bar, offset, dir,
+size, value)` — and discards everything else (PCI cfg, RPC framing,
+IRQ deliveries, DMA events, busy-wait markers). Only 32-bit MMIO is
+emitted by the trace today; the parser tolerates an integer suffix in
+`WR<N>` / `RD<N>` so 16/8-bit widths land cleanly if the kernel grows
+them later.
+
+The corpus uses `dir="read"|"write"` and `size` in bytes; this parser
+converts WR/RD + suffix accordingly.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Optional
+
+
+# Anchors on `mech=MMIO` so we positively skip cfg/rx/dma/irq/udelay
+# lines without matching their op-name tokens. Phase column is captured
+# for diagnostic reporting (knowing the divergence happened in
+# `phase=inference` vs `phase=fw_boot` is the load-bearing context).
+_MMIO_RE = re.compile(
+    r"^\[trc\]\s+"
+    r"phase=(?P<phase>\S+)\s+"
+    r"mech=MMIO\s+"
+    r"(?P<op>WR|RD)(?P<width>\d+)\s+"
+    r"bar=(?P<bar>\d+)\s+"
+    r"off=0x(?P<off>[0-9a-fA-F]+)\s+"
+    r"val=0x(?P<val>[0-9a-fA-F]+)"
+    r"\s*$"
+)
+
+
+@dataclass(frozen=True)
+class BoundaryTraceOp:
+    """One MMIO operation captured by the kernel's boundary trace.
+
+    Field shapes mirror the corpus op-entry contract (see
+    docs/hailo-re-corpus-format.md §Lines 2..N) so a BoundaryTraceOp
+    can be lined up against a corpus op by `(bar, offset, dir, size,
+    value)`. `phase` is the kernel-side phase mask at emit time and is
+    metadata only — corpus entries don't carry it.
+
+    `value` is the little-endian hex string the kernel emitted, with
+    no `0x` prefix and zero-padded to `size * 2` chars. Matches the
+    corpus's `value` field exactly so equality comparisons are
+    string-trivial.
+    """
+
+    bar: int
+    offset: int
+    dir: str       # "read" or "write"
+    size: int      # bytes
+    value: str     # zero-padded LE-hex, no 0x
+    phase: str     # informational; e.g. "fw_boot", "model_load"
+    raw_line: str  # original line for error reporting
+
+
+def parse_trace_line(line: str) -> Optional[BoundaryTraceOp]:
+    """Parse one boundary-trace line. Returns None for non-MMIO lines.
+
+    Non-MMIO trace lines (PCI cfg, RPC, IRQ, DMA, busy-wait) and
+    completely unrelated serial output (boot banner, shell prompts,
+    hailo replay-step diagnostics) all return None — they're not
+    errors, they're just not the corpus's op-shape.
+    """
+    m = _MMIO_RE.match(line.rstrip("\r\n"))
+    if m is None:
+        return None
+    width_bits = int(m.group("width"))
+    if width_bits % 8 != 0 or width_bits == 0:
+        # Kernel today emits 32 only; reject obvious garbage rather
+        # than coerce a nonsense byte count.
+        return None
+    size = width_bits // 8
+    raw_val = m.group("val")
+    # Pad to canonical LE-hex width so a malformed-but-otherwise-valid
+    # line ("val=0x1" when size=4) still compares correctly against
+    # the corpus's zero-padded form ("00000001").
+    value = raw_val.zfill(size * 2).lower()
+    return BoundaryTraceOp(
+        bar=int(m.group("bar")),
+        offset=int(m.group("off"), 16),
+        dir="write" if m.group("op") == "WR" else "read",
+        size=size,
+        value=value,
+        phase=m.group("phase"),
+        raw_line=line.rstrip("\r\n"),
+    )
+
+
+def parse_trace_stream(lines: Iterable[str]) -> Iterator[BoundaryTraceOp]:
+    """Yield BoundaryTraceOp for every parseable MMIO line, skipping
+    everything else. The caller is free to wrap with `list()` if a
+    one-shot in-memory parse is preferred over streaming."""
+    for line in lines:
+        op = parse_trace_line(line)
+        if op is not None:
+            yield op

--- a/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
@@ -86,7 +86,14 @@ def parse_trace_line(line: str) -> Optional[BoundaryTraceOp]:
         return None
     size = width_bits // 8
     raw_val = m.group("val")
-    # Pad to canonical LE-hex width so a malformed-but-otherwise-valid
+    # Reject over-wide hex (e.g. "val=0x123456789" for a 4-byte op).
+    # The kernel doesn't emit these today, but if it ever does we want
+    # the line to fail parsing loudly — not silently mismatch against
+    # the corpus's narrower stored value (zfill only pads, never
+    # truncates).
+    if len(raw_val) > size * 2:
+        return None
+    # Pad to canonical LE-hex width so a short-but-otherwise-valid
     # line ("val=0x1" when size=4) still compares correctly against
     # the corpus's zero-padded form ("00000001").
     value = raw_val.zfill(size * 2).lower()

--- a/host-tools/hailo-re-driver/hailo_re_driver/cli.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/cli.py
@@ -321,6 +321,17 @@ def native_diff_main(argv: Optional[list[str]] = None) -> int:
     args = p.parse_args(argv)
     _setup_logging(args.verbose)
 
+    # A non-positive look-ahead would make every shape mismatch an
+    # immediate hard divergence (the inner range(1, lookahead+1) is
+    # empty). Probably not what the operator meant — fail fast with a
+    # specific message instead of producing a confusing report.
+    if args.lookahead <= 0:
+        print(
+            f"--lookahead must be > 0, got {args.lookahead}",
+            file=sys.stderr,
+        )
+        return 2
+
     corpus = corpus_mod.load(args.corpus)
     with args.trace.open() as f:
         trace_ops = list(parse_trace_stream(f))

--- a/host-tools/hailo-re-driver/hailo_re_driver/cli.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/cli.py
@@ -1,10 +1,14 @@
 """Command-line entry points for the driver.
 
-Three commands:
+Four commands:
 
-- `hailo-re-bootstrap`  — run the Phase 1/2 single-step loop.
-- `hailo-re-validate`   — Phase 3 re-validation; stamp validated_at_commit.
-- `hailo-re-diff`       — standalone corpus diff tool.
+- `hailo-re-bootstrap`   — run the Phase 1/2 single-step loop.
+- `hailo-re-validate`    — Phase 3 re-validation; stamp validated_at_commit.
+- `hailo-re-diff`        — standalone corpus diff tool.
+- `hailo-re-native-diff` — diff a SLM-OS native-flow boundary trace
+                            against a corpus, locating the first hard
+                            divergence (most relevant to the #682
+                            reopen criteria).
 """
 
 from __future__ import annotations
@@ -276,4 +280,52 @@ def diff_main(argv: Optional[list[str]] = None) -> int:
     else:
         report = diff_mod.diff_corpora(args.left, args.right)
     print(diff_mod.format_report(report, show_matches=args.show_matches))
+    return 1 if report.diverged else 0
+
+
+# --------------------------------------------------------------------------- #
+# hailo-re-native-diff
+# --------------------------------------------------------------------------- #
+
+
+def native_diff_main(argv: Optional[list[str]] = None) -> int:
+    """Diff a native-flow boundary trace against a corpus.
+
+    Unlike `hailo-re-diff --observed`, this expects a raw capture from
+    the kernel boundary-trace toolkit (`hailo trace ...` plus
+    `scripts/capture-hailo-trace.sh`), not a pre-formatted observed-
+    trace JSONL. The aligner does bounded look-ahead resync, so
+    extra/missing ops on either side don't immediately stop the walk.
+    """
+    from . import native_diff as native_diff_mod
+    from .boundary_trace import parse_trace_stream
+
+    p = argparse.ArgumentParser(
+        prog="hailo-re-native-diff",
+        description=(
+            "Diff a SLM-OS native-flow boundary-trace capture against a "
+            "corpus. Locates the first position where SLM-OS native and "
+            "HailoRT-via-corpus take divergent paths — the actionable "
+            "finding for the #682 reopen criteria."
+        ),
+    )
+    p.add_argument("corpus", type=Path,
+                   help="corpus JSONL (header + ops)")
+    p.add_argument("trace", type=Path,
+                   help="capture-hailo-trace.sh output (mixed serial log; "
+                        "non-MMIO lines are silently skipped)")
+    p.add_argument("--lookahead", type=int, default=8,
+                   help="resync look-ahead window; wider papers over more "
+                        "skew, narrower surfaces more divergences (default: 8)")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+    _setup_logging(args.verbose)
+
+    corpus = corpus_mod.load(args.corpus)
+    with args.trace.open() as f:
+        trace_ops = list(parse_trace_stream(f))
+    report = native_diff_mod.diff_native_against_corpus(
+        corpus.ops, trace_ops, lookahead=args.lookahead,
+    )
+    print(native_diff_mod.format_report(report))
     return 1 if report.diverged else 0

--- a/host-tools/hailo-re-driver/hailo_re_driver/native_diff.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/native_diff.py
@@ -1,0 +1,294 @@
+"""Diff a SLM-OS native-flow boundary trace against a corpus.
+
+Unlike `hailo-re-validate` (which assumes SLM-OS replays the corpus
+op-by-op and emits one observed line per corpus seq), this diff
+operates on a free-running native flow trace from the kernel's
+boundary-trace toolkit. The native flow does NOT preserve corpus seq
+order — SLM-OS's native driver issues ops in its own order, may add
+ops HailoRT didn't, and may skip ops HailoRT did. So strict
+position-by-position comparison breaks almost immediately.
+
+The strategy here is **ordered lockstep with bounded look-ahead
+resync**:
+
+- Walk corpus and trace pointers forward in parallel.
+- At each step compare `(bar, offset, dir, size, value)` tuples.
+- On match: advance both, continue.
+- On mismatch: peek up to `lookahead` ops ahead on each side to see
+  if a small skew explains it (SLM-OS added/missed a handful of ops
+  but otherwise stays on the captured path). If a resync is found,
+  record the skipped ops as `extra_in_trace` or `missing_from_trace`
+  and continue from the resync point.
+- If no resync is found within the window, the divergence is real —
+  record `first_divergent_corpus_op` + `first_divergent_trace_op`
+  and stop walking. The caller decides what to do with the report.
+
+`lookahead=8` is the V1 default. Wider is more forgiving (better
+for early-init ops where SLM-OS may probe before HailoRT does), but
+also more likely to skip past a real divergence by interpreting it
+as an asymmetric skip. Capture the cmdline-level argument so a real
+investigation can tune it without code changes.
+
+This module is **strictly** position-based. A multi-set / Hungarian-
+alignment approach would surface "all the ops one side has and the
+other doesn't" without an ordering claim, but answers a different
+question — for the #682 reopen criteria we want to know *where in
+the dispatch sequence* SLM-OS deviates from HailoRT, which is an
+ordered-divergence question.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+from .boundary_trace import BoundaryTraceOp
+from .corpus import OpEntry
+
+
+def _ops_equal(corpus_op: OpEntry, trace_op: BoundaryTraceOp) -> bool:
+    """A corpus op and trace op match iff every wire-observable field
+    agrees. `phase` is metadata only (trace-side context), `seq` and
+    `source` are corpus-side bookkeeping — neither participates."""
+    return (
+        corpus_op.bar == trace_op.bar
+        and corpus_op.offset == trace_op.offset
+        and corpus_op.dir == trace_op.dir
+        and corpus_op.size == trace_op.size
+        and corpus_op.value.lower() == trace_op.value.lower()
+    )
+
+
+def _shape_match(corpus_op: OpEntry, trace_op: BoundaryTraceOp) -> bool:
+    """Shape match ignores value. Used by resync look-ahead so a
+    different read-back value (e.g. a status register that flipped
+    between captures) doesn't prevent us from rejoining the sequence
+    — that's reported as a `value_mismatch` instead of an asymmetric
+    skip, which is more actionable for the operator."""
+    return (
+        corpus_op.bar == trace_op.bar
+        and corpus_op.offset == trace_op.offset
+        and corpus_op.dir == trace_op.dir
+        and corpus_op.size == trace_op.size
+    )
+
+
+@dataclass(frozen=True)
+class _ValueMismatch:
+    corpus_idx: int
+    corpus_op: OpEntry
+    trace_idx: int
+    trace_op: BoundaryTraceOp
+
+
+@dataclass(frozen=True)
+class _AsymmetricSkip:
+    """Records that one side had ops the other side didn't, recovered
+    via look-ahead. `side` is "trace" (extra ops in trace not in
+    corpus) or "corpus" (missing ops from trace that the corpus has)."""
+
+    side: str           # "trace" or "corpus"
+    corpus_idx: int     # corpus index where the skip began
+    trace_idx: int      # trace index where the skip began
+    skipped_ops_count: int
+
+
+@dataclass
+class NativeDiffReport:
+    """Result of a `diff_native_against_corpus` call.
+
+    `diverged` is True iff a position was reached where no look-ahead
+    resync could explain the mismatch (i.e. SLM-OS native and the
+    corpus genuinely disagree on what should happen next). The
+    first_divergent_* fields locate it; `value_mismatches` and
+    `asymmetric_skips` collect the soft divergences encountered
+    along the way for context.
+    """
+
+    diverged: bool
+    matched_op_count: int
+    corpus_op_count: int
+    trace_op_count: int
+    first_divergent_corpus_idx: Optional[int] = None
+    first_divergent_corpus_op: Optional[OpEntry] = None
+    first_divergent_trace_idx: Optional[int] = None
+    first_divergent_trace_op: Optional[BoundaryTraceOp] = None
+    value_mismatches: List[_ValueMismatch] = field(default_factory=list)
+    asymmetric_skips: List[_AsymmetricSkip] = field(default_factory=list)
+
+
+def diff_native_against_corpus(
+    corpus_ops: Sequence[OpEntry],
+    trace_ops: Sequence[BoundaryTraceOp],
+    *,
+    lookahead: int = 8,
+) -> NativeDiffReport:
+    """Align trace_ops against corpus_ops and report the first hard
+    divergence (or None if they line up cleanly).
+
+    `corpus_ops` is assumed to be in seq-monotonic order (the order
+    `corpus.load(...).ops` returns). `trace_ops` is in capture order
+    from the kernel boundary trace.
+    """
+    i = 0  # corpus pointer
+    j = 0  # trace pointer
+    matched = 0
+    value_mismatches: List[_ValueMismatch] = []
+    asymmetric_skips: List[_AsymmetricSkip] = []
+
+    while i < len(corpus_ops) and j < len(trace_ops):
+        c = corpus_ops[i]
+        t = trace_ops[j]
+
+        if _ops_equal(c, t):
+            matched += 1
+            i += 1
+            j += 1
+            continue
+
+        if _shape_match(c, t):
+            # Same wire location, different value. Soft divergence —
+            # most often a status-register read that flipped, sometimes
+            # a real protocol-level value-mismatch (e.g. SLM-OS wrote
+            # the wrong descriptor field). Record + advance both so
+            # we can find the next divergence too.
+            value_mismatches.append(_ValueMismatch(
+                corpus_idx=i, corpus_op=c, trace_idx=j, trace_op=t,
+            ))
+            i += 1
+            j += 1
+            continue
+
+        # Hard mismatch in shape. Try resync:
+        # 1. Does corpus[i] match trace[j+k] for some k in [1, lookahead]?
+        #    → SLM-OS did `k` extra ops; advance trace past them.
+        resync_in_trace: Optional[int] = None
+        for k in range(1, lookahead + 1):
+            if j + k >= len(trace_ops):
+                break
+            if _shape_match(c, trace_ops[j + k]):
+                resync_in_trace = k
+                break
+
+        # 2. Does corpus[i+k] match trace[j] for some k in [1, lookahead]?
+        #    → SLM-OS missed `k` ops; advance corpus past them.
+        resync_in_corpus: Optional[int] = None
+        for k in range(1, lookahead + 1):
+            if i + k >= len(corpus_ops):
+                break
+            if _shape_match(corpus_ops[i + k], t):
+                resync_in_corpus = k
+                break
+
+        # Prefer the closer resync; tie-break toward "trace had extra"
+        # because in practice native-flow traces are noisier than the
+        # HailoRT-derived corpus (cache maintenance, sanity reads,
+        # etc.).
+        if resync_in_trace is not None and (
+            resync_in_corpus is None or resync_in_trace <= resync_in_corpus
+        ):
+            asymmetric_skips.append(_AsymmetricSkip(
+                side="trace", corpus_idx=i, trace_idx=j,
+                skipped_ops_count=resync_in_trace,
+            ))
+            j += resync_in_trace
+            continue
+        if resync_in_corpus is not None:
+            asymmetric_skips.append(_AsymmetricSkip(
+                side="corpus", corpus_idx=i, trace_idx=j,
+                skipped_ops_count=resync_in_corpus,
+            ))
+            i += resync_in_corpus
+            continue
+
+        # No resync within the window → hard divergence.
+        return NativeDiffReport(
+            diverged=True,
+            matched_op_count=matched,
+            corpus_op_count=len(corpus_ops),
+            trace_op_count=len(trace_ops),
+            first_divergent_corpus_idx=i,
+            first_divergent_corpus_op=c,
+            first_divergent_trace_idx=j,
+            first_divergent_trace_op=t,
+            value_mismatches=value_mismatches,
+            asymmetric_skips=asymmetric_skips,
+        )
+
+    # Reached the end of one side without a hard divergence. If the
+    # tail of either side is non-empty, that's reportable as an
+    # asymmetric-skip too — but not a "divergence" in the strict
+    # sense.
+    if i < len(corpus_ops):
+        asymmetric_skips.append(_AsymmetricSkip(
+            side="corpus",
+            corpus_idx=i,
+            trace_idx=j,
+            skipped_ops_count=len(corpus_ops) - i,
+        ))
+    if j < len(trace_ops):
+        asymmetric_skips.append(_AsymmetricSkip(
+            side="trace",
+            corpus_idx=i,
+            trace_idx=j,
+            skipped_ops_count=len(trace_ops) - j,
+        ))
+
+    return NativeDiffReport(
+        diverged=False,
+        matched_op_count=matched,
+        corpus_op_count=len(corpus_ops),
+        trace_op_count=len(trace_ops),
+        value_mismatches=value_mismatches,
+        asymmetric_skips=asymmetric_skips,
+    )
+
+
+def format_report(report: NativeDiffReport) -> str:
+    """Render a NativeDiffReport for the operator. Designed to be
+    pasted into a Hailo support ticket / GH issue verbatim."""
+    lines = [
+        "native-flow vs corpus diff",
+        "  matched ops:        %d / corpus=%d trace=%d" % (
+            report.matched_op_count,
+            report.corpus_op_count,
+            report.trace_op_count,
+        ),
+        "  value mismatches:   %d" % len(report.value_mismatches),
+        "  asymmetric skips:   %d" % len(report.asymmetric_skips),
+        "",
+    ]
+    if report.diverged:
+        c = report.first_divergent_corpus_op
+        t = report.first_divergent_trace_op
+        assert c is not None and t is not None
+        lines.append(
+            "DIVERGED at corpus_idx=%d trace_idx=%d:" % (
+                report.first_divergent_corpus_idx,
+                report.first_divergent_trace_idx,
+            )
+        )
+        lines.append(
+            "  corpus expected: bar=%d off=0x%04x size=%d dir=%-5s value=%s seq=%d" % (
+                c.bar, c.offset, c.size, c.dir, c.value, c.seq,
+            )
+        )
+        lines.append(
+            "  trace observed:  bar=%d off=0x%04x size=%d dir=%-5s value=%s phase=%s" % (
+                t.bar, t.offset, t.size, t.dir, t.value, t.phase,
+            )
+        )
+    else:
+        lines.append("clean match (no hard divergence)")
+    if report.value_mismatches:
+        lines.append("")
+        lines.append("first 5 value mismatches:")
+        for vm in report.value_mismatches[:5]:
+            lines.append(
+                "  corpus[%d] bar=%d off=0x%04x dir=%s: expected=%s observed=%s (phase=%s)" % (
+                    vm.corpus_idx, vm.corpus_op.bar, vm.corpus_op.offset,
+                    vm.corpus_op.dir, vm.corpus_op.value,
+                    vm.trace_op.value, vm.trace_op.phase,
+                )
+            )
+    return "\n".join(lines)

--- a/host-tools/hailo-re-driver/hailo_re_driver/native_diff.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/native_diff.py
@@ -40,10 +40,16 @@ ordered-divergence question.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Sequence
+from typing import List, Literal, Optional, Sequence
 
 from .boundary_trace import BoundaryTraceOp
 from .corpus import OpEntry
+
+
+# Discriminator for `_AsymmetricSkip.side`. `Literal` rather than an enum
+# keeps the report JSON-serialisable trivially while still making typos
+# like `side="tarce"` a type-checker error.
+SkipSide = Literal["trace", "corpus"]
 
 
 def _ops_equal(corpus_op: OpEntry, trace_op: BoundaryTraceOp) -> bool:
@@ -87,7 +93,7 @@ class _AsymmetricSkip:
     via look-ahead. `side` is "trace" (extra ops in trace not in
     corpus) or "corpus" (missing ops from trace that the corpus has)."""
 
-    side: str           # "trace" or "corpus"
+    side: SkipSide
     corpus_idx: int     # corpus index where the skip began
     trace_idx: int      # trace index where the skip began
     skipped_ops_count: int
@@ -249,13 +255,10 @@ def format_report(report: NativeDiffReport) -> str:
     pasted into a Hailo support ticket / GH issue verbatim."""
     lines = [
         "native-flow vs corpus diff",
-        "  matched ops:        %d / corpus=%d trace=%d" % (
-            report.matched_op_count,
-            report.corpus_op_count,
-            report.trace_op_count,
-        ),
-        "  value mismatches:   %d" % len(report.value_mismatches),
-        "  asymmetric skips:   %d" % len(report.asymmetric_skips),
+        f"  matched ops:        {report.matched_op_count} / "
+        f"corpus={report.corpus_op_count} trace={report.trace_op_count}",
+        f"  value mismatches:   {len(report.value_mismatches)}",
+        f"  asymmetric skips:   {len(report.asymmetric_skips)}",
         "",
     ]
     if report.diverged:
@@ -263,20 +266,16 @@ def format_report(report: NativeDiffReport) -> str:
         t = report.first_divergent_trace_op
         assert c is not None and t is not None
         lines.append(
-            "DIVERGED at corpus_idx=%d trace_idx=%d:" % (
-                report.first_divergent_corpus_idx,
-                report.first_divergent_trace_idx,
-            )
+            f"DIVERGED at corpus_idx={report.first_divergent_corpus_idx} "
+            f"trace_idx={report.first_divergent_trace_idx}:"
         )
         lines.append(
-            "  corpus expected: bar=%d off=0x%04x size=%d dir=%-5s value=%s seq=%d" % (
-                c.bar, c.offset, c.size, c.dir, c.value, c.seq,
-            )
+            f"  corpus expected: bar={c.bar} off=0x{c.offset:04x} "
+            f"size={c.size} dir={c.dir:<5} value={c.value} seq={c.seq}"
         )
         lines.append(
-            "  trace observed:  bar=%d off=0x%04x size=%d dir=%-5s value=%s phase=%s" % (
-                t.bar, t.offset, t.size, t.dir, t.value, t.phase,
-            )
+            f"  trace observed:  bar={t.bar} off=0x{t.offset:04x} "
+            f"size={t.size} dir={t.dir:<5} value={t.value} phase={t.phase}"
         )
     else:
         lines.append("clean match (no hard divergence)")
@@ -285,10 +284,9 @@ def format_report(report: NativeDiffReport) -> str:
         lines.append("first 5 value mismatches:")
         for vm in report.value_mismatches[:5]:
             lines.append(
-                "  corpus[%d] bar=%d off=0x%04x dir=%s: expected=%s observed=%s (phase=%s)" % (
-                    vm.corpus_idx, vm.corpus_op.bar, vm.corpus_op.offset,
-                    vm.corpus_op.dir, vm.corpus_op.value,
-                    vm.trace_op.value, vm.trace_op.phase,
-                )
+                f"  corpus[{vm.corpus_idx}] bar={vm.corpus_op.bar} "
+                f"off=0x{vm.corpus_op.offset:04x} dir={vm.corpus_op.dir}: "
+                f"expected={vm.corpus_op.value} observed={vm.trace_op.value} "
+                f"(phase={vm.trace_op.phase})"
             )
     return "\n".join(lines)

--- a/host-tools/hailo-re-driver/pyproject.toml
+++ b/host-tools/hailo-re-driver/pyproject.toml
@@ -14,9 +14,10 @@ dependencies = []
 dev = ["pytest>=7"]
 
 [project.scripts]
-hailo-re-bootstrap = "hailo_re_driver.cli:bootstrap_main"
-hailo-re-validate  = "hailo_re_driver.cli:validate_main"
-hailo-re-diff      = "hailo_re_driver.cli:diff_main"
+hailo-re-bootstrap   = "hailo_re_driver.cli:bootstrap_main"
+hailo-re-validate    = "hailo_re_driver.cli:validate_main"
+hailo-re-diff        = "hailo_re_driver.cli:diff_main"
+hailo-re-native-diff = "hailo_re_driver.cli:native_diff_main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/host-tools/hailo-re-driver/tests/test_boundary_trace.py
+++ b/host-tools/hailo-re-driver/tests/test_boundary_trace.py
@@ -111,6 +111,21 @@ class ParseTraceLineTests(unittest.TestCase):
             with self.subTest(line=line):
                 self.assertIsNone(parse_trace_line(line))
 
+    def test_rejects_value_wider_than_op_size(self) -> None:
+        """Over-wide hex (e.g. 9 chars for a 4-byte op) must NOT be
+        silently kept — the corpus stores 8 chars and a wider trace
+        value would mysteriously mismatch. Fail parsing loudly so the
+        operator sees the format-divergence, not a confusing value
+        miss in the diff report."""
+        for line in [
+            # 9 hex chars for WR32 (max 8):
+            "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x123456789",
+            # 17 chars for RD32:
+            "[trc] phase=link       mech=MMIO RD32 bar=0 off=0x0098 val=0x12345678abcdef012",
+        ]:
+            with self.subTest(line=line):
+                self.assertIsNone(parse_trace_line(line))
+
     def test_rejects_zero_or_unaligned_width(self) -> None:
         """`WR0` / `RD7` aren't valid widths. The kernel doesn't emit
         these, but reject them rather than coerce to a nonsense byte

--- a/host-tools/hailo-re-driver/tests/test_boundary_trace.py
+++ b/host-tools/hailo-re-driver/tests/test_boundary_trace.py
@@ -1,0 +1,162 @@
+"""Regression coverage for the kernel boundary-trace line parser.
+
+The kernel's `hailo trace` framework emits one column-padded line per
+instrumented op (`kernel/ai_accel/hailo/hailo_trace.c`). The parser
+must accept the live format unchanged and reject everything that
+isn't an MMIO op so a divergence diff can run against the corpus
+without false matches from PCI cfg / RPC framing / IRQ delivery lines.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import conftest  # noqa: F401
+
+from hailo_re_driver.boundary_trace import (
+    BoundaryTraceOp,
+    parse_trace_line,
+    parse_trace_stream,
+)
+
+
+class ParseTraceLineTests(unittest.TestCase):
+    """One assertion per behaviour — these are the live-format contract
+    the kernel emit helpers in hailo_trace.c enforce."""
+
+    def test_parses_mmio_write_32(self) -> None:
+        line = "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x12345678"
+        op = parse_trace_line(line)
+        self.assertIsNotNone(op)
+        assert op is not None  # for mypy
+        self.assertEqual(op.bar, 0)
+        self.assertEqual(op.offset, 0x98)
+        self.assertEqual(op.dir, "write")
+        self.assertEqual(op.size, 4)
+        self.assertEqual(op.value, "12345678")
+        self.assertEqual(op.phase, "link")
+
+    def test_parses_mmio_read_32(self) -> None:
+        line = "[trc] phase=fw_boot    mech=MMIO RD32 bar=4 off=0x0640 val=0x00000000"
+        op = parse_trace_line(line)
+        self.assertIsNotNone(op)
+        assert op is not None
+        self.assertEqual(op.dir, "read")
+        self.assertEqual(op.bar, 4)
+        self.assertEqual(op.offset, 0x640)
+        self.assertEqual(op.value, "00000000")
+        self.assertEqual(op.phase, "fw_boot")
+
+    def test_value_zero_padded_to_size(self) -> None:
+        """A short hex (`val=0x1` for a 32-bit op) must canonicalise to
+        the corpus's zero-padded form so equality compares cleanly."""
+        line = "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x1"
+        op = parse_trace_line(line)
+        assert op is not None
+        self.assertEqual(op.value, "00000001")
+
+    def test_value_lowercased(self) -> None:
+        """The corpus uses lowercase hex; the trace might emit either
+        case depending on uart_printf's `%x` form. Parser canonicalises
+        so the diff need not branch."""
+        line = "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x00AB val=0xCAFEBABE"
+        op = parse_trace_line(line)
+        assert op is not None
+        self.assertEqual(op.offset, 0xAB)
+        self.assertEqual(op.value, "cafebabe")
+
+    def test_phase_preserved_for_diagnostics(self) -> None:
+        line = "[trc] phase=inference  mech=MMIO RD32 bar=2 off=0x0050 val=0x00000003"
+        op = parse_trace_line(line)
+        assert op is not None
+        self.assertEqual(op.phase, "inference")
+
+    def test_raw_line_preserved_without_trailing_newline(self) -> None:
+        line = "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x12345678\r\n"
+        op = parse_trace_line(line)
+        assert op is not None
+        # Trailing CR/LF must NOT leak into the captured raw_line so
+        # error messages quoting it stay one-liner clean.
+        self.assertFalse(op.raw_line.endswith("\n"))
+        self.assertFalse(op.raw_line.endswith("\r"))
+
+    def test_skips_non_mmio_mech(self) -> None:
+        """`mech=` values other than MMIO (cfg, rx, irq, dma, udelay)
+        must return None — the corpus only contains BAR MMIO ops."""
+        for line in [
+            "[trc] phase=link       mech=cfg  CFG_WR bdf=0001 off=0x0004 width=4 val=0x12345678",
+            "[trc] phase=postboot   mech=rpc  tx op=4 len=8 cpu=APP",
+            "[trc] phase=postboot   mech=irq  spi=42 istatus=0x1 imask=0xff",
+            "[trc] phase=inference  mech=dma  arm ch=2 base=0x100",
+            "[trc] phase=fw_boot    mech=BUSY udelay us=500 tag=fw-magic",
+        ]:
+            with self.subTest(line=line):
+                self.assertIsNone(parse_trace_line(line))
+
+    def test_skips_completely_unrelated_serial_output(self) -> None:
+        """The capture file mixes trace lines with shell prompts, boot
+        banners, and hailo replay-step diagnostics — all must skip
+        without raising. Streaming-parse depends on this being silent."""
+        for line in [
+            "",
+            "slmos>",
+            "hailo: probe: link up at gen2 x1",
+            "INFO hailo_re_driver.loop: iter=1 corpus=... last_validated_seq=2",
+            "HAILO_RE_CORPUS_RESPONSE seq=128 bar=4 offset=3204 size=4 value=42000000 slmos_sha=abc",
+            # close-to-format-but-wrong lines that must still skip:
+            "[trc] phase=link mech=MMIO WR32",                # truncated
+            "[trc] phase=link mech=MMIO bar=0 off=0x98",      # missing op
+            "[xyz] phase=link mech=MMIO WR32 bar=0 off=0x98 val=0x1",  # wrong prefix
+        ]:
+            with self.subTest(line=line):
+                self.assertIsNone(parse_trace_line(line))
+
+    def test_rejects_zero_or_unaligned_width(self) -> None:
+        """`WR0` / `RD7` aren't valid widths. The kernel doesn't emit
+        these, but reject them rather than coerce to a nonsense byte
+        count — corrupted serial output is more likely than such a
+        kernel-side bug, and corruption shouldn't silently land in a
+        diff result."""
+        for line in [
+            "[trc] phase=link       mech=MMIO WR0  bar=0 off=0x0098 val=0x12345678",
+            "[trc] phase=link       mech=MMIO RD7  bar=0 off=0x0098 val=0x12345678",
+        ]:
+            with self.subTest(line=line):
+                self.assertIsNone(parse_trace_line(line))
+
+
+class ParseTraceStreamTests(unittest.TestCase):
+    """The streaming helper must skip non-MMIO lines silently — typical
+    capture files have ~10:1 noise:signal so a stream that raised on
+    every cfg/rpc line would be unusable."""
+
+    def test_filters_mmio_lines_from_mixed_stream(self) -> None:
+        lines = [
+            "boot banner",
+            "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x00000001",
+            "[trc] phase=link       mech=cfg  CFG_RD bdf=0001 off=0x0004 width=4 val=0x12",
+            "[trc] phase=link       mech=MMIO RD32 bar=0 off=0x0098 val=0x00000001",
+            "slmos>",
+            "[trc] phase=fw_boot    mech=MMIO WR32 bar=4 off=0x1018 val=0xdeadbeef",
+        ]
+        ops = list(parse_trace_stream(lines))
+        self.assertEqual(len(ops), 3)
+        self.assertEqual([op.dir for op in ops], ["write", "read", "write"])
+        self.assertEqual([op.offset for op in ops], [0x98, 0x98, 0x1018])
+        self.assertEqual(ops[2].value, "deadbeef")
+        self.assertEqual(ops[2].phase, "fw_boot")
+
+    def test_empty_input_yields_nothing(self) -> None:
+        self.assertEqual(list(parse_trace_stream([])), [])
+
+    def test_no_mmio_lines_yields_nothing(self) -> None:
+        lines = [
+            "slmos>",
+            "[trc] phase=link       mech=cfg  CFG_RD bdf=0001 off=0x0004 width=4 val=0x12",
+            "hailo: probe: link up",
+        ]
+        self.assertEqual(list(parse_trace_stream(lines)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_native_diff.py
+++ b/host-tools/hailo-re-driver/tests/test_native_diff.py
@@ -1,0 +1,243 @@
+"""Regression coverage for native-flow vs corpus diff alignment.
+
+The diff has to tolerate three real-world skews between SLM-OS's
+native Hailo driver and the HailoRT-derived corpus:
+
+  1. Extra ops in trace (SLM-OS does cache maintenance / sanity reads
+     HailoRT doesn't).
+  2. Missing ops in trace (HailoRT does init steps SLM-OS skips —
+     this is what we WANT to surface for #682 reopen).
+  3. Same wire location, different value (status registers; some
+     reads of e.g. interrupt-counters legitimately differ between
+     captures).
+
+These tests pin the alignment behaviour for each case. The bigger
+question — "does this find the actual #682 ch=2 divergence in a real
+trace" — needs a hardware capture and is out of unit-test scope.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import List
+
+import conftest  # noqa: F401
+
+from hailo_re_driver.boundary_trace import BoundaryTraceOp
+from hailo_re_driver.corpus import OpEntry
+from hailo_re_driver.native_diff import (
+    NativeDiffReport,
+    diff_native_against_corpus,
+    format_report,
+)
+
+
+def _c(seq: int, bar: int, off: int, dir: str, val: str,
+       size: int = 4) -> OpEntry:
+    """Compact corpus-entry builder for tests."""
+    return OpEntry(
+        seq=seq, bar=bar, offset=off, size=size, dir=dir, value=val,
+        source="qemu_capture" if dir == "write" else "slmos_observed",
+        validated_at_commit=None, validated_at=None,
+    )
+
+
+def _t(bar: int, off: int, dir: str, val: str,
+       size: int = 4, phase: str = "fw_boot") -> BoundaryTraceOp:
+    """Compact trace-op builder for tests."""
+    return BoundaryTraceOp(
+        bar=bar, offset=off, dir=dir, size=size, value=val,
+        phase=phase, raw_line="<test>",
+    )
+
+
+class CleanMatchTests(unittest.TestCase):
+    def test_identical_sequences_report_no_divergence(self) -> None:
+        corpus = [_c(1, 0, 0x98, "write", "00000001"),
+                  _c(2, 0, 0x98, "read",  "00000001"),
+                  _c(3, 4, 0x640, "read", "00000000")]
+        trace = [_t(0, 0x98, "write", "00000001"),
+                 _t(0, 0x98, "read",  "00000001"),
+                 _t(4, 0x640, "read", "00000000")]
+        report = diff_native_against_corpus(corpus, trace)
+        self.assertFalse(report.diverged)
+        self.assertEqual(report.matched_op_count, 3)
+        self.assertEqual(report.value_mismatches, [])
+        self.assertEqual(report.asymmetric_skips, [])
+
+    def test_empty_corpus_and_empty_trace(self) -> None:
+        report = diff_native_against_corpus([], [])
+        self.assertFalse(report.diverged)
+        self.assertEqual(report.matched_op_count, 0)
+
+
+class HardDivergenceTests(unittest.TestCase):
+    """A position with no resync within the look-ahead window is the
+    actionable finding — it's where SLM-OS native takes a different
+    branch from HailoRT and we can't pretend they're on the same path."""
+
+    def test_first_op_mismatch_with_no_resync_diverges(self) -> None:
+        corpus = [_c(1, 0, 0x98, "write", "00000001"),
+                  _c(2, 0, 0x9c, "write", "00000002"),
+                  _c(3, 0, 0xa0, "write", "00000003")]
+        # Trace touches completely unrelated addresses → no shape match
+        # found within lookahead → hard divergence at idx 0.
+        trace = [_t(2, 0x40, "write", "ffffffff"),
+                 _t(2, 0x44, "write", "ffffffff"),
+                 _t(2, 0x48, "write", "ffffffff")]
+        report = diff_native_against_corpus(corpus, trace, lookahead=4)
+        self.assertTrue(report.diverged)
+        self.assertEqual(report.first_divergent_corpus_idx, 0)
+        self.assertEqual(report.first_divergent_trace_idx, 0)
+        assert report.first_divergent_corpus_op is not None
+        self.assertEqual(report.first_divergent_corpus_op.offset, 0x98)
+
+    def test_divergence_after_clean_prefix_reports_correct_index(self) -> None:
+        """If the first N ops match, the reported divergence index must
+        point at the FIRST hard mismatch — not the last clean match."""
+        common = [_c(i + 1, 0, 0x100 + i * 4, "write", f"{i:08x}")
+                  for i in range(5)]
+        # Trace replicates the first 5, then takes a different path.
+        trace = [_t(0, 0x100 + i * 4, "write", f"{i:08x}") for i in range(5)]
+        trace += [_t(2, 0x40, "write", "ffffffff")]  # divergence
+        corpus = common + [_c(6, 0, 0x114, "write", "00000005"),
+                           _c(7, 0, 0x118, "write", "00000006")]
+        report = diff_native_against_corpus(corpus, trace, lookahead=2)
+        self.assertTrue(report.diverged)
+        self.assertEqual(report.first_divergent_corpus_idx, 5)
+        self.assertEqual(report.first_divergent_trace_idx, 5)
+        self.assertEqual(report.matched_op_count, 5)
+
+
+class ValueMismatchTests(unittest.TestCase):
+    """Same wire-location, different value — soft divergence. Recorded
+    + walk continues, because the most common cause is a status
+    register that flipped between captures, not a protocol bug."""
+
+    def test_value_mismatch_recorded_and_walk_continues(self) -> None:
+        corpus = [_c(1, 0, 0x98, "write", "00000001"),
+                  _c(2, 0, 0x9c, "read", "00000002"),  # value differs
+                  _c(3, 0, 0xa0, "write", "00000003")]
+        trace = [_t(0, 0x98, "write", "00000001"),
+                 _t(0, 0x9c, "read", "deadbeef"),  # native saw different
+                 _t(0, 0xa0, "write", "00000003")]
+        report = diff_native_against_corpus(corpus, trace)
+        self.assertFalse(report.diverged)
+        self.assertEqual(report.matched_op_count, 2)  # the 2 that matched fully
+        self.assertEqual(len(report.value_mismatches), 1)
+        vm = report.value_mismatches[0]
+        self.assertEqual(vm.corpus_idx, 1)
+        self.assertEqual(vm.trace_idx, 1)
+        self.assertEqual(vm.corpus_op.value, "00000002")
+        self.assertEqual(vm.trace_op.value, "deadbeef")
+
+
+class AsymmetricSkipTests(unittest.TestCase):
+    """Bounded look-ahead lets us resync when one side has a small
+    burst of extra ops. Look-ahead can't be too wide or it papers
+    over real divergences as "skips" — keep the default narrow."""
+
+    def test_extra_ops_in_trace_are_skipped_and_recorded(self) -> None:
+        """SLM-OS native often emits cache-maintenance or sanity-read
+        ops HailoRT didn't. The resync should look ahead in TRACE,
+        skip the extras, and continue matching."""
+        corpus = [_c(1, 0, 0x98, "write", "00000001"),
+                  _c(2, 0, 0x9c, "write", "00000002"),
+                  _c(3, 0, 0xa0, "write", "00000003")]
+        trace = [_t(0, 0x98, "write", "00000001"),
+                 _t(0, 0x500, "read", "0badbabe"),  # extra noise op
+                 _t(0, 0x504, "read", "deadcafe"),  # extra noise op
+                 _t(0, 0x9c, "write", "00000002"),
+                 _t(0, 0xa0, "write", "00000003")]
+        report = diff_native_against_corpus(corpus, trace, lookahead=4)
+        self.assertFalse(report.diverged)
+        self.assertEqual(report.matched_op_count, 3)
+        self.assertEqual(len(report.asymmetric_skips), 1)
+        skip = report.asymmetric_skips[0]
+        self.assertEqual(skip.side, "trace")
+        self.assertEqual(skip.skipped_ops_count, 2)
+        self.assertEqual(skip.corpus_idx, 1)  # corpus expected 0x9c next
+
+    def test_extra_ops_in_corpus_are_skipped_and_recorded(self) -> None:
+        """HailoRT does init steps SLM-OS skips. Look-ahead in CORPUS
+        finds the resync point. Recording this as a `corpus`-side skip
+        is the actionable signal — these are ops we KNOW HailoRT did
+        that our native driver isn't doing, which for the #682 reopen
+        is exactly what we want to surface."""
+        corpus = [_c(1, 0, 0x98, "write", "00000001"),
+                  _c(2, 0, 0x100, "write", "babeface"),  # skipped by native
+                  _c(3, 0, 0x104, "write", "12345678"),  # skipped by native
+                  _c(4, 0, 0x9c, "write", "00000002"),
+                  _c(5, 0, 0xa0, "write", "00000003")]
+        trace = [_t(0, 0x98, "write", "00000001"),
+                 _t(0, 0x9c, "write", "00000002"),
+                 _t(0, 0xa0, "write", "00000003")]
+        report = diff_native_against_corpus(corpus, trace, lookahead=4)
+        self.assertFalse(report.diverged)
+        self.assertEqual(report.matched_op_count, 3)
+        self.assertEqual(len(report.asymmetric_skips), 1)
+        skip = report.asymmetric_skips[0]
+        self.assertEqual(skip.side, "corpus")
+        self.assertEqual(skip.skipped_ops_count, 2)
+        self.assertEqual(skip.trace_idx, 1)  # trace already at 0x9c
+
+    def test_lookahead_bound_is_respected(self) -> None:
+        """A gap wider than `lookahead` must produce a HARD divergence,
+        not silently skip past it. Otherwise the diff would paper over
+        the very thing it exists to find."""
+        corpus = [_c(1, 0, 0x98, "write", "00000001")]
+        # Insert (lookahead+1) noise ops in the trace before the
+        # corpus op shows up → no resync within window.
+        trace = ([_t(0, 0x500 + i * 4, "read", "00000000")
+                  for i in range(5)] +
+                 [_t(0, 0x98, "write", "00000001")])
+        report = diff_native_against_corpus(corpus, trace, lookahead=4)
+        self.assertTrue(report.diverged)
+        self.assertEqual(report.first_divergent_corpus_idx, 0)
+
+    def test_tail_imbalance_recorded_not_divergence(self) -> None:
+        """If we walk off one end with a clean tail on the other, that's
+        a soft skip on the longer side, not a hard divergence — the
+        run may just have stopped early."""
+        corpus = [_c(1, 0, 0x98, "write", "00000001"),
+                  _c(2, 0, 0x9c, "write", "00000002"),
+                  _c(3, 0, 0xa0, "write", "00000003")]
+        trace = [_t(0, 0x98, "write", "00000001")]  # trace stops short
+        report = diff_native_against_corpus(corpus, trace)
+        self.assertFalse(report.diverged)
+        self.assertEqual(report.matched_op_count, 1)
+        self.assertEqual(len(report.asymmetric_skips), 1)
+        skip = report.asymmetric_skips[0]
+        self.assertEqual(skip.side, "corpus")
+        self.assertEqual(skip.skipped_ops_count, 2)
+
+
+class FormatReportTests(unittest.TestCase):
+    """The formatted report is meant to be paste-into-ticket
+    actionable. Pin the structure so a future refactor doesn't break
+    the consumers it was designed for."""
+
+    def test_clean_match_renders_summary(self) -> None:
+        corpus = [_c(1, 0, 0x98, "write", "00000001")]
+        trace = [_t(0, 0x98, "write", "00000001")]
+        report = diff_native_against_corpus(corpus, trace)
+        text = format_report(report)
+        self.assertIn("matched ops:", text)
+        self.assertIn("clean match", text)
+        self.assertNotIn("DIVERGED", text)
+
+    def test_divergence_renders_both_sides_with_addresses(self) -> None:
+        corpus = [_c(7, 0, 0x98, "write", "00000001")]
+        trace = [_t(2, 0x40, "read", "ffffffff")]
+        report = diff_native_against_corpus(corpus, trace)
+        text = format_report(report)
+        self.assertIn("DIVERGED", text)
+        self.assertIn("seq=7", text)        # corpus seq for cross-ref
+        self.assertIn("bar=0", text)
+        self.assertIn("bar=2", text)
+        self.assertIn("0x0098", text)
+        self.assertIn("0x0040", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host-tools/hailo-re-driver/tests/test_native_diff.py
+++ b/host-tools/hailo-re-driver/tests/test_native_diff.py
@@ -211,6 +211,25 @@ class AsymmetricSkipTests(unittest.TestCase):
         self.assertEqual(skip.side, "corpus")
         self.assertEqual(skip.skipped_ops_count, 2)
 
+    def test_trace_longer_than_corpus_records_trace_side_tail_skip(self) -> None:
+        """Converse of the previous test: the trace runs past the end
+        of the corpus. The leftover trace ops must land as a single
+        `side="trace"` skip, NOT a hard divergence (we just ran the
+        native flow further than the corpus captured)."""
+        corpus = [_c(1, 0, 0x98, "write", "00000001")]
+        trace = [_t(0, 0x98, "write", "00000001"),
+                 _t(0, 0x9c, "write", "00000002"),
+                 _t(0, 0xa0, "write", "00000003")]
+        report = diff_native_against_corpus(corpus, trace)
+        self.assertFalse(report.diverged)
+        self.assertEqual(report.matched_op_count, 1)
+        self.assertEqual(len(report.asymmetric_skips), 1)
+        skip = report.asymmetric_skips[0]
+        self.assertEqual(skip.side, "trace")
+        self.assertEqual(skip.skipped_ops_count, 2)
+        self.assertEqual(skip.corpus_idx, 1)
+        self.assertEqual(skip.trace_idx, 1)
+
 
 class FormatReportTests(unittest.TestCase):
     """The formatted report is meant to be paste-into-ticket


### PR DESCRIPTION
## Summary
- New `hailo-re-native-diff` host-side tool: align a SLM-OS native-flow boundary-trace capture against the Phase 2 corpus and surface the first position where SLM-OS diverges from HailoRT's recorded BAR-op sequence. That divergence is the actionable artifact for the #682 reopen criteria — proof of the protocol gap to attach to a Hailo support ticket.
- Parses raw `capture-hailo-trace.sh` output directly (no separate translator step). Skips non-MMIO trace lines (cfg, rpc, irq, dma, busy-wait) and unrelated serial noise silently.
- Bounded look-ahead resync (default 8) handles the inevitable skew between native flow and HailoRT (cache maintenance / sanity reads on one side, init ops on the other) without papering over real divergences. Value-only mismatches recorded soft; only positions with no resync are reported as hard.

## What didn't change
- No kernel changes. Strictly host-side tooling.
- No corpus state changes. The saturated corpus (33424 lines) is the read-only input.

## Limitations (recorded inline)
- Strictly an ordered-divergence tool. Won't answer "are there ops one side has and the other doesn't, regardless of position?" — a follow-up multi-set comparator can if needed.
- The capture step itself is not yet wired up (separate work — needs a kernel build with trace phases armed + a real lab run).

## Next steps (separate work, not in this PR)
1. Build kernel with `HAILO_TRACE_PHASE_DEFAULT` covering fw_boot/postboot/model_load/inference and `HAILO_TRACE_MECH_DEFAULT=mmio`.
2. Run `scripts/capture-hailo-trace.sh --phase ... --mech mmio --shell-cmd "hailo boot; hailo load <hef> sched; hailo infer 128"` on pi-5-1.
3. `hailo-re-native-diff <corpus> <trace.log>` → first hard divergence is the #682 reopen artifact.

## Test plan
- [x] `python3 -m unittest discover tests` — 105/105 (was 82; +23 new in this PR: 12 boundary-trace parser + 11 native-diff alignment)
- [x] End-to-end CLI smoke test on synthetic input: clean match (rc=0), value-only mismatch (rc=0 + report), hard divergence (rc=1 + both sides reported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)