### PR TITLE
hailo-re: native-diff parser must byte-swap trace values to LE wire order

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
@@ -106,10 +106,8 @@ def parse_trace_line(line: str) -> Optional[BoundaryTraceOp]:
     # on the first end-to-end native-flow capture against the 4.23.0
     # grind corpus: all 4 BAR0 ATR-programming writes showed
     # byte-reversed values until this swap was added.
-    value = "".join(
-        int_hex[2 * (size - 1 - i): 2 * (size - 1 - i) + 2]
-        for i in range(size)
-    )
+    byte_chunks = [int_hex[2 * i: 2 * i + 2] for i in range(size)]
+    value = "".join(reversed(byte_chunks))
     return BoundaryTraceOp(
         bar=int(m.group("bar")),
         offset=int(m.group("off"), 16),

--- a/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/boundary_trace.py
@@ -93,10 +93,23 @@ def parse_trace_line(line: str) -> Optional[BoundaryTraceOp]:
     # truncates).
     if len(raw_val) > size * 2:
         return None
-    # Pad to canonical LE-hex width so a short-but-otherwise-valid
-    # line ("val=0x1" when size=4) still compares correctly against
-    # the corpus's zero-padded form ("00000001").
-    value = raw_val.zfill(size * 2).lower()
+    # Pad to canonical width first.
+    int_hex = raw_val.zfill(size * 2).lower()
+    # The kernel emits `uart_printf("val=0x%08x", val)` — the uint32's
+    # integer value rendered high-nibble-first ("00000017" for integer
+    # 23). The corpus stores values in WIRE order: little-endian
+    # bytes-as-hex (integer 23 written via writel hits the bus as the
+    # 4-byte sequence 17 00 00 00, rendered "17000000" per
+    # docs/hailo-re-corpus-format.md §Operation entries). Byte-swap so
+    # the trace value matches the corpus's encoding — without this,
+    # every multi-byte op silently value-mismatches. Directly observed
+    # on the first end-to-end native-flow capture against the 4.23.0
+    # grind corpus: all 4 BAR0 ATR-programming writes showed
+    # byte-reversed values until this swap was added.
+    value = "".join(
+        int_hex[2 * (size - 1 - i): 2 * (size - 1 - i) + 2]
+        for i in range(size)
+    )
     return BoundaryTraceOp(
         bar=int(m.group("bar")),
         offset=int(m.group("off"), 16),

--- a/host-tools/hailo-re-driver/tests/test_boundary_trace.py
+++ b/host-tools/hailo-re-driver/tests/test_boundary_trace.py
@@ -55,6 +55,27 @@ class ParseTraceLineTests(unittest.TestCase):
         self.assertEqual(op.value, "00000000")
         self.assertEqual(op.phase, "fw_boot")
 
+    def test_byte_swap_generalises_to_other_widths(self) -> None:
+        """The kernel only emits WR32/RD32 today, but the byte-swap is
+        size-parameterised. Pin its behaviour at width=16 so a future
+        emit helper for half-word ops can't quietly break the size=2
+        path. (And size=1 is a no-op palindrome — also asserted here
+        as the trivial edge.)"""
+        # WR16: 0x1234 → bytes 34 12 → "3412"
+        op16 = parse_trace_line(
+            "[trc] phase=link       mech=MMIO WR16 bar=0 off=0x0098 val=0x1234"
+        )
+        assert op16 is not None
+        self.assertEqual(op16.size, 2)
+        self.assertEqual(op16.value, "3412")
+        # WR8: 0xab → "ab" (single byte; byte-swap is identity).
+        op8 = parse_trace_line(
+            "[trc] phase=link       mech=MMIO WR8  bar=0 off=0x0098 val=0xab"
+        )
+        assert op8 is not None
+        self.assertEqual(op8.size, 1)
+        self.assertEqual(op8.value, "ab")
+
     def test_value_byte_swapped_for_le_wire_order(self) -> None:
         """The fix found on the first end-to-end native-flow capture:
         every BAR0 ATR-programming write (`val=0x00000017`, ...) was

--- a/host-tools/hailo-re-driver/tests/test_boundary_trace.py
+++ b/host-tools/hailo-re-driver/tests/test_boundary_trace.py
@@ -25,6 +25,12 @@ class ParseTraceLineTests(unittest.TestCase):
     the kernel emit helpers in hailo_trace.c enforce."""
 
     def test_parses_mmio_write_32(self) -> None:
+        """The kernel emits the uint32 as integer-as-hex
+        (`%08x` → "12345678" for 0x12345678). The corpus stores wire-
+        byte order (little-endian: that same 0x12345678 hits the bus
+        as the 4-byte sequence 78 56 34 12, recorded as "78563412").
+        Parser byte-swaps so trace ops compare directly against the
+        corpus encoding."""
         line = "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x12345678"
         op = parse_trace_line(line)
         self.assertIsNotNone(op)
@@ -33,7 +39,7 @@ class ParseTraceLineTests(unittest.TestCase):
         self.assertEqual(op.offset, 0x98)
         self.assertEqual(op.dir, "write")
         self.assertEqual(op.size, 4)
-        self.assertEqual(op.value, "12345678")
+        self.assertEqual(op.value, "78563412")  # LE byte order
         self.assertEqual(op.phase, "link")
 
     def test_parses_mmio_read_32(self) -> None:
@@ -44,16 +50,31 @@ class ParseTraceLineTests(unittest.TestCase):
         self.assertEqual(op.dir, "read")
         self.assertEqual(op.bar, 4)
         self.assertEqual(op.offset, 0x640)
+        # All zeros is a palindrome under byte-swap; still asserts the
+        # field is present + canonical.
         self.assertEqual(op.value, "00000000")
         self.assertEqual(op.phase, "fw_boot")
 
-    def test_value_zero_padded_to_size(self) -> None:
+    def test_value_byte_swapped_for_le_wire_order(self) -> None:
+        """The fix found on the first end-to-end native-flow capture:
+        every BAR0 ATR-programming write (`val=0x00000017`, ...) was
+        silently value-mismatching against the corpus's wire-order
+        encoding (`17000000`, ...) until the parser byte-swapped. Pin
+        the conversion direction so a refactor can't reintroduce it."""
+        line = "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0700 val=0x00000017"
+        op = parse_trace_line(line)
+        assert op is not None
+        self.assertEqual(op.value, "17000000")
+
+    def test_value_zero_padded_then_swapped(self) -> None:
         """A short hex (`val=0x1` for a 32-bit op) must canonicalise to
-        the corpus's zero-padded form so equality compares cleanly."""
+        '00000001' as integer-as-hex first, THEN byte-swap to
+        '01000000' to match the corpus's wire-order encoding for an
+        integer-1 store."""
         line = "[trc] phase=link       mech=MMIO WR32 bar=0 off=0x0098 val=0x1"
         op = parse_trace_line(line)
         assert op is not None
-        self.assertEqual(op.value, "00000001")
+        self.assertEqual(op.value, "01000000")
 
     def test_value_lowercased(self) -> None:
         """The corpus uses lowercase hex; the trace might emit either
@@ -63,7 +84,9 @@ class ParseTraceLineTests(unittest.TestCase):
         op = parse_trace_line(line)
         assert op is not None
         self.assertEqual(op.offset, 0xAB)
-        self.assertEqual(op.value, "cafebabe")
+        # Lowercased AND byte-swapped: 0xCAFEBABE → "cafebabe" →
+        # bytes "be ba fe ca" → "bebafeca".
+        self.assertEqual(op.value, "bebafeca")
 
     def test_phase_preserved_for_diagnostics(self) -> None:
         line = "[trc] phase=inference  mech=MMIO RD32 bar=2 off=0x0050 val=0x00000003"
@@ -158,7 +181,9 @@ class ParseTraceStreamTests(unittest.TestCase):
         self.assertEqual(len(ops), 3)
         self.assertEqual([op.dir for op in ops], ["write", "read", "write"])
         self.assertEqual([op.offset for op in ops], [0x98, 0x98, 0x1018])
-        self.assertEqual(ops[2].value, "deadbeef")
+        # 0xdeadbeef → byte-swapped to LE wire order:
+        # bytes ef be ad de → "efbeadde".
+        self.assertEqual(ops[2].value, "efbeadde")
         self.assertEqual(ops[2].phase, "fw_boot")
 
     def test_empty_input_yields_nothing(self) -> None:


### PR DESCRIPTION
## Summary
Fixes a byte-order bug in `hailo_re_driver/boundary_trace.py` (introduced in PR #993) that made every multi-byte op silently value-mismatch against the corpus.

- Kernel emits `uart_printf("val=0x%08x", val)` — uint32 integer rendered high-nibble-first (`0x00000017` → `"00000017"`)
- Corpus stores values in **wire byte order** — little-endian (`writel(0x00000017, addr)` hits the bus as `17 00 00 00`, recorded as `"17000000"` per `docs/hailo-re-corpus-format.md` §Operation entries)
- Without a swap, every multi-byte op silently value-mismatched

Directly observed on the first end-to-end native-flow capture: all four BAR0 ATR-programming writes (`0x700`-`0x710`) showed reversed values until this fix.

## After the fix
The first-bootphase capture went from 4 matched ops (mostly noise) to 8 matched with default lookahead, or 15 with `--lookahead 32` — exposing two real, actionable protocol divergences that I've filed separately:

- #995 — HailoRT does write-then-read-back-verify on every register; SLM-OS doesn't
- #996 — SLM-OS reprograms BAR0 ATR three times during boot, HailoRT once

## Test plan
- [x] `python3 -m unittest discover tests` — 108/108 (was 107 → +1 new regression test pinning the byte-swap direction explicitly)
- [x] End-to-end re-run of the first native-flow capture via `hailo-re-native-diff` against the saturated 4.23.0 grind corpus — value-mismatches dropped from 4 to 0 across the BAR0 ATR writes; matched op count went up; remaining divergences are real protocol-level findings (filed as #995, #996)

🤖 Generated with [Claude Code](https://claude.com/claude-code)