### PR TITLE
hailo: fix VDMA boundary channel direction mismatch wedging IN-channel inference (#682)

### DIFF
--- a/kernel/ai_accel/hailo/hailo_infer.c
+++ b/kernel/ai_accel/hailo/hailo_infer.c
@@ -64,8 +64,9 @@ static inline uint64_t cntfrq_read(void)
  * TODO(phase-5.4+): no cross-caller serialization. The current
  * sole caller is the shell on CPU 0; a future AI-scheduler policy
  * submitting concurrent inferences would race on the shared VDMA
- * channel state (channels 0 and 1 are hardcoded via the shell
- * command and the static per-channel register banks live in BAR2).
+ * channel state (boundary channels resolve to ch=2 H2D + ch=16 D2H
+ * via the translator's offset constants — see hailo_cs_translator.h
+ * — and the static per-channel register banks live in BAR2).
  * When a second caller arrives, wrap the body in a file-scope
  * spin_lock(&infer_lock) — plain, not irqsave, because the poll
  * waits can run for milliseconds.
@@ -83,6 +84,16 @@ int hailo_infer_run(const struct hailo_infer_config *cfg,
         return HAILO_ERR_INVAL;
     }
     if (cfg->input_channel == cfg->output_channel) return HAILO_ERR_INVAL;
+    /* H2D / D2H direction split — fw v4.23 binds boundary input
+     * channels to [0, 15] and outputs to [16, 31]. A direction
+     * mismatch silently wedges: fw waits for activity on the
+     * channel the CS RPC named (e.g. ch=16 D2H output) while the
+     * host arms HOST registers on a different sub-block (e.g.
+     * ch=1 H2D HOST). See #682 — closed-then-reopened-then-fixed
+     * 2026-05-25 after a side-by-side BAR2 capture confirmed the
+     * channel-direction divergence.  */
+    if (cfg->input_channel  >= HAILO_VDMA_H2D_CHANNEL_COUNT) return HAILO_ERR_INVAL;
+    if (cfg->output_channel <  HAILO_VDMA_H2D_CHANNEL_COUNT) return HAILO_ERR_INVAL;
     if (cfg->input_page_size == 0 || cfg->output_page_size == 0) {
         return HAILO_ERR_INVAL;
     }

--- a/kernel/ai_accel/hailo/hailo_infer.h
+++ b/kernel/ai_accel/hailo/hailo_infer.h
@@ -41,9 +41,15 @@ struct hailo_infer_config {
     uint32_t input_bytes;
     uint32_t output_bytes;
 
-    /* VDMA channel assignments (Hailo-8 uses 0..15). Typical
-     * layout: input on a low-indexed channel, output on a
-     * higher-indexed one. */
+    /* VDMA channel assignments. Hailo-8 fw v4.23 splits the 32 VDMA
+     * channels into H2D [0, 15] (host→device, used for input) and
+     * D2H [16, 31] (device→host, used for output). `input_channel`
+     * MUST land in H2D and `output_channel` in D2H; mismatched
+     * directions silently wedge the engine (#682). Callers should
+     * use the translator's HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
+     * HAILO_CS_BOUNDARY_{INPUT,OUTPUT}_CHANNEL_OFFSET so the host
+     * MMIO and the CS OPEN_BOUNDARY RPCs reference the same
+     * channels by construction. */
     uint8_t  input_channel;
     uint8_t  output_channel;
 

--- a/kernel/ai_accel/hailo/hailo_shell.c
+++ b/kernel/ai_accel/hailo/hailo_shell.c
@@ -1545,10 +1545,12 @@ static int cmd_hailo(int argc, char *argv[])
     if (argc >= 2 && strcmp(argv[1], "infer") == 0) {
         /* `hailo infer <hex-bytes>` — run an end-to-end inference
          * smoke test with a synthetic tensor of the given size.
-         * Uses channel 0 (input) / 1 (output) and data_id 0 by
-         * default — these would be HEF-derived in a real call.
-         * Fails on Pi 5 today (no active stream context); exercises
-         * the hailo_infer_run pipeline end-to-end in QEMU tests. */
+         * Uses the same boundary-channel constants the CS translator
+         * emits in OPEN_BOUNDARY_{INPUT,OUTPUT} RPCs (config+1 = H2D 2,
+         * config+15 = D2H 16 for the default config channel). data_id
+         * is still a stub — would be HEF-derived in a real call.
+         * Exercises the hailo_infer_run pipeline end-to-end in QEMU
+         * tests. */
         if (argc < 3) {
             shell_puts("usage: hailo infer <hex-bytes>\n");
             return 0;
@@ -1575,8 +1577,10 @@ static int cmd_hailo(int argc, char *argv[])
         struct hailo_infer_config cfg = {
             .input_bytes     = bytes,
             .output_bytes    = bytes,
-            .input_channel   = 0,
-            .output_channel  = 1,
+            .input_channel   = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
+                                         HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET),
+            .output_channel  = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
+                                         HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET),
             .input_data_id   = 0,
             .output_data_id  = 0,
             .input_page_size = 512,

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -2092,8 +2092,19 @@ static int hailo_backend_load_model(struct inference_device *dev,
             slots[i].cfg = (struct hailo_infer_config){
                 .input_bytes      = input_bytes,
                 .output_bytes     = output_bytes,
-                .input_channel    = 0,
-                .output_channel   = 1,
+                /* Boundary channel indices MUST match the packed_vdma
+                 * the CS translator emits in OPEN_BOUNDARY_{INPUT,
+                 * OUTPUT}_CHANNEL: input = config+1 (H2D 2), output =
+                 * config+15 (D2H 16) with the default config channel
+                 * (HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL = 1). Hardcoding
+                 * 0/1 here armed the host VDMA registers on a different
+                 * pair of channels than the firmware was told to wait
+                 * on, so `num_proc` never advanced on the IN channel
+                 * (#682, located via BAR2 diff against HailoRT 2026-05-25). */
+                .input_channel    = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
+                                              HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET),
+                .output_channel   = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
+                                              HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET),
                 .input_data_id    = in_data_id,
                 .output_data_id   = out_data_id,
                 .input_page_size  = in_page_size,

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -2092,15 +2092,11 @@ static int hailo_backend_load_model(struct inference_device *dev,
             slots[i].cfg = (struct hailo_infer_config){
                 .input_bytes      = input_bytes,
                 .output_bytes     = output_bytes,
-                /* Boundary channel indices MUST match the packed_vdma
-                 * the CS translator emits in OPEN_BOUNDARY_{INPUT,
-                 * OUTPUT}_CHANNEL: input = config+1 (H2D 2), output =
-                 * config+15 (D2H 16) with the default config channel
-                 * (HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL = 1). Hardcoding
-                 * 0/1 here armed the host VDMA registers on a different
-                 * pair of channels than the firmware was told to wait
-                 * on, so `num_proc` never advanced on the IN channel
-                 * (#682, located via BAR2 diff against HailoRT 2026-05-25). */
+                /* Boundary channels MUST match the packed_vdma the CS
+                 * translator emits in OPEN_BOUNDARY_{INPUT,OUTPUT}_CHANNEL
+                 * — see hailo_cs_translator.h. Hardcoded 0/1 here pre-#682
+                 * armed different host VDMA registers than the channels
+                 * the fw was told to wait on. */
                 .input_channel    = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
                                               HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET),
                 .output_channel   = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -336,15 +336,22 @@ static void mock_write32(uint8_t bar, uint32_t offset, uint32_t value)
      * any write to a channel's NUM_AVAIL (offset 2 within the
      * 4-byte dword at CHANNEL_CONTROL_OFFSET) also bumps NUM_PROC
      * (16-bit value at CHANNEL_NUM_PROC_OFFSET=0x04) to match,
-     * simulating the device completing the transfer immediately. */
+     * simulating the device completing the transfer immediately.
+     *
+     * Each 0x20-byte channel window has a HOST sub-block and a
+     * DEVICE sub-block; the driver swaps which half is which based
+     * on direction (H2D = HOST at +0x00, D2H = HOST at +0x10).
+     * Auto-advance fires on the HOST base-dword of either half so
+     * tests can exercise both input (H2D) and output (D2H) channels
+     * end-to-end through the mock. */
     if (bar == HAILO_BAR_VDMA && offset + 4 <= MOCK_BAR2_SIZE) {
         memcpy(&mock_bar2[offset], &value, sizeof(value));
         if (mock_vdma_auto_advance
-         && (offset & 0x1Fu) == 0) {
-            /* Write to the channel-base dword. NUM_AVAIL lives in
-             * bits [31:16] of this dword. Mirror it to NUM_PROC
-             * (16-bit at offset+0x04) so a subsequent poll of
-             * num_proc sees completion. */
+         && ((offset & 0x1Fu) == 0x00u || (offset & 0x1Fu) == 0x10u)) {
+            /* Write to a HOST-sub-block base-dword. NUM_AVAIL lives
+             * in bits [31:16]; mirror it to NUM_PROC (16-bit at
+             * +0x04 within the same sub-block) so a subsequent poll
+             * sees completion. */
             uint16_t num_avail = (uint16_t)(value >> 16);
             memcpy(&mock_bar2[offset + 0x04],
                    &num_avail, sizeof(num_avail));
@@ -5930,7 +5937,7 @@ static void test_infer_rejects_null_args(void)
     infer_setup_running();
     struct hailo_infer_config cfg = {
         .input_bytes = 512, .output_bytes = 512,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_page_size = 512, .output_page_size = 512,
         .timeout_us = 100000,
     };
@@ -5972,13 +5979,99 @@ static void test_infer_rejects_bad_channel(void)
         hailo_infer_run(&cfg, buf, buf, NULL));
 }
 
+static void test_infer_rejects_input_in_d2h_range(void)
+{
+    /* #682: input_channel must land in H2D [0, 15]. Setting it
+     * to a D2H channel (16..31) silently armed the wrong host
+     * MMIO sub-block before the direction-range check; fw waited
+     * on the CS-RPC's channel forever. */
+    infer_setup_running();
+    struct hailo_infer_config cfg = {
+        .input_bytes = 512, .output_bytes = 512,
+        .input_channel = HAILO_VDMA_H2D_CHANNEL_COUNT,   /* 16 — D2H, illegal for input */
+        .output_channel = HAILO_VDMA_H2D_CHANNEL_COUNT + 1,
+        .input_page_size = 512, .output_page_size = 512,
+        .timeout_us = 100000,
+    };
+    uint8_t buf[512] = {0};
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_infer_run(&cfg, buf, buf, NULL));
+}
+
+static void test_infer_rejects_output_in_h2d_range(void)
+{
+    /* #682 symmetry: output_channel must land in D2H [16, 31].
+     * The old default (.output_channel = 1) was in H2D and is the
+     * literal value the production bug shipped with. */
+    infer_setup_running();
+    struct hailo_infer_config cfg = {
+        .input_bytes = 512, .output_bytes = 512,
+        .input_channel  = 0,
+        .output_channel = HAILO_VDMA_H2D_CHANNEL_COUNT - 1u, /* 15 — H2D, illegal for output */
+        .input_page_size = 512, .output_page_size = 512,
+        .timeout_us = 100000,
+    };
+    uint8_t buf[512] = {0};
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_infer_run(&cfg, buf, buf, NULL));
+}
+
+static void test_infer_rejects_old_default_pair(void)
+{
+    /* Pins the exact (0, 1) value pair that the two hardcoded call
+     * sites used to ship with — `hailo_shell.c:1578-1579` and
+     * `inference_device_hailo.c:2095-2096`. If a future refactor
+     * regresses either site back to "first available" channel
+     * selection, this test fires. */
+    infer_setup_running();
+    struct hailo_infer_config cfg = {
+        .input_bytes = 512, .output_bytes = 512,
+        .input_channel  = 0,
+        .output_channel = 1,
+        .input_page_size = 512, .output_page_size = 512,
+        .timeout_us = 100000,
+    };
+    uint8_t buf[512] = {0};
+    TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL,
+        hailo_infer_run(&cfg, buf, buf, NULL));
+}
+
+static void test_infer_translator_offsets_yield_valid_channels(void)
+{
+    /* Pin the channel-pair the two production-shape call sites
+     * compute from the translator's constants. Any future tweak to
+     * either constant or the default config channel that would push
+     * a boundary into the wrong direction range fails this test
+     * before it can wedge the engine on real hardware. */
+    uint8_t in_ch  = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
+                               HAILO_CS_BOUNDARY_INPUT_CHANNEL_OFFSET);
+    uint8_t out_ch = (uint8_t)(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL +
+                               HAILO_CS_BOUNDARY_OUTPUT_CHANNEL_OFFSET);
+    TEST_ASSERT_TRUE(in_ch  <  HAILO_VDMA_H2D_CHANNEL_COUNT);
+    TEST_ASSERT_TRUE(out_ch >= HAILO_VDMA_H2D_CHANNEL_COUNT);
+    TEST_ASSERT_TRUE(out_ch <  HAILO_VDMA_MAX_CHANNELS);
+    TEST_ASSERT_NOT_EQUAL(in_ch, out_ch);
+    /* And the runtime guard accepts them end-to-end. */
+    infer_setup_running();
+    struct hailo_infer_config cfg = {
+        .input_bytes = 512, .output_bytes = 512,
+        .input_channel  = in_ch,
+        .output_channel = out_ch,
+        .input_page_size = 512, .output_page_size = 512,
+        .timeout_us = 100000,
+    };
+    uint8_t buf[512] = {0};
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_infer_run(&cfg, buf, buf, NULL));
+}
+
 static void test_infer_rejects_zero_sizes(void)
 {
     infer_setup_running();
     uint8_t buf[512] = {0};
     struct hailo_infer_config cfg = {
         .input_bytes = 0,   .output_bytes = 512,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_page_size = 512, .output_page_size = 512,
         .timeout_us = 100000,
     };
@@ -5995,7 +6088,7 @@ static void test_infer_rejects_nodev_when_not_running(void)
     boot_setup_probed();   /* state=PROBED, not RUNNING */
     struct hailo_infer_config cfg = {
         .input_bytes = 512, .output_bytes = 512,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_page_size = 512, .output_page_size = 512,
         .timeout_us = 100000,
     };
@@ -6012,7 +6105,7 @@ static void test_infer_end_to_end_via_auto_advance(void)
     infer_setup_running();
     struct hailo_infer_config cfg = {
         .input_bytes = 1024, .output_bytes = 2048,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_data_id = 0x01, .output_data_id = 0x02,
         .input_page_size = 512, .output_page_size = 1024,
         .timeout_us = 100000,
@@ -6037,7 +6130,7 @@ static void test_infer_timeout_without_auto_advance(void)
     mock_vdma_auto_advance = false;
     struct hailo_infer_config cfg = {
         .input_bytes = 512, .output_bytes = 512,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_page_size = 512, .output_page_size = 512,
         .timeout_us = 500,   /* very short so the test finishes fast */
     };
@@ -6056,7 +6149,7 @@ static void test_infer_propagates_tensor_alloc_failure(void)
     mock_dma_force_null = true;
     struct hailo_infer_config cfg = {
         .input_bytes = 512, .output_bytes = 512,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_page_size = 512, .output_page_size = 512,
         .timeout_us = 100000,
     };
@@ -6077,7 +6170,7 @@ static void test_infer_rejects_oversized_output_desc_count(void)
     struct hailo_infer_config cfg = {
         .input_bytes = 512,
         .output_bytes = 1024u * 1024u,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_page_size = 512, .output_page_size = 1,
         .timeout_us = 100000,
     };
@@ -6111,7 +6204,7 @@ static void test_infer_cleanup_on_midflight_failure(void)
     mock_vdma_auto_advance = false;
     struct hailo_infer_config cfg = {
         .input_bytes = 512, .output_bytes = 512,
-        .input_channel = 0, .output_channel = 1,
+        .input_channel = 2, .output_channel = 16,
         .input_page_size = 512, .output_page_size = 512,
         .timeout_us = 500,
     };
@@ -8240,6 +8333,10 @@ int test_suite_hailo(void)
     RUN_TEST(test_infer_rejects_null_args);
     RUN_TEST(test_infer_rejects_same_channels);
     RUN_TEST(test_infer_rejects_bad_channel);
+    RUN_TEST(test_infer_rejects_input_in_d2h_range);
+    RUN_TEST(test_infer_rejects_output_in_h2d_range);
+    RUN_TEST(test_infer_rejects_old_default_pair);
+    RUN_TEST(test_infer_translator_offsets_yield_valid_channels);
     RUN_TEST(test_infer_rejects_zero_sizes);
     RUN_TEST(test_infer_rejects_nodev_when_not_running);
     RUN_TEST(test_infer_end_to_end_via_auto_advance);


### PR DESCRIPTION
## Summary

- Two host-MMIO call sites (`hailo_shell.c`, `inference_device_hailo.c`) hardcoded `.input_channel = 0, .output_channel = 1`, while the CS translator emits `packed_vdma_channel_id = config + {1, 15}` (ch=2 H2D, ch=16 D2H) in the `OPEN_BOUNDARY_{INPUT,OUTPUT}_CHANNEL` RPCs the firmware consumes. The host and the firmware were referencing different MMIO registers on different channels and never converging — the IN-channel wedge that's been #682's signature.
- Derive both channel indices at both call sites from `HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL + HAILO_CS_BOUNDARY_{INPUT,OUTPUT}_CHANNEL_OFFSET` so the host-side MMIO and the CS RPC share a single source of truth.
- Add a runtime H2D [0, 15] / D2H [16, 31] direction-range check in `hailo_infer_run` so future direction-mismatched callers fail fast with `HAILO_ERR_INVAL` instead of silently wedging.

## Root cause

Located 2026-05-25 via the first side-by-side BAR2 diff between HailoRT-on-Linux and SLM-OS-native running the same MNIST HEF on pi-5-1:

|  | HailoRT (Linux) | SLM-OS (before fix) |
|---|---|---|
| BAR2 ops | 98 | 4800 |
| Channels touched | **ch=2 (H2D) + ch=16 (D2H)** | **ch=0 + ch=1** |
| `NUM_PROC` behaviour | non-zero progressing | 0x00000000 forever |

The translator at `hailo_cs_translator.c:212/249` already computes the right packed channels from `config_vdma_channel + offset` constants. The header pins the H2D/D2H direction split with `_Static_assert`s. The bug was purely that the host-side VDMA-arming code at the two call sites bypassed those constants and used raw \"first available\" indices.

## Regression coverage

`kernel/tests/test_hailo.c`:

- `test_infer_rejects_input_in_d2h_range` — input in [16, 31] is rejected
- `test_infer_rejects_output_in_h2d_range` — output in [0, 15] is rejected
- `test_infer_rejects_old_default_pair` — pins the shipped `(0, 1)` value to fail
- `test_infer_translator_offsets_yield_valid_channels` — pins the derivation chain so a future bump to either constant that pushes a boundary into the wrong direction trips the test before it can ship

Existing infer tests that used the now-invalid `(0, 1)` pair updated to `(2, 16)`. The mock BAR2 auto-advance handler now mirrors NUM_AVAIL → NUM_PROC on either HOST sub-block (+0x00 H2D, +0x10 D2H) so D2H output channels complete end-to-end through the mock — this surfaced as a side effect of switching outputs into the D2H range.

## Test plan

- [x] `make test` — full kernel test suite on QEMU ARM64 (passes)
- [ ] Build for Pi 5: `make kernel PLATFORM=RASPI5`
- [ ] Deploy to pi-5-1 via `sdwire_update`, capture BAR2 ops on `hailo infer 128` and verify writes hit ch=2 (BAR2+0x40..) and ch=16 (BAR2+0x200..) instead of ch=0 / ch=1
- [ ] Run end-to-end MNIST native flow (`hailo load /mnt/files/user.hef sched` + inference) and confirm completion instead of `num_proc` wedge
- [ ] Diff post-fix SLM-OS BAR2 trace against the 2026-05-25 Linux ftrace — channel-arming offsets should converge

Closes #682 (pending hardware verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)