### PR TITLE
hailo: #1001 IOVA reachability probe + DMA-content diff plan

### DIFF
--- a/docs/hailo-dma-content-diff-plan.md
+++ b/docs/hailo-dma-content-diff-plan.md
@@ -1,0 +1,181 @@
+# Hailo DMA buffer content diff plan (#1001 follow-up)
+
+## Why
+
+Every BAR0/BAR2/BAR4 MMIO write SLM-OS issues during MNIST load + first-frame
+inference is byte-faithful to HailoRT v4.23 on Pi 5 (see PR #999 + #1004 +
+#1008 chain and the per-byte BAR2 trace comparison in
+`~/slmos-ref/derivatives/slmos-traces/`). HailoRT runs MNIST end-to-end at
+~11k FPS on this exact silicon; SLM-OS wedges at `ch=2 num_proc=0` with all
+8 IN descriptor `status` bytes untouched (sentinel probe 2026-05-27 proved
+fw never writes them).
+
+The IOVA reachability hypothesis is also disconfirmed: fw DOES write to our
+0x100xxx IOVA range for cfg-channel CCW upload (`ch=0 proc=0x006e006d`
+post-load). So the wedge is at fw decision level, not transport level.
+
+What remains untraced is **the content of host RAM that fw reads via DMA**.
+The wire bytes that program WHERE to read are equal between sides. The
+bytes fw actually reads from those addresses have never been compared.
+
+Two distinct content regions are candidates:
+
+1. **CCWS data** at IOVAs the cfg-channel descriptors point to. PR #1007's
+   `hailo_ccw_dump_fingerprint` exists but dumps only the first 64 B and
+   only one action at a time. We need full content dumps for byte-diff.
+2. **Boundary descriptor list bytes** (per-descriptor: `page_size_desc_control`,
+   `addr_l_rsvd_data_id`, `addr_h`, `remaining_page_size_status`). 16 bytes
+   × 8 IN descs + 16 × 8 OUT descs = 256 bytes. Already dumpable via
+   `hailo_vdma_dump_desc` (the variant that shows all four fields per desc,
+   not the `_status` one), but not in a parser-friendly format.
+3. **CCWS desc list bytes** — similar shape, for ch=0/ch=1 (cfg) channels.
+
+Boundary INPUT DMA buffer content itself (the 784-byte input image) is
+zeros for `model infer mnist`, so a byte-diff against Linux only matters
+if Linux differs from "zeros" in any subtle way (alignment, padding).
+Probably not load-bearing but cheap to include.
+
+## What to dump
+
+### SLM-OS side
+
+Single new shell command `hailo dma-dump` that runs immediately after
+`hailo load /mnt/files/user.hef sched` and before `hailo runmodel 1`. It
+prints to UART, one region per logical artifact:
+
+```
+[dma-dump:ccws_block] iova=0x... size=112256
+  0x00000000: 00 00 00 00 84 06 20 00 00 00 00 01 00 00 00 00
+  0x00000010: ...
+  ... full hex dump, 16 B per line ...
+
+[dma-dump:cfg_ch0_desc_list] iova=0x... count=8 stride=16
+  desc[0]: page_size_desc_control=0x... addr_l_rsvd_data_id=0x... addr_h=0x... rps_full=0x...
+  desc[1]: ...
+
+[dma-dump:cfg_ch1_desc_list] ...
+[dma-dump:boundary_in_desc_list] ...
+[dma-dump:boundary_out_desc_list] ...
+
+[dma-dump:boundary_in_buf] iova=0x... size=784
+  0x00000000: 00 00 00 00 ...
+  ...
+[dma-dump:boundary_out_buf] iova=0x... size=10
+  0x00000000: 00 00 00 00 ...
+```
+
+UART throughput at 115200 baud is ~11 KB/s. Total dump volume:
+- CCWS block: 112256 B → 7016 lines × 60 chars ≈ 420 KB → ~40 s
+- Descriptor lists: 8 descs × 4 = 32 descs × ~80 chars = ~2.5 KB → <1 s
+- Boundary buffers: 784 + 10 B → ~50 lines → <1 s
+
+CCWS dominates. Either capture full (accept 40 s pause) or sample (first
++ last + every Nth byte). Recommend full dump given this runs once per
+investigation session.
+
+A `hailo dma-snap-iova <iova> <len>` variant for ad-hoc dumps is also
+worth having.
+
+### Linux side
+
+`hailo_pci` doesn't expose host RAM by default. The PR #997 framework
+adds a kprobe-based trace hook on `hailo_resource_write32` and similar.
+We need a kprobe that triggers AT MATCHING POINTS to SLM-OS's dump
+boundaries — specifically right before the same boundary IN submit.
+
+Two options:
+
+**(a) Extend `hailo_pci` with a debugfs entry `dma_dump`.** A user-space
+trigger (`echo 1 > /sys/kernel/debug/hailo_pci/dma_dump`) calls a kernel
+function that walks the same logical structures and prints them via
+`pr_info`. This requires building a custom `hailo_pci.ko` from source
+with our patch — moderate effort but the trace framework we built for
+#997 already shows this is workable.
+
+**(b) Drive from user-space via `hailortcli` with extra debug flags.**
+HailoRT can be coaxed into dumping internal state with environment
+variables (`HAILO_DEBUG=1` etc.), but its dumps focus on protocol-level
+state, not raw DMA buffer bytes. Less direct.
+
+(a) is the more reliable path. The PR #783 trace framework + the PR
+#997 kprobe instrumentation chain in `~/slmos-ref/derivatives/...` is
+the template.
+
+## Hex format
+
+The two sides MUST emit byte-for-byte identical hex format so a literal
+`diff` is meaningful. Suggested:
+
+```
+[dma-dump:<region_name>] iova=0x<hex> size=<dec>
+0x<offset_hex_8>: bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
+```
+
+- One leading line per region with region-name + iova + size.
+- Hex bytes in lowercase, single-space separated, 16 per line.
+- No ASCII column (collides with multi-byte UART newline handling on
+  Pi 5; we've seen `\r\r\n` artifacts in serial captures).
+- Trailing newline at end of region.
+
+## Capture procedure
+
+1. Build SLM-OS with the `hailo dma-dump` command, deploy to pi-5-1
+   (SLMOS card). Run `hailo probe → boot → load → dma-dump`. Save UART
+   capture to `~/slmos-ref/derivatives/slmos-traces/slmos-dma-dump-mnist-<date>.txt`.
+2. Build patched `hailo_pci.ko` with debugfs `dma_dump` entry. Swap to
+   Pi OS card. Run `hailortcli run /tmp/mnist.hef -c 1` and after the
+   load phase trigger the dump via debugfs. Save dmesg capture to
+   `~/slmos-ref/derivatives/slmos-traces/hailort-linux-dma-dump-mnist-<date>.log`.
+3. Extract region-by-region hex from both captures (Python helper —
+   one input per side, output one file per region). Format identical.
+4. `diff -u` each pair. Expected outcomes:
+   - **All regions identical → no DMA-content divergence; wedge cause
+     is even deeper inside fw than we can probe from host.**
+   - **A region differs → starting point for a fix.** Especially
+     interesting differences:
+     - CCWS bytes differ → HEF parser is emitting different bytes than
+       HailoRT (similar shape to the original #1005 misread, but now
+       provable).
+     - Descriptor list bytes differ → SLM-OS programs descriptors
+       differently. The 4-field-per-desc dump should make this jump
+       out.
+     - Boundary IN/OUT buffer differs → initial-state differs.
+
+## Effort estimate
+
+- SLM-OS `hailo dma-dump` command: small (~2 hours). Reuses existing
+  desc list pointers and CCWS buffer reference; just need format +
+  hex helper + shell wiring.
+- Linux-side `hailo_pci` patch + debugfs entry: moderate (~half day to
+  a day). Custom module build + Pi OS deploy is well-trodden via
+  PR #997's framework.
+- Diff procedure + Python helper: small (~1 hour).
+
+Total: ~1-2 sessions to execute end-to-end.
+
+## Definitive-ness of the result
+
+This is THE remaining host-observable test. If all DMA buffer contents
+match byte-for-byte and the wedge still reproduces, host-side investigation
+is mathematically exhausted (every byte SLM-OS hands to fw is identical to
+HailoRT's). At that point the only remaining directions are:
+
+1. **fw memory inspection** — BAR4 region content dumps pre/post-load,
+   looking for fw-internal state divergence. The PR #997 framework
+   covers BAR0/BAR2; need to extend it to BAR4 windowed reads.
+2. **Hailo support escalation** — present the byte-faithful evidence
+   and request fw-side debug.
+3. **Capstone writeup** — accept the chain as complete; the limit is
+   in the closed firmware.
+
+## Cross-references
+
+- PR #999: channel-index direction fix (the only landed fix in #682 chain)
+- PR #1004: load-time RPC byte-faithfulness
+- PR #1007: CCW fingerprint dump (template for `hailo dma-dump`)
+- PR #1008: CCW total_bytes display bug fix + modern Op-graph walker
+- Memory `hailo_682_root_cause_channel_index`: full disconfirmation chain
+- Memory `hailo_trace_toolkit`: PRs #780/#783 trace framework
+- Memory `hailo_re_corpus_bar_coverage`: structural BAR coverage limit
+- Sentinel-probe trace (2026-05-27): proves fw never writes to IN desc
+  list — the wedge is at fw decision level, not PCIe transport

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -2574,6 +2574,44 @@ static int hailo_backend_run(struct inference_device *dev,
     hailo_vdma_snap_channels("pre-IN-submit");
 #endif
 
+#ifdef HAILO_WIRE_DEBUG
+    /* #1001 IOVA reachability probe. Pre-fill IN descriptor list's
+     * `remaining_page_size_status` with a sentinel pattern so we can
+     * distinguish "fw never wrote to our DMA target" (sentinel
+     * survives) from "fw wrote 0" (status reads back as 0 from
+     * zero-init dma_alloc). The existing dump path at
+     * hailo_vdma_dump_desc_status reads the same field post-timeout.
+     * Cache-clean pushes the sentinel to DRAM so fw observes our
+     * value, not a stale L1/L2 copy.
+     *
+     * Result 2026-05-27 on pi-5-1: sentinel survives unchanged across
+     * all 8 IN descriptors. Combined with cfg-channel success
+     * evidence (fw DID write to 0x100xxx IOVAs for CCW upload), this
+     * proves the wedge is at fw decision level (refuses to dispatch
+     * ch=2) rather than PCIe transport level. IOVA pinning would not
+     * help. See docs/hailo-dma-content-diff-plan.md for the next
+     * orthogonal experiment. */
+    {
+        const uint32_t IOVA_PROBE_SENTINEL = 0xABABABABu;
+        uint32_t probe_n = slot->boundary_in_list.desc_count;
+        if (probe_n > 8u) probe_n = 8u;
+        for (uint32_t i = 0; i < probe_n; i++) {
+            slot->boundary_in_list.descs[i].remaining_page_size_status =
+                IOVA_PROBE_SENTINEL;
+        }
+        if (hailo_platform && hailo_platform->cache_clean) {
+            hailo_platform->cache_clean(
+                slot->boundary_in_list.descs,
+                (size_t)probe_n
+                    * sizeof(struct hailo_vdma_descriptor));
+        }
+        uart_printf("[probe] IN desc[0..%u] rps pre-filled with "
+                    "sentinel 0x%08x\r\n",
+                    (unsigned)probe_n,
+                    (unsigned)IOVA_PROBE_SENTINEL);
+    }
+#endif /* HAILO_WIRE_DEBUG */
+
     int rc;
     uint64_t t_in_submit  = timer_get_count();
     rc = hailo_vdma_submit_and_wait(in_channel, in_num_avail,

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -2619,6 +2619,27 @@ static int hailo_backend_run(struct inference_device *dev,
     uint64_t t_in_done = timer_get_count();
 #ifdef HAILO_WIRE_DEBUG
     hailo_vdma_snap_channels("post-IN-submit");
+    /* #1001 IOVA probe cleanup: on submit-success, restore the
+     * pre-fill sentinel back to 0 so a subsequent inference doesn't
+     * observe stale 0xABABABAB in the desc rps field and mistake it
+     * for a fw-side artifact. On submit-failure (the wedge path)
+     * we leave the sentinel intact so the dump at
+     * hailo_vdma_dump_desc_status below can confirm fw never wrote.
+     * Matches the pre-fill cap (probe_n ≤ 8u) so the two paths stay
+     * in sync. */
+    if (rc == HAILO_OK) {
+        uint32_t cleanup_n = slot->boundary_in_list.desc_count;
+        if (cleanup_n > 8u) cleanup_n = 8u;
+        for (uint32_t i = 0; i < cleanup_n; i++) {
+            slot->boundary_in_list.descs[i].remaining_page_size_status = 0;
+        }
+        if (hailo_platform && hailo_platform->cache_clean) {
+            hailo_platform->cache_clean(
+                slot->boundary_in_list.descs,
+                (size_t)cleanup_n
+                    * sizeof(struct hailo_vdma_descriptor));
+        }
+    }
 #endif
     if (rc != HAILO_OK) {
         uart_printf("[hailo] run: IN submit_and_wait rc=%d (avail=%u)\r\n",


### PR DESCRIPTION
## Summary

- **Sentinel-byte IOVA reachability probe** (`HAILO_WIRE_DEBUG`-gated) at `inference_device_hailo.c:2573-2607`. Pre-fills IN descriptor list's `remaining_page_size_status` field with `0xABABABAB` before VDMA submit so the existing post-timeout dump path can distinguish *fw didn't write* (sentinel survives) from *fw wrote 0* (zero-init default).
- **DMA-content diff plan** at `docs/hailo-dma-content-diff-plan.md`. Writeup of the next concrete host-observable experiment after this probe: byte-diff the host RAM contents fw reads via DMA (CCWS block, all 4 descriptor lists, boundary buffers) between SLM-OS and HailoRT. The wire bytes that program WHERE fw reads match between sides; the bytes fw actually reads from those addresses have never been compared.

## Why

Continues the #682/#1001 chain. Two questions this PR answers:

1. *Can fw reach our 0x100xxx IOVAs at all?* — yes for cfg channels (`ch=0 proc=0x006e006d` post-load) but the probe confirms fw **never writes** to our boundary IN descriptor list even on a wedged run. Sentinel pattern intact across all 8 entries post-30s timeout. Combined with cfg-success, this proves the wedge is at fw decision level (refuses to dispatch ch=2), not PCIe transport level. **IOVA pinning would not help.**
2. *What's the next concrete experiment?* — DMA-content diff. Doc covers what to dump on each side, the hex format for `diff`-ability, the capture procedure, and the effort estimate (~1-2 sessions).

## Cumulative state on #682 chain

After this PR: **8 disconfirmed host-side hypotheses**, 6 merged PRs (one — channel-index in #999 — landed as a real defect fix). DMA-content diff is the last cheap-ish host-observable lever. If it also disconfirms, host-side investigation is mathematically exhausted and only fw-memory inspection or Hailo escalation remain.

| Hypothesis | Verdict |
|---|---|
| Channel-index direction | Fixed (PR #999) |
| sequence=0 in control RPCs | Disconfirmed (#1003) |
| Drop post-RESET pings | Disconfirmed (#1003) |
| Longer post-BOOT_IRQ settle | Disconfirmed (#1003) |
| PMCSR D0→D3→D0 cycle | Disconfirmed by direct A/B (2026-05-27) |
| MSI vs polled wait | Disconfirmed by source-read (2026-05-27) |
| BAR4 padding 40→64 bytes | Disconfirmed by source-read — wrong premise; alignment is 4 not 64 |
| **IOVA reachability** | **Disconfirmed by this PR's probe (2026-05-27)** |
| DMA-content byte-diff | Untested — plan in this PR |

## Test plan

- [x] QEMU ARM64 test suite passes (`make test`)
- [x] x86-64 builds clean (`make kernel PLATFORM=X86_64`)
- [x] Pi 5 hardware probe verified — sentinel survives across all 8 IN descriptors on wedged `hailo runmodel 1`, behaviour identical to baseline otherwise

The probe is gated under `HAILO_WIRE_DEBUG` so default builds pay zero cost. Future investigation only needs `make kernel PLATFORM=RASPI5 HAILO_WIRE_DEBUG=ON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)