### PR TITLE
hailo: pre-fill boundary desc rings + drop last-desc LIRQ (#1001 defensive cleanup)

### DIFF
--- a/kernel/ai_accel/hailo/hailo_vdma.c
+++ b/kernel/ai_accel/hailo/hailo_vdma.c
@@ -357,6 +357,78 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
     return (int)descs_needed;
 }
 
+/* Make a boundary descriptor ring byte-faithful to HailoRT's
+ * post-`launch_transfer` state, with two changes on top of what
+ * `hailo_vdma_program_buffer` produces:
+ *
+ *   1. Pre-program descs[descs_used..desc_count-1] with valid
+ *      `page_size_desc_control` (DESC_VALID + the same page_size as
+ *      the active descs) and addresses that continue the
+ *      +page_size pattern past the buffer end. fw never DMAs those
+ *      descs because num_avail caps it at the active subset, but
+ *      they're structurally valid (control byte != 0) so any
+ *      ring-state pre-fetch HailoRT may exercise sees the same
+ *      shape SLM-OS now presents.
+ *
+ *   2. Clear LIRQ bits on the last active descriptor (its control
+ *      byte becomes plain DESC_VALID). `hailo_vdma_program_buffer`
+ *      sets `0x2e` (HOST_IRQ | REQ_IRQ_PROCESSED | REQ_IRQ_ERR |
+ *      DESC_VALID); HailoRT keeps `0x02`. Per the 2026-05-27 DMA-
+ *      content byte-diff capture, HailoRT relies on num_proc poll
+ *      (or device-side completion) rather than the per-descriptor
+ *      IRQ-request bits.
+ *
+ * Cache-cleaned to DRAM so fw observes both changes.
+ *
+ * Rationale: 2026-05-27 DMA-content byte-diff between SLM-OS (PR
+ * #1010 dma-dump) and HailoRT (Linux hailo_pci dma_dump hook)
+ * surfaced these two wire-level divergences. Both were tested as
+ * #1001 wedge candidates and both disconfirmed (wedge symptom
+ * byte-identical with and without the changes); retained as
+ * permanent parity to eliminate the divergences from future
+ * investigations and to suppress a fw-side spurious
+ * `event_id=0(ETHERNET_RX_ERROR)` d2h notification that fires
+ * whenever HOST_IRQ bits are set on a last desc. See memory
+ * `hailo_682_root_cause_channel_index.md` for the full chain.
+ *
+ * Caller responsibility: call AFTER `hailo_vdma_program_buffer`,
+ * with the same `buffer_iova` and `buffer_size` so the address
+ * pattern continues seamlessly. */
+void hailo_vdma_match_hailort_boundary_ring(
+        struct hailo_vdma_desc_list *list,
+        uint64_t buffer_iova,
+        uint32_t buffer_size,
+        uint8_t  data_id)
+{
+    if (!list || !list->descs || list->desc_count == 0u) return;
+    if (list->desc_page_size == 0u) return;
+
+    const uint32_t page_size  = list->desc_page_size;
+    const uint32_t descs_used = (buffer_size + page_size - 1u) / page_size;
+
+    /* (1) Pre-fill descs[descs_used..desc_count-1] with a valid shape. */
+    for (uint32_t i = descs_used; i < list->desc_count; i++) {
+        uint64_t addr = buffer_iova + (uint64_t)i * (uint64_t)page_size;
+        hailo_vdma_program_descriptor(&list->descs[i], addr,
+                                      (uint16_t)page_size, data_id);
+    }
+
+    /* (2) Clear LIRQ bits on the last active descriptor. */
+    if (descs_used > 0u) {
+        struct hailo_vdma_descriptor *last = &list->descs[descs_used - 1u];
+        last->page_size_desc_control =
+            (last->page_size_desc_control & ~0xFFu)
+            | (uint32_t)HAILO_VDMA_DESC_DESC_CONTROL;
+    }
+
+    if (hailo_platform && hailo_platform->cache_clean) {
+        hailo_platform->cache_clean(
+            list->descs,
+            (size_t)list->desc_count
+                * sizeof(struct hailo_vdma_descriptor));
+    }
+}
+
 /* -------------------------------------------------------------------------- */
 /* Channel start / stop / submit                                               */
 /* -------------------------------------------------------------------------- */

--- a/kernel/ai_accel/hailo/hailo_vdma.h
+++ b/kernel/ai_accel/hailo/hailo_vdma.h
@@ -220,6 +220,29 @@ int hailo_vdma_program_buffer(struct hailo_vdma_desc_list *list,
                               uint32_t buffer_size,
                               uint8_t  data_id);
 
+/*
+ * Aligns a boundary descriptor ring with HailoRT's post-launch_transfer
+ * state. Call AFTER `hailo_vdma_program_buffer` with the same
+ * (buffer_iova, buffer_size, data_id) tuple. Two changes:
+ *   1. Pre-program descs[descs_used..desc_count-1] with a valid
+ *      (DESC_VALID + page_size + continuing addresses) pattern.
+ *   2. Clear LIRQ bits on the last active descriptor.
+ * Cache-cleaned to DRAM. Safe to call on rings with desc_count == 0
+ * or no active buffer (early-returns).
+ *
+ * Disconfirmed as a #1001 wedge fix on hardware 2026-05-27 — kept
+ * for wire-byte parity with HailoRT and to suppress a fw-side
+ * spurious `event_id=0(ETHERNET_RX_ERROR)` d2h notification that
+ * fires whenever HOST_IRQ bits are set on a last desc. See
+ * `hailo_vdma.c:hailo_vdma_match_hailort_boundary_ring` for the
+ * full rationale.
+ */
+void hailo_vdma_match_hailort_boundary_ring(
+        struct hailo_vdma_desc_list *list,
+        uint64_t buffer_iova,
+        uint32_t buffer_size,
+        uint8_t  data_id);
+
 /* -------------------------------------------------------------------------- */
 /* Channel start / stop / submit                                               */
 /* -------------------------------------------------------------------------- */

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1400,6 +1400,69 @@ static int context_switch_load(struct hailo_model_slot *slot,
             rc = HAILO_ERR_IO;
             goto fail;
         }
+        /* #1001 hyp-X (2026-05-27 DMA-content diff): HailoRT pre-programs
+         * EVERY descriptor of the ring with valid `page_size_desc_control
+         * = 0x00020002` + incrementing addresses, even though only
+         * desc[0..1] are active for the 784 B MNIST input. SLM-OS until
+         * now left descs[active..desc_count-1] all-zero, which fw may
+         * read during ring validation / pre-fetch and interpret as
+         * "ring is disabled" — refusing to dispatch ch=2. Test: pre-fill
+         * every unused descriptor with the same shape HailoRT uses,
+         * keeping num_avail=2 so fw only DMAs the 2 active descs.
+         *
+         * Addresses for the pre-fill descs continue the incrementing
+         * pattern past the buffer end — these are not meant to be DMA'd
+         * (num_avail=2 limits fw to descs[0..1]), they just need to be
+         * structurally valid descriptors so fw's ring-state check
+         * doesn't reject. */
+        {
+            const uint32_t descs_used =
+                (in_bytes + HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE - 1u)
+                / HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
+            for (uint32_t i = descs_used;
+                 i < slot->boundary_in_list.desc_count;
+                 i++) {
+                uint64_t addr = slot->boundary_in_tensor.iova
+                              + (uint64_t)i
+                                * HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
+                hailo_vdma_program_descriptor(
+                    &slot->boundary_in_list.descs[i],
+                    addr,
+                    HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
+                    HAILO_VDMA_HOST_DMA_DATA_ID);
+            }
+            /* #1001 hyp-Y (2026-05-27): clear LIRQ bits on the last
+             * active descriptor. SLM-OS sets `0x2e` (HOST_IRQ |
+             * REQ_IRQ_PROCESSED | REQ_IRQ_ERR | DESC_VALID); HailoRT
+             * keeps `0x02` (DESC_VALID only) per the 2026-05-27 Linux
+             * DMA-content capture. These bits are HOST-IRQ requests
+             * (whether completion fires an IRQ TO HOST, separate from
+             * fw scheduling), so they THEORETICALLY shouldn't gate fw
+             * dispatch. But last untested wire-level diff. Test:
+             * overwrite to match HailoRT. */
+            if (descs_used > 0u) {
+                uint32_t last_idx = descs_used - 1u;
+                uint32_t ps_ctrl =
+                    slot->boundary_in_list.descs[last_idx]
+                        .page_size_desc_control;
+                slot->boundary_in_list.descs[last_idx]
+                    .page_size_desc_control =
+                    (ps_ctrl & ~0xFFu) | 0x02u;
+                INFO("hailo: hyp-Y cleared IN desc[%u] LIRQ "
+                     "(0x%02x -> 0x02) for #1001",
+                     (unsigned)last_idx, (unsigned)(ps_ctrl & 0xFFu));
+            }
+            if (hailo_platform && hailo_platform->cache_clean) {
+                hailo_platform->cache_clean(
+                    slot->boundary_in_list.descs,
+                    (size_t)slot->boundary_in_list.desc_count
+                        * sizeof(struct hailo_vdma_descriptor));
+            }
+            INFO("hailo: pre-filled IN desc ring [%u..%u] "
+                 "(hyp-X test for #1001)",
+                 (unsigned)descs_used,
+                 (unsigned)slot->boundary_in_list.desc_count - 1u);
+        }
         boundary_in_iova = slot->boundary_in_list.iova;
     }
     cs_load_stage_set(20);
@@ -1450,6 +1513,50 @@ static int context_switch_load(struct hailo_model_slot *slot,
             WARN("hailo backend: boundary OUT program_buffer failed (rc=%d)", prog);
             rc = HAILO_ERR_IO;
             goto fail;
+        }
+        /* #1001 hyp-X (symmetric to the IN side above) — pre-fill the
+         * OUT ring's unused descriptors so fw sees valid entries
+         * across the whole 32-slot ring, matching what HailoRT's
+         * launch_transfer leaves behind. */
+        {
+            const uint32_t descs_used =
+                (out_bytes + HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE - 1u)
+                / HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
+            for (uint32_t i = descs_used;
+                 i < slot->boundary_out_list.desc_count;
+                 i++) {
+                uint64_t addr = slot->boundary_out_tensor.iova
+                              + (uint64_t)i
+                                * HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
+                hailo_vdma_program_descriptor(
+                    &slot->boundary_out_list.descs[i],
+                    addr,
+                    HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
+                    HAILO_VDMA_HOST_DMA_DATA_ID);
+            }
+            /* #1001 hyp-Y: same LIRQ clear on OUT side. */
+            if (descs_used > 0u) {
+                uint32_t last_idx = descs_used - 1u;
+                uint32_t ps_ctrl =
+                    slot->boundary_out_list.descs[last_idx]
+                        .page_size_desc_control;
+                slot->boundary_out_list.descs[last_idx]
+                    .page_size_desc_control =
+                    (ps_ctrl & ~0xFFu) | 0x02u;
+                INFO("hailo: hyp-Y cleared OUT desc[%u] LIRQ "
+                     "(0x%02x -> 0x02) for #1001",
+                     (unsigned)last_idx, (unsigned)(ps_ctrl & 0xFFu));
+            }
+            if (hailo_platform && hailo_platform->cache_clean) {
+                hailo_platform->cache_clean(
+                    slot->boundary_out_list.descs,
+                    (size_t)slot->boundary_out_list.desc_count
+                        * sizeof(struct hailo_vdma_descriptor));
+            }
+            INFO("hailo: pre-filled OUT desc ring [%u..%u] "
+                 "(hyp-X test for #1001)",
+                 (unsigned)descs_used,
+                 (unsigned)slot->boundary_out_list.desc_count - 1u);
         }
         boundary_out_iova = slot->boundary_out_list.iova;
     }

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -1400,69 +1400,18 @@ static int context_switch_load(struct hailo_model_slot *slot,
             rc = HAILO_ERR_IO;
             goto fail;
         }
-        /* #1001 hyp-X (2026-05-27 DMA-content diff): HailoRT pre-programs
-         * EVERY descriptor of the ring with valid `page_size_desc_control
-         * = 0x00020002` + incrementing addresses, even though only
-         * desc[0..1] are active for the 784 B MNIST input. SLM-OS until
-         * now left descs[active..desc_count-1] all-zero, which fw may
-         * read during ring validation / pre-fetch and interpret as
-         * "ring is disabled" — refusing to dispatch ch=2. Test: pre-fill
-         * every unused descriptor with the same shape HailoRT uses,
-         * keeping num_avail=2 so fw only DMAs the 2 active descs.
-         *
-         * Addresses for the pre-fill descs continue the incrementing
-         * pattern past the buffer end — these are not meant to be DMA'd
-         * (num_avail=2 limits fw to descs[0..1]), they just need to be
-         * structurally valid descriptors so fw's ring-state check
-         * doesn't reject. */
-        {
-            const uint32_t descs_used =
-                (in_bytes + HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE - 1u)
-                / HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
-            for (uint32_t i = descs_used;
-                 i < slot->boundary_in_list.desc_count;
-                 i++) {
-                uint64_t addr = slot->boundary_in_tensor.iova
-                              + (uint64_t)i
-                                * HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
-                hailo_vdma_program_descriptor(
-                    &slot->boundary_in_list.descs[i],
-                    addr,
-                    HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
-                    HAILO_VDMA_HOST_DMA_DATA_ID);
-            }
-            /* #1001 hyp-Y (2026-05-27): clear LIRQ bits on the last
-             * active descriptor. SLM-OS sets `0x2e` (HOST_IRQ |
-             * REQ_IRQ_PROCESSED | REQ_IRQ_ERR | DESC_VALID); HailoRT
-             * keeps `0x02` (DESC_VALID only) per the 2026-05-27 Linux
-             * DMA-content capture. These bits are HOST-IRQ requests
-             * (whether completion fires an IRQ TO HOST, separate from
-             * fw scheduling), so they THEORETICALLY shouldn't gate fw
-             * dispatch. But last untested wire-level diff. Test:
-             * overwrite to match HailoRT. */
-            if (descs_used > 0u) {
-                uint32_t last_idx = descs_used - 1u;
-                uint32_t ps_ctrl =
-                    slot->boundary_in_list.descs[last_idx]
-                        .page_size_desc_control;
-                slot->boundary_in_list.descs[last_idx]
-                    .page_size_desc_control =
-                    (ps_ctrl & ~0xFFu) | 0x02u;
-                INFO("hailo: hyp-Y cleared IN desc[%u] LIRQ "
-                     "(0x%02x -> 0x02) for #1001",
-                     (unsigned)last_idx, (unsigned)(ps_ctrl & 0xFFu));
-            }
-            if (hailo_platform && hailo_platform->cache_clean) {
-                hailo_platform->cache_clean(
-                    slot->boundary_in_list.descs,
-                    (size_t)slot->boundary_in_list.desc_count
-                        * sizeof(struct hailo_vdma_descriptor));
-            }
-            INFO("hailo: pre-filled IN desc ring [%u..%u] "
-                 "(hyp-X test for #1001)",
-                 (unsigned)descs_used,
-                 (unsigned)slot->boundary_in_list.desc_count - 1u);
-        }
+        /* Align boundary IN ring with HailoRT's post-launch_transfer
+         * state — pre-fill descs beyond the active range + drop LIRQ
+         * on the last active. See
+         * `hailo_vdma.c:hailo_vdma_match_hailort_boundary_ring` for
+         * the rationale and disconfirmation history. Net effect on
+         * #1001: no wedge change but eliminates two wire divergences
+         * from SLM-OS↔HailoRT parity. */
+        hailo_vdma_match_hailort_boundary_ring(
+            &slot->boundary_in_list,
+            slot->boundary_in_tensor.iova,
+            in_bytes,
+            HAILO_VDMA_HOST_DMA_DATA_ID);
         boundary_in_iova = slot->boundary_in_list.iova;
     }
     cs_load_stage_set(20);
@@ -1514,50 +1463,13 @@ static int context_switch_load(struct hailo_model_slot *slot,
             rc = HAILO_ERR_IO;
             goto fail;
         }
-        /* #1001 hyp-X (symmetric to the IN side above) — pre-fill the
-         * OUT ring's unused descriptors so fw sees valid entries
-         * across the whole 32-slot ring, matching what HailoRT's
-         * launch_transfer leaves behind. */
-        {
-            const uint32_t descs_used =
-                (out_bytes + HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE - 1u)
-                / HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
-            for (uint32_t i = descs_used;
-                 i < slot->boundary_out_list.desc_count;
-                 i++) {
-                uint64_t addr = slot->boundary_out_tensor.iova
-                              + (uint64_t)i
-                                * HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE;
-                hailo_vdma_program_descriptor(
-                    &slot->boundary_out_list.descs[i],
-                    addr,
-                    HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE,
-                    HAILO_VDMA_HOST_DMA_DATA_ID);
-            }
-            /* #1001 hyp-Y: same LIRQ clear on OUT side. */
-            if (descs_used > 0u) {
-                uint32_t last_idx = descs_used - 1u;
-                uint32_t ps_ctrl =
-                    slot->boundary_out_list.descs[last_idx]
-                        .page_size_desc_control;
-                slot->boundary_out_list.descs[last_idx]
-                    .page_size_desc_control =
-                    (ps_ctrl & ~0xFFu) | 0x02u;
-                INFO("hailo: hyp-Y cleared OUT desc[%u] LIRQ "
-                     "(0x%02x -> 0x02) for #1001",
-                     (unsigned)last_idx, (unsigned)(ps_ctrl & 0xFFu));
-            }
-            if (hailo_platform && hailo_platform->cache_clean) {
-                hailo_platform->cache_clean(
-                    slot->boundary_out_list.descs,
-                    (size_t)slot->boundary_out_list.desc_count
-                        * sizeof(struct hailo_vdma_descriptor));
-            }
-            INFO("hailo: pre-filled OUT desc ring [%u..%u] "
-                 "(hyp-X test for #1001)",
-                 (unsigned)descs_used,
-                 (unsigned)slot->boundary_out_list.desc_count - 1u);
-        }
+        /* Align boundary OUT ring with HailoRT — same shape as the
+         * IN side above. */
+        hailo_vdma_match_hailort_boundary_ring(
+            &slot->boundary_out_list,
+            slot->boundary_out_tensor.iova,
+            out_bytes,
+            HAILO_VDMA_HOST_DMA_DATA_ID);
         boundary_out_iova = slot->boundary_out_list.iova;
     }
     cs_load_stage_set(21);

--- a/kernel/tests/test_hailo.c
+++ b/kernel/tests/test_hailo.c
@@ -5550,6 +5550,76 @@ static void test_vdma_program_buffer_rejects_null_list(void)
     TEST_ASSERT_EQUAL_INT(HAILO_ERR_INVAL, rc);
 }
 
+/* #1001 PR #1012: after program_buffer + match_hailort_boundary_ring,
+ * the last active desc loses its LIRQ bits and descs beyond it carry
+ * a continuing-pattern shape matching HailoRT's launch_transfer leftover
+ * state. MNIST shape: 784 B / 512 B page = 2 active descs in a 32-slot
+ * ring. */
+static void test_vdma_match_hailort_boundary_ring_mnist_in(void)
+{
+    vdma_setup();
+    struct hailo_vdma_desc_list list;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_vdma_desc_list_alloc(32, 512, /*circular=*/false, &list));
+
+    /* Program 2 active descs the same way the load path does. */
+    int rc = hailo_vdma_program_buffer(&list, 0,
+        /*iova=*/0x10020b4000ULL, /*size=*/784, /*data_id=*/0x05);
+    TEST_ASSERT_EQUAL_INT(2, rc);
+    /* Confirm pre-call state: desc[1] has LAST_DESC_CTRL (0x2e),
+     * desc[2] is zero. */
+    TEST_ASSERT_EQUAL_UINT32((272u << 8) | LAST_DESC_CTRL,  /* 784 - 512 = 272 residue */
+                             list.descs[1].page_size_desc_control);
+    TEST_ASSERT_EQUAL_UINT32(0u, list.descs[2].page_size_desc_control);
+
+    hailo_vdma_match_hailort_boundary_ring(&list,
+        /*iova=*/0x10020b4000ULL, /*size=*/784, /*data_id=*/0x05);
+
+    /* desc[1] LIRQ bits cleared → control byte is just 0x02. Page
+     * size stays 272 (residue). */
+    TEST_ASSERT_EQUAL_UINT32((272u << 8) | 0x02u,
+                             list.descs[1].page_size_desc_control);
+    /* desc[2..31] now carry the continuing-pattern shape: page_size
+     * = 512, control = DESC_VALID, address = iova + i*512. */
+    for (uint32_t i = 2; i < list.desc_count; i++) {
+        TEST_ASSERT_EQUAL_UINT32((512u << 8) | 0x02u,
+                                 list.descs[i].page_size_desc_control);
+        TEST_ASSERT_EQUAL_UINT32(
+            (uint32_t)(0x10020b4000ULL + (uint64_t)i * 512ULL) | 0x05u,
+            list.descs[i].addr_l_rsvd_data_id);
+        TEST_ASSERT_EQUAL_UINT32(
+            (uint32_t)((0x10020b4000ULL + (uint64_t)i * 512ULL) >> 32),
+            list.descs[i].addr_h);
+    }
+    /* desc[0] stays as program_buffer wrote it. */
+    TEST_ASSERT_EQUAL_UINT32((512u << 8) | 0x02u,
+                             list.descs[0].page_size_desc_control);
+    hailo_vdma_desc_list_free(&list);
+}
+
+/* NULL / zero-shape inputs: helper must early-return cleanly, leaving
+ * the list untouched (or, for NULL, just not crashing). */
+static void test_vdma_match_hailort_boundary_ring_handles_nulls(void)
+{
+    /* NULL list pointer — must not crash. */
+    hailo_vdma_match_hailort_boundary_ring(NULL, 0x1000, 512, 0);
+
+    vdma_setup();
+    struct hailo_vdma_desc_list list;
+    TEST_ASSERT_EQUAL_INT(HAILO_OK,
+        hailo_vdma_desc_list_alloc(8, 512, false, &list));
+    /* desc_count > 0 but buffer_size = 0 → descs_used = 0, so loop
+     * pre-fills descs[0..7]. With descs_used==0 the LIRQ-clear block
+     * is skipped (guard). */
+    hailo_vdma_match_hailort_boundary_ring(&list,
+        /*iova=*/0x4000, /*size=*/0, /*data_id=*/0x03);
+    TEST_ASSERT_EQUAL_UINT32((512u << 8) | 0x02u,
+                             list.descs[0].page_size_desc_control);
+    TEST_ASSERT_EQUAL_UINT32((512u << 8) | 0x02u,
+                             list.descs[7].page_size_desc_control);
+    hailo_vdma_desc_list_free(&list);
+}
+
 static void test_vdma_program_buffer_rejects_zero_size(void)
 {
     vdma_setup();
@@ -8339,6 +8409,10 @@ int test_suite_hailo(void)
     RUN_TEST(test_vdma_program_buffer_rejects_null_list);
     RUN_TEST(test_vdma_program_buffer_rejects_zero_size);
     RUN_TEST(test_vdma_program_buffer_cache_clean_uses_correct_offset);
+
+    /* #1001 PR #1012: HailoRT-parity ring finalization */
+    RUN_TEST(test_vdma_match_hailort_boundary_ring_mnist_in);
+    RUN_TEST(test_vdma_match_hailort_boundary_ring_handles_nulls);
     RUN_TEST(test_vdma_channel_start_programs_regs);
     RUN_TEST(test_vdma_channel_start_encodes_address_l);
     RUN_TEST(test_vdma_channel_start_rejects_misaligned_iova);


### PR DESCRIPTION
## Summary

Aligns SLM-OS's boundary IN + OUT descriptor ring programming with HailoRT's exact wire shape, based on the 2026-05-27 DMA-content byte-diff (SLM-OS PR #1010 + Linux-side `hailo_pci` hook this session).

Two changes to `context_switch_load` in `inference_device_hailo.c`:

1. **Pre-fill the entire ring.** After `hailo_vdma_program_buffer` programs the descriptors actually active for the current submit (2 for the 784 B MNIST IN, 1 for the 16 B OUT), pre-program descs[`descs_used`..31] with the same `page_size_desc_control = 0x00020002` + page-incrementing addresses. Addresses extend past the buffer end but are never DMA'd because `num_avail` caps fw at the active subset.

2. **Clear last-desc LIRQ.** Overwrite the LIRQ bits HailoRT v4.23 left set by `program_buffer` (`0x2e`) with HailoRT's pattern (`0x02`, DESC_VALID only).

Cache-cleaned to DRAM after both changes.

## Does this fix #1001?

**No.** Tested on pi-5-1 2026-05-27. Same wedge signature: `ch=2 TIMEOUT proc_end=0x00000000 base_end=0x00022801`, IN desc[0..7] status=0x00, `inference_run rc=-7`. fw doesn't gate ch=2 dispatch on either of these divergences.

## Why merge then?

- **Eliminates two real wire-level divergences** from SLM-OS↔HailoRT parity. Every visible-from-host wire byte for the boundary-channel programming now matches HailoRT byte-for-byte. Future investigations don't need to re-test these as candidates.
- **Suppresses a noisy d2h notification.** The previously-mysterious `event_id=0 ETHERNET_RX_ERROR payload_len=0` notification in the wedge logs turned out to be LIRQ-correlated — vanishes when the last-desc LIRQ bits are cleared. Less log noise during diagnostic runs.

## Hypothesis chain on #1001

This pair is hypothesis #9 and #10 in the host-side disconfirmation chain. After this PR, every wire-byte-comparable divergence between SLM-OS and HailoRT has been tested and ruled out. Only direction left for #1001 is fw-memory inspection (hard) or Hailo support escalation. Memory `hailo_682_root_cause_channel_index.md` has the full chain.

## Test plan

- [x] `make test` (QEMU ARM64) passes
- [x] `make kernel PLATFORM=RASPI5 AI_SCHED=ON` builds clean
- [x] Pi 5 hardware verified — ring pre-fill + LIRQ clear both land at load time per boot log (`pre-filled IN desc ring [2..31]`, `hyp-Y cleared IN desc[1] LIRQ (0x2e -> 0x02)`)
- [x] Wedge reproduces with the same signature (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)