### PR TITLE
hailo: cleanup batch 2 — dry-run transport, Phase 6 constants/macro (closes #810, partial #337)

### DIFF
--- a/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
+++ b/host-tools/hailo-re-driver/hailo_re_driver/slmos_runner.py
@@ -129,16 +129,58 @@ def subprocess_transport(argv: list[str], timeout: Optional[float]) -> CmdResult
 
 
 def dry_run_transport(argv: list[str], _timeout: Optional[float]) -> CmdResult:
-    """No-op transport: log the command, return success with empty stdout.
+    """No-op transport: log the command, return success with a synthetic
+    stdout that downstream parsers accept.
 
     Used by the CLI's `--dry-run` to surface-check labctl invocations without
     touching hardware. For end-to-end loop simulation (where the SLM-OS side
-    must actually return synthesised RESPONSE lines), use
-    `MockSlmosRunner` with `--mock-slmos-responses`.
+    must actually return real-shape RESPONSE lines for a specific corpus
+    walk), use `MockSlmosRunner` with `--mock-slmos-responses`.
+
+    Per #810, the dry-run transport must synthesise enough output for the
+    three labctl commands `SlmosRunner` issues so the loop can advance
+    one iteration cleanly instead of failing at "did not see shell prompt
+    after flash+reboot":
+
+    * `labctl serial capture <sbc> --until <re>` → emit the `slmos>` prompt
+      so `_shell_prompt_re.search(stdout)` succeeds.
+    * `labctl serial send <sbc> '\\r hailo replay-step <path> <seq>' ...`
+      → emit a synthetic `HAILO_RE_CORPUS_RESPONSE` line with sentinel
+      `value=deadbeef` + 40 zero `slmos_sha` so `parse_replay_output`
+      classifies the iteration as a success without burning the timeout.
+    * Anything else (sdwire update, etc.) → empty stdout, returncode=0.
+
+    The seq embedded in the synthesised RESPONSE is parsed out of the
+    `replay-step <path> <seq>` token in argv so the loop's
+    `last_seq_appended` advances correctly.
     """
+    stdout = ""
+    if len(argv) >= 4 and argv[0] == "labctl" and argv[1] == "serial":
+        if argv[2] == "capture":
+            # The `--until` pattern is typically `slmos>` but can be a
+            # configured prompt regex. Emit a literal `slmos>` — the
+            # default matcher in SlmosRunner uses the same string and
+            # the dry-run path doesn't need to support custom prompts.
+            stdout = "slmos> \n"
+        elif argv[2] == "send":
+            # Locate the `hailo replay-step <path> <seq>` token in argv
+            # to extract the seq. The cmd is a single argv element
+            # (one combined string), so split it ourselves.
+            seq = 0
+            for arg in argv:
+                if "hailo replay-step " in arg:
+                    parts = arg.strip().split()
+                    # ['hailo', 'replay-step', '<path>', '<seq>']
+                    if len(parts) >= 4 and parts[-1].isdigit():
+                        seq = int(parts[-1])
+                    break
+            stdout = (
+                f"HAILO_RE_CORPUS_RESPONSE seq={seq} bar=0 offset=0 "
+                f"size=4 value=deadbeef slmos_sha={'0' * 40}\n"
+            )
     return CmdResult(
         returncode=0,
-        stdout="",
+        stdout=stdout,
         stderr=f"[dry-run] {' '.join(shlex.quote(a) for a in argv)}\n",
     )
 

--- a/host-tools/hailo-re-driver/tests/test_slmos_runner.py
+++ b/host-tools/hailo-re-driver/tests/test_slmos_runner.py
@@ -25,6 +25,7 @@ from hailo_re_driver.slmos_runner import (
     ReplayRefused,
     ReplayResponse,
     SlmosRunner,
+    dry_run_transport,
     parse_replay_output,
 )
 
@@ -425,6 +426,75 @@ class SoftRefuseUntilRegexTests(unittest.TestCase):
             "bar=4 offset=0x0"
         )
         self.assertIsNone(rx.search(line))
+
+
+class DryRunTransportTests(unittest.TestCase):
+    """#810: `dry_run_transport` must synthesise enough output for the
+    three labctl commands `SlmosRunner` issues so the loop can advance
+    one iteration cleanly without touching hardware. Pre-fix the
+    transport returned empty stdout for every call, which made
+    `wait_for_shell()` fail at the prompt regex and bubble up as
+    'did not see shell prompt after flash+reboot (rc=0)'.
+    """
+
+    def test_capture_emits_shell_prompt(self) -> None:
+        """`labctl serial capture ... --until slmos>` must produce
+        stdout containing the prompt so `_shell_prompt_re.search`
+        succeeds in `SlmosRunner.replay_step`."""
+        argv = [
+            "labctl", "serial", "capture", "pi-5-1",
+            "--until", "slmos>", "--timeout", "45.0",
+        ]
+        result = dry_run_transport(argv, None)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("slmos>", result.stdout)
+
+    def test_send_emits_synthetic_response_with_seq(self) -> None:
+        """`labctl serial send ... 'hailo replay-step <path> <seq>'`
+        must produce a HAILO_RE_CORPUS_RESPONSE line that
+        `parse_replay_output` classifies as a ReplayResponse, with
+        the seq carried through from argv."""
+        cmd = "\rhailo replay-step 0:/corpus.jsonl 47"
+        argv = [
+            "labctl", "serial", "send", "pi-5-1", cmd,
+            "--capture", "30", "--until", "slmos_sha=[0-9a-f]{40}",
+        ]
+        result = dry_run_transport(argv, None)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("HAILO_RE_CORPUS_RESPONSE", result.stdout)
+        self.assertIn("seq=47", result.stdout)
+        # The downstream parser must classify it as a successful
+        # response (not a divergence, error, or refusal).
+        parsed = parse_replay_output(result.stdout)
+        self.assertIsInstance(parsed, ReplayResponse)
+
+    def test_send_with_no_seq_in_cmd_still_returns_success(self) -> None:
+        """Defensive: if the synthesised command doesn't carry a
+        recognisable replay-step seq, fall back to seq=0 rather than
+        crash. Empty stdout would re-trigger the original #810 bug."""
+        argv = ["labctl", "serial", "send", "pi-5-1", "\rhello"]
+        result = dry_run_transport(argv, None)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("HAILO_RE_CORPUS_RESPONSE", result.stdout)
+        self.assertIn("seq=0", result.stdout)
+
+    def test_sdwire_update_returns_empty_stdout(self) -> None:
+        """flash_and_reboot calls `labctl sdwire update ...`. That
+        path doesn't need synthesised stdout — `SlmosRunner` only
+        checks returncode == 0 from the flash step."""
+        argv = ["labctl", "sdwire", "update", "pi-5-1", "-p", "1",
+                "-c", "/tmp/kernel.bin:kernel_2712.img", "--reboot"]
+        result = dry_run_transport(argv, None)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_stderr_carries_command_log(self) -> None:
+        """The pre-fix behaviour of echoing the would-be argv to
+        stderr was useful for debugging — preserve it."""
+        argv = ["labctl", "serial", "capture", "pi-5-1", "--until", "slmos>"]
+        result = dry_run_transport(argv, None)
+        self.assertIn("[dry-run]", result.stderr)
+        self.assertIn("labctl", result.stderr)
 
 
 if __name__ == "__main__":

--- a/kernel/ai_accel/hailo/hailo_cs_translator.c
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.c
@@ -257,13 +257,11 @@ static int translate_open_boundary_for_pad(
         uint32_t periph_frame = pad_periph_frame_size(pad);
         struct hailo_cs_act_open_boundary_input_channel body = {
             .packed_vdma_channel_id = packed_vdma,
-            .host_buffer_info = {
-                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
-                .dma_address      = cfg->boundary_input_desc_list_iova,
-                .desc_page_size   = cfg->boundary_desc_page_size,
-                .total_desc_count = cfg->boundary_input_total_desc_count,
-                .bytes_in_pattern = periph_frame,
-            },
+            .host_buffer_info = HAILO_CS_HOST_BUFFER_INFO_EXTERNAL(
+                cfg->boundary_input_desc_list_iova,
+                cfg->boundary_desc_page_size,
+                cfg->boundary_input_total_desc_count,
+                periph_frame),
             .stream_index             = stream_index,
             .network_index            = 0,
             .periph_bytes_per_buffer  =
@@ -285,18 +283,16 @@ static int translate_open_boundary_for_pad(
             return HAILO_ERR_INVAL;
         }
         uint32_t periph_frame = pad_periph_frame_size(pad);
+        /* Output: periph frame == core_bytes_per_buffer per
+         * pad_periph_frame_size. bytes_in_pattern = 16 for MNIST's
+         * 1x1x10 (padded) output on the wire. */
         struct hailo_cs_act_open_boundary_output_channel body = {
             .packed_vdma_channel_id = packed_vdma,
-            .host_buffer_info = {
-                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
-                .dma_address      = cfg->boundary_output_desc_list_iova,
-                .desc_page_size   = cfg_output_page_size(cfg),
-                .total_desc_count = cfg->boundary_output_total_desc_count,
-                /* Output: periph frame == core_bytes_per_buffer per
-                 * pad_periph_frame_size. bytes_in_pattern = 16 for
-                 * MNIST's 1x1x10 (padded) output on the wire. */
-                .bytes_in_pattern = periph_frame,
-            },
+            .host_buffer_info = HAILO_CS_HOST_BUFFER_INFO_EXTERNAL(
+                cfg->boundary_output_desc_list_iova,
+                cfg_output_page_size(cfg),
+                cfg->boundary_output_total_desc_count,
+                periph_frame),
         };
         (void)stream_index;   /* OUTPUT body omits stream_index today. */
         return hailo_cs_builder_append(
@@ -913,13 +909,11 @@ static int translate_preliminary(const struct hef_info *info,
         struct hailo_cs_act_activate_cfg_channel bulk = {
             .packed_vdma_channel_id = cfg->cfg_channel_1_packed_vdma,
             .config_stream_index    = cfg->cfg_channel_1_stream_index,
-            .host_buffer_info = {
-                .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
-                .dma_address      = cfg->cfg_channel_1_desc_list_iova,
-                .desc_page_size   = cfg->ccw_desc_page_size,
-                .total_desc_count = cfg->cfg_channel_1_total_desc_count,
-                .bytes_in_pattern = cfg->cfg_channel_1_bytes_in_pattern,
-            },
+            .host_buffer_info = HAILO_CS_HOST_BUFFER_INFO_EXTERNAL(
+                cfg->cfg_channel_1_desc_list_iova,
+                cfg->ccw_desc_page_size,
+                cfg->cfg_channel_1_total_desc_count,
+                cfg->cfg_channel_1_bytes_in_pattern),
         };
         rc = hailo_cs_builder_append(b, HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,
                                      &bulk, sizeof(bulk));
@@ -929,13 +923,11 @@ static int translate_preliminary(const struct hef_info *info,
     struct hailo_cs_act_activate_cfg_channel act = {
         .packed_vdma_channel_id = cfg->config_vdma_channel,
         .config_stream_index    = cfg->config_stream_index,
-        .host_buffer_info = {
-            .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,
-            .dma_address      = cfg->ccw_desc_list_iova,
-            .desc_page_size   = cfg->ccw_desc_page_size,
-            .total_desc_count = cfg->ccw_total_desc_count,
-            .bytes_in_pattern = cfg->ccw_bytes_in_pattern,
-        },
+        .host_buffer_info = HAILO_CS_HOST_BUFFER_INFO_EXTERNAL(
+            cfg->ccw_desc_list_iova,
+            cfg->ccw_desc_page_size,
+            cfg->ccw_total_desc_count,
+            cfg->ccw_bytes_in_pattern),
     };
     rc = hailo_cs_builder_append(b, HAILO_CS_ACT_ACTIVATE_CFG_CHANNEL,
                                  &act, sizeof(act));

--- a/kernel/ai_accel/hailo/hailo_cs_translator.h
+++ b/kernel/ai_accel/hailo/hailo_cs_translator.h
@@ -134,6 +134,54 @@ _Static_assert(HAILO_CS_DEFAULT_CONFIG_VDMA_CHANNEL
                <= HAILO_CS_PCIE_MAX_D2H,
                "boundary OUTPUT channel must not exceed D2H upper bound");
 
+/* #337-5: CCW + boundary page-size + desc-count defaults. Moved here
+ * (from inference_device_hailo.c) so the "config_channel + 1 / +2"
+ * invariant and the page-size invariants live in one file. Values
+ * are pinned against HailoRT v4.23's MNIST wire capture on pi-5-1:
+ *
+ *   CCW_DESC_PAGE_SIZE        = 512  — MVP cfg-channel page granularity.
+ *   BOUNDARY_PAGE_SIZE        = 512  — INPUT boundary page size; fw
+ *                                       silently refuses transfers
+ *                                       whose host-side geometry
+ *                                       disagrees with the OpenBoundary
+ *                                       advertised value.
+ *   BOUNDARY_OUTPUT_PAGE_SIZE = 64   — OUTPUT boundary page size; the
+ *                                       MIN_VDMA_DESCRIPTOR_BUFFER_SIZE
+ *                                       value lets tiny outputs (16 B
+ *                                       for MNIST) use the smallest
+ *                                       descriptor granularity.
+ *   BOUNDARY_DESC_COUNT       = 32   — HailoRT allocates 32 entries
+ *                                       per boundary SG list on v4.23.
+ *                                       Power-of-2 floor (the alloc API
+ *                                       rounds up anyway).
+ *
+ * See `kernel/inference/inference_device_hailo.c` for the detailed
+ * #253 byte-verification notes that pinned these values. */
+#define HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE         512u
+#define HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE         512u
+#define HAILO_CS_DEFAULT_BOUNDARY_OUTPUT_PAGE_SIZE  64u
+#define HAILO_CS_DEFAULT_BOUNDARY_DESC_COUNT        32u
+
+/* #337-2: compound literal for `struct hailo_cs_host_buffer_info`
+ * with buffer_type pinned to EXTERNAL_DESC. The four host-side
+ * VDMA descriptor lists SLM-OS programs (cfg ch0/ch1 + boundary
+ * IN/OUT) always use the external-descriptor path; this macro
+ * collapses the buffer_type + named-field noise at every
+ * OpenBoundary / ActivateCfgChannel call site to a single line:
+ *
+ *   .host_buffer_info = HAILO_CS_HOST_BUFFER_INFO_EXTERNAL(
+ *       iova, page_size, desc_count, bytes_in_pattern),
+ *
+ * Caller-side struct initializers wrap this in `{ ... }` per C99
+ * compound-literal rules. */
+#define HAILO_CS_HOST_BUFFER_INFO_EXTERNAL(iova, page, count, pattern) { \
+    .buffer_type      = HAILO_CS_HOST_BUFFER_EXTERNAL_DESC,              \
+    .dma_address      = (iova),                                          \
+    .desc_page_size   = (page),                                          \
+    .total_desc_count = (count),                                         \
+    .bytes_in_pattern = (pattern),                                       \
+}
+
 struct hailo_cs_translate_cfg {
     /* packed_vdma_channel_id for the config stream (the channel the
      * firmware DMA-pulls CCW payloads through). Typical choice on

--- a/kernel/inference/inference_device_hailo.c
+++ b/kernel/inference/inference_device_hailo.c
@@ -829,40 +829,34 @@ static int pick_largest_pads(const struct hef_info *info,
 /* slots as having no context-switch resources to release.                      */
 /* -------------------------------------------------------------------------- */
 
-/* CCW + boundary page-size defaults shared between allocation and
- * translate_cfg. The MVP hardcodes both to match ctxsmoke's
- * shell-command sizing on pi-5-1. The matching config-VDMA-channel
- * default lives in hailo_cs_translator.h alongside the boundary-
- * channel offsets and their compile-time range guards. */
-#define HAILO_CS_DEFAULT_CCW_DESC_PAGE_SIZE   512u
-/* HailoRT v4.23 wire capture on pi-5-1 shows boundary channels use
- * desc_page_size=512 (pios_ACTIVATION.bin / pios_DYNAMIC.bin: low-16
- * of OpenBoundary.host_buffer_info.desc_page_size = 0x0200). 4096
- * is within the HW 4 KB cap but fw appears to cache the
- * (desc_page_size, total_desc_count) pair declared in
- * OpenBoundary and silently refuse transfers whose host-side geometry
- * disagrees. Matching HailoRT's chosen values byte-for-byte is the
- * safest default. */
-#define HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE   512u
-/* Output-side boundary desc page size. HailoRT v4.23 on MNIST
- * allocates the output boundary descriptor list at page_size=64
- * (MIN_VDMA_DESCRIPTOR_BUFFER_SIZE) while the input uses 512. See
- * pios_DYNAMIC.bin host_buffer_info.desc_page_size fields for
- * ACTIVATE_BOUNDARY_INPUT vs ACTIVATE_BOUNDARY_OUTPUT — the LE
- * bytes at abs offset 0x22-0x23 of the DYNAMIC stream are
- * 0x40 0x00 (=64) for OUTPUT and 0x00 0x02 (=512) for INPUT.
- * The asymmetry lets tiny output tensors (16 B for MNIST) use the
- * smallest possible descriptor granularity without overcommitting
- * SG table space. Firmware cross-validates the declared page size
- * against the descriptor list's own header and silently wedges
- * the D2H pipe (num_proc stays 0 forever) on a mismatch.
- * Byte-verified on pi-5-1 #253. */
-#define HAILO_CS_DEFAULT_BOUNDARY_OUTPUT_PAGE_SIZE  64u
-/* HailoRT allocates a 32-entry boundary SG list on v4.23 (host_buffer_
- * info.total_desc_count = 32). Our desc_count_for() rounds up to a
- * power of two anyway, so for MNIST-scale transfers (one 784 B frame
- * in a 512 B page = 2 descs) the floor pushes us to 32 explicitly. */
-#define HAILO_CS_DEFAULT_BOUNDARY_DESC_COUNT  32u
+/* #337-5: CCW + boundary page-size + desc-count defaults moved to
+ * hailo_cs_translator.h so the "config_channel + 1 / +2" + page-size
+ * invariants live in one file. The detailed #253 byte-verification
+ * notes that pinned these values stay here as historical reference:
+ *
+ *   - HAILO_CS_DEFAULT_BOUNDARY_PAGE_SIZE (=512): HailoRT v4.23 wire
+ *     capture on pi-5-1 (pios_ACTIVATION.bin / pios_DYNAMIC.bin: low-
+ *     16 of OpenBoundary.host_buffer_info.desc_page_size = 0x0200).
+ *     4096 is within the HW 4 KB cap but fw appears to cache the
+ *     (desc_page_size, total_desc_count) pair declared in
+ *     OpenBoundary and silently refuse transfers whose host-side
+ *     geometry disagrees.
+ *
+ *   - HAILO_CS_DEFAULT_BOUNDARY_OUTPUT_PAGE_SIZE (=64): pios_DYNAMIC.
+ *     bin host_buffer_info.desc_page_size for ACTIVATE_BOUNDARY_OUTPUT
+ *     reads 0x40 0x00 (=64) vs 0x00 0x02 (=512) for INPUT at abs
+ *     offset 0x22-0x23 of the DYNAMIC stream. MIN_VDMA_DESCRIPTOR_
+ *     BUFFER_SIZE. Lets tiny outputs (16 B for MNIST) use the
+ *     smallest descriptor granularity without overcommitting SG
+ *     table space. fw cross-validates the declared page size
+ *     against the descriptor list's own header and silently wedges
+ *     the D2H pipe (num_proc stays 0 forever) on a mismatch.
+ *
+ *   - HAILO_CS_DEFAULT_BOUNDARY_DESC_COUNT (=32): HailoRT v4.23 host_
+ *     buffer_info.total_desc_count = 32. Our desc_count_for() rounds
+ *     up to a power of two anyway, so for MNIST-scale transfers
+ *     (one 784 B frame in a 512 B page = 2 descs) the floor pushes
+ *     us to 32 explicitly. */
 
 /* Round `bytes` up to `page_size` and return the descriptor count
  * needed to cover the region, rounded UP to the next power of two


### PR DESCRIPTION
## Summary

Second cleanup batch. Closes #810 entirely + closes 2 of 8 items on #337.

| Closes | Item | Change shape |
|---|---|---|
| #810 | dry_run_transport synthesises labctl output | 50-line `argv`-introspection patch in `slmos_runner.py` + 5 unit tests |
| #337-5 | Move page-size + desc-count constants to translator header | move 4 #defines + their detail comments |
| #337-2 | `HAILO_CS_HOST_BUFFER_INFO_EXTERNAL` compound-literal macro | new macro + 4 call-site rewrites (net -12 lines) |

## #810 detail

Pre-fix dry-run flow failed at "did not see shell prompt after flash+reboot (rc=0)" because `dry_run_transport` returned empty stdout for every call, and `wait_for_shell()`'s `_shell_prompt_re.search(stdout)` matched nothing. New behavior:

- `labctl serial capture <sbc> --until <re>` → `stdout="slmos> \n"`
- `labctl serial send <sbc> '\\r hailo replay-step <path> <seq>' ...` → synthesised `HAILO_RE_CORPUS_RESPONSE seq=<extracted> bar=0 offset=0 size=4 value=deadbeef slmos_sha=<40 zeros>` so `parse_replay_output()` classifies as `ReplayResponse`.
- Anything else (sdwire update, etc.) → empty stdout (unchanged; those paths only check returncode).

5 new tests cover each branch + the defensive seq-extraction fallback. Total host-tools tests: 128 (up from 123).

## #337 deferred items (kept open)

- Item 1: split `translate_open_boundary_for_pad` per direction — better done together with Item 3
- Item 3: `boundary_packed_id` helper — marginal without Item 1
- Item 4: split `context_switch_load` (~170 lines) — invasive, deserves its own PR
- Item 6: factor `ctxs[]` 4-entry table — already concise; abstraction would add lines
- Items 7, 8: test fixture builder + byte-offset helper — better added when writing new tests

Updating #337 with which items are closed and which remain.

## Test plan

- [x] `make test` (QEMU ARM64) passes
- [x] `python3 -m unittest discover -s tests` (host-tools) passes — 128 tests
- [x] `make kernel PLATFORM=RASPI5 AI_SCHED=ON` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)