### PR TITLE
docs: Hailo post-#1001 sweep — record 2026-05-28 second-pass closure

### DIFF
--- a/docs/hailo-dma-content-diff-plan.md
+++ b/docs/hailo-dma-content-diff-plan.md
@@ -1,5 +1,18 @@
 # Hailo DMA buffer content diff plan (#1001 follow-up)
 
+**Status (2026-05-28):** EXECUTED. SLM-OS side landed in PR
+[#1010](https://github.com/SLM-OS/SLM-Operating-System/pull/1010); the
+matching Linux `hailo_pci` patch landed cross-side during the same session.
+Capture ran 2026-05-27 on `pi-5-1` against HailoRT reference. Outcome:
+**CCWS payload + boundary IN/OUT descriptor-list payloads byte-faithful to
+HailoRT, wedge persists.** This was THE remaining host-observable test
+(see §"Definitive-ness of the result" below) — its conclusion exhausts
+the host-side surface area, and
+[#1001](https://github.com/SLM-OS/SLM-Operating-System/issues/1001) was
+closed 2026-05-28 on that basis. The plan below is retained as
+historical reference and as a template for any future DMA-content
+investigation.
+
 ## Why
 
 Every BAR0/BAR2/BAR4 MMIO write SLM-OS issues during MNIST load + first-frame
@@ -96,7 +109,7 @@ Companion deploy script at
 covers patch apply + DKMS rebuild + dump trigger + dmesg capture in
 one run.
 
-**Status: draft skeleton, deploy-pending.** Several field names
+**Status (originally drafted): draft skeleton, deploy-pending.** Several field names
 (`hailo_pcie_board.vdma.controller.file_context_list`,
 `hailo_descriptors_list_buffer.dma_address`, the per-fd context
 tracking inside the controller struct) are inferred from the .c files

--- a/docs/hailo-lifecycle.md
+++ b/docs/hailo-lifecycle.md
@@ -929,16 +929,27 @@ chase the same ghosts.
 | hyp-T | VDM QoS programming on PCIe1 RC | **Confirmed** — implemented |
 | hyp-U/V/W | Bridge-error diagnostic + SCB0 widen | **Confirmed** — implemented |
 | hyp-X-1 | Pre-IN-submit IRQ drain | Disconfirmed |
-| hyp-X-3 | Boundary IN ch=2 wedge investigation | **Open — see #682** |
+| hyp-X-3 | Boundary IN ch=2 wedge investigation | **Closed exhausted — see #682 (2026-05-12) and #1001 (2026-05-28)** |
+| hyp-X (#1012) | Pre-program all 32 IN ring slots (HailoRT parity) | Disconfirmed on hardware; kept as defensive wire parity |
+| hyp-Y (#1012) | Clear LIRQ bit on last descriptor (HailoRT parity) | Disconfirmed on hardware; kept as defensive wire parity. Side-finding: clearing LIRQ also suppresses the spurious `event_id=0 ETHERNET_RX_ERROR` d2h notification (LIRQ side-effect, not a wedge signal). |
+| dma-content-diff | Host RAM that fw reads via DMA byte-faithful to HailoRT | Disconfirmed as cause — content matches, wedge persists (PR #1010, 2026-05-27) |
 
-The ch=2 wedge (hyp-X-3) is the current open issue. The host-side
-hypotheses (missing ioctl, wrong descriptor field values, partial vs
-full-ring bind, dynamic vs static bind, alternate interrupt-domain
-on launch) have all been eliminated; the wedge is in fw-side ch=2
-arm logic and currently sits with Hailo support.
+The ch=2 wedge (hyp-X-3) is closed exhausted across two passes. #682
+closed 2026-05-12 after the Linux-side fw_control kprobe showed
+HailoRT uses fw_control only for IDENTIFY and routes primary
+configuration through undocumented BAR4 mmap writes. #1001 closed
+2026-05-28 after a second-pass 10-hypothesis chain plus the
+DMA-content byte-diff proved every host-observable byte — MMIO wire,
+DMA descriptor list, DMA CCWS payload — matches HailoRT and the
+wedge still reproduces. Remaining attack surfaces are external to
+host-observable state (fw-memory BAR4 inspection, Hailo support
+escalation, HailoRT runtime decompilation). See
+`docs/hailo-protocol-architecture.md` §"Update 2026-05-28" for the
+full disconfirmation surface.
 
 ---
 
-*Last updated: 2026-05-10. Reflects the state of the codebase at
-PR #768 (`682/ushim-bind-parity` merged into main). Doc-review fixes
-applied in PR #771.*
+*Last updated: 2026-05-28. Second-pass closure of the ch=2 wedge
+(#1001) appended; §15 glossary expanded with hyp-X / hyp-Y / DMA
+content-diff outcomes. Original lifecycle text last revised 2026-05-10
+at PR #768 (`682/ushim-bind-parity`); doc-review fixes in PR #771.*

--- a/docs/hailo-protocol-architecture.md
+++ b/docs/hailo-protocol-architecture.md
@@ -1,6 +1,6 @@
 # Hailo NPU Protocol Architecture
 
-**Status:** Reference document, anchored to empirical findings on Hailo-8L AI HAT+ with firmware v4.23 on Raspberry Pi 5, captured 2026-05-12. Re-validate before assuming the same shape for future firmware revisions or different Hailo SoCs.
+**Status:** Reference document, anchored to empirical findings on Hailo-8L AI HAT+ with firmware v4.23 on Raspberry Pi 5. Initial capture 2026-05-12 (§"Empirical evidence" — Linux ftrace + kprobe on `hailo_pcie_write_firmware_control`). Extended 2026-05-28 (§"Update 2026-05-28" — host-side wire byte-diff + DMA-content byte-diff, [#1001](https://github.com/SLM-OS/SLM-Operating-System/issues/1001) closed exhausted). Re-validate before assuming the same shape for future firmware revisions or different Hailo SoCs.
 
 ## TL;DR
 
@@ -12,7 +12,7 @@ Hailo's NPU configuration uses **two protocols simultaneously**:
 
 A host that uses only the documented fw_control RPC protocol completes ~90% of the load (firmware accepts every RPC with rc=0) but cannot complete the final channel-to-inference-path binding. The wedge surfaces as: `hailo runmodel <h>` writes `num_avail=2` to ch=2; firmware never advances `num_proc`; timeout after 500 ms.
 
-This is the root cause of [#682](https://github.com/SLM-OS/SLM-Operating-System/issues/682) (closed 2026-05-12 as Hailo-side architectural limit).
+This is the root cause of [#682](https://github.com/SLM-OS/SLM-Operating-System/issues/682) (closed 2026-05-12 as Hailo-side architectural limit) and its downstream [#1001](https://github.com/SLM-OS/SLM-Operating-System/issues/1001) (closed 2026-05-28 after a second-pass disconfirmation chain — see §"Update 2026-05-28" below for the additional evidence).
 
 ## Empirical evidence
 
@@ -93,6 +93,29 @@ These hypotheses were investigated and **disproven** during the #682 bisection. 
 | HEF-specific MNIST issue | RULED OUT | Wedge reproduces shape-identically across other model attempts; descriptor list shape matches Linux exactly for MNIST. |
 | BAR4 misalignment | RULED OUT | All bar4_write/read paths are 32-bit aligned; verified empirically via wire-debug. |
 | Cache coherency (descriptor list DMA) | RULED OUT | Descriptor list is cleaned via `cache_clean` before submit; HAILO_WIRE_DEBUG dump from DRAM matches programmed values. |
+| IN ring descriptor pre-fill (full ring vs partial) | DISPROVEN (PR #1012, hyp-X) | HailoRT pre-programs all 32 ring slots before any submit; SLM-OS pre-programmed only the first N. Aligning to full-ring pre-fill: null effect, wedge persists. |
+| Last-descriptor LIRQ bit (`0x2e` vs `0x02`) | DISPROVEN (PR #1012, hyp-Y) | HailoRT clears the LIRQ bit on the final descriptor of the transfer; SLM-OS left it set. Aligning to the cleared form: null effect on wedge (side-finding: clearing LIRQ also suppressed the spurious `event_id=0 ETHERNET_RX_ERROR` d2h notification, which is therefore a fw side-effect of LIRQ, not a wedge signal). |
+| DMA buffer content (CCWS + boundary desc-list payload) | RULED OUT (PR #1010, 2026-05-27) | Per the plan in `docs/hailo-dma-content-diff-plan.md` — full host-RAM content dump on both sides; byte-faithful match across cfg-channel CCWS and boundary IN/OUT desc-list payloads. fw rejects ch=2 dispatch on something invisible to host-observable host wire AND host RAM. |
+
+## Update 2026-05-28: DMA content byte-faithful, wedge persists
+
+Between 2026-05-25 and 2026-05-28 the BAR4-RE attempt (PR #795 et seq.) and the DMA-content byte-diff plan (this file's neighbour `hailo-dma-content-diff-plan.md`) were executed end-to-end against [#1001](https://github.com/SLM-OS/SLM-Operating-System/issues/1001) — the downstream "host has all observable wedge state matching HailoRT, fw still rejects ch=2" follow-on to #682.
+
+**Ten additional hypotheses** were tested on hardware (`pi-5-1`) during that pass: channel-direction, seq=0, drop-pings, longer-settle, PMCSR cycle, MSI/polled-only, BAR4 padding, IOVA reachability, full-ring pre-program (hyp-X), and last-descriptor LIRQ clear (hyp-Y). All ten disconfirmed.
+
+**Two real wire divergences were found** (full-ring pre-program + LIRQ-clear) and corrected as defensive parity in PR [#1012](https://github.com/SLM-OS/SLM-Operating-System/pull/1012). Neither moved the wedge. They are kept in-tree because byte-parity with HailoRT is independently load-bearing for any future investigation.
+
+**The decisive new evidence** is the DMA-content byte-diff. Prior bisections had only proven the *wire* bytes (MMIO writes into BAR0/BAR2/BAR4) were byte-faithful between SLM-OS and HailoRT. The 2026-05-27 capture extended that to **host-RAM content read via DMA**: CCWS data at the cfg-channel IOVAs, and the full 256-byte boundary descriptor-list payloads (IN + OUT, all 32 slots each). Both byte-faithful to HailoRT. The wedge persists.
+
+This closes the host-observable surface area. Every byte SLM-OS hands to firmware — by MMIO write, by DMA read, in every order, with every observable timing — matches HailoRT. The firmware still refuses to advance `num_proc` on ch=2.
+
+**Remaining paths forward** (all external to the host-observable surface):
+
+- fw-memory inspection via BAR4 windowed reads — extend the PR #997 framework from BAR0/BAR2 to BAR4 and dump fw-internal state pre/post-load.
+- Hailo support escalation — present the byte-faithful evidence and request fw-side debug.
+- Live HailoRT decompilation / dynamic instrumentation under userspace gdb to capture the BAR-write sequence Linux uses for the same load.
+
+None of these can land before the SLM-OS capstone deadline. #1001 is closed and the chain accepted as the most thorough negative result the project can produce on host hardware alone.
 
 ## Reopen criteria
 
@@ -100,10 +123,10 @@ These hypotheses were investigated and **disproven** during the #682 bisection. 
 
 - Hailo publishes the BAR4 configuration protocol (or releases HailoRT source).
 - A new firmware revision exposes additional fw_control opcodes that complete channel binding.
-- A reverse-engineering effort produces a verified mapping from HailoRT operations to BAR4 writes.
+- A reverse-engineering effort produces a verified mapping from HailoRT operations to BAR4 writes **AND** demonstrates that replicating those writes alone unblocks the wedge. (Note: a partial RE attempt was made 2026-05-25 → 2026-05-28; producing byte-faithful host wire + DMA content was not sufficient — see §"Update 2026-05-28". A re-attempt that does not address what fw reads from BAR4 *itself* post-load will reproduce the same exhaustion.)
 - A different host runtime (not HailoRT) is observed completing MNIST inference on Hailo-8L using only documented interfaces.
 
-Mere "I have a new hypothesis about descriptor bytes / settle timing / channel state" is not sufficient — those have been exhaustively bisected and the surface area is closed.
+Mere "I have a new hypothesis about descriptor bytes / settle timing / channel state / wire ordering / DMA content" is not sufficient — those surfaces have been exhaustively bisected across two passes (the 2026-05-12 #682 chain and the 2026-05-28 #1001 chain) and are closed.
 
 ## Capture procedure for future Hailo investigations
 

--- a/docs/pi5-ai-hat-plan.md
+++ b/docs/pi5-ai-hat-plan.md
@@ -2,16 +2,20 @@
 
 **Target:** GeeekPi AI HAT+ (Hailo-8L, 13 TOPS) and AI HAT+ 26 TOPS (Hailo-8) on Raspberry Pi 5, end-to-end to running AI inference workloads from SLM-OS.
 
-**Status (2026-05-12):** Phase 0–7 software-complete. **Phase 8 CLOSED** —
-boundary-input submit blocker tracked in
-[#682](https://github.com/SLM-OS/SLM-Operating-System/issues/682) was
-investigated to root cause and accepted as a Hailo-side architectural
-limit. SLM-OS gets ~90% through HEF load (last_err=0, all RPCs rc=0,
-descriptors bit-identical to HailoRT), but the final channel-to-inference
-binding lives in an undocumented direct-BAR4-write protocol that
-HailoRT (proprietary userspace) uses and that fw_control RPCs cannot
-fully reproduce. See `docs/hailo-protocol-architecture.md` for the
-empirical finding, vendor comparison, and reopen criteria.
+**Status (2026-05-28):** Phase 0–7 software-complete. **Phase 8 CLOSED
+(twice).** First closure 2026-05-12 ([#682](https://github.com/SLM-OS/SLM-Operating-System/issues/682))
+when fw_control RPCs were proven sufficient for ~90% of HEF load but
+insufficient for the final channel-to-inference binding (Linux capture:
+HailoRT uses fw_control only for IDENTIFY; primary config goes through
+undocumented BAR4 mmap writes). Re-opened in spirit as
+[#1001](https://github.com/SLM-OS/SLM-Operating-System/issues/1001), a
+second-pass disconfirmation chain (2026-05-25 → 2026-05-28) that proved
+every host-observable byte — MMIO wire, DMA descriptor list, DMA CCWS
+payload — byte-faithful to HailoRT. Wedge persists. #1001 closed
+exhausted 2026-05-28. See `docs/hailo-protocol-architecture.md`
+§"Update 2026-05-28" for the additional disconfirmation surface and
+§"Reopen criteria" for what the chain rules out for any future
+re-attempt.
 
 **Scope honesty (2026-04-24, audit F-04 / F-11):** The current Hailo
 backend should be characterized as a **Hailo-8L / MNIST bring-up
@@ -1567,4 +1571,65 @@ engineering effort under the §9 reopen criteria.
 
 ---
 
-*Last updated: 2026-05-12 (Phase 8 closed, #682 accepted as Hailo-side limit)*
+## 10. Phase 8 second-pass closure — 2026-05-28: DMA content also byte-faithful (#1001)
+
+After §9's 2026-05-12 closure of #682, [#1001](https://github.com/SLM-OS/SLM-Operating-System/issues/1001)
+tracked the downstream observation that even with every host-observable
+RPC and wire byte matching HailoRT, fw still refused to advance
+`num_proc` on the boundary IN channel. The chain re-opened the §9
+"reverse-engineering effort" reopen-criterion as scope.
+
+### What was tried in the second pass
+
+Ten further hypotheses, all tested on `pi-5-1` against a real
+HailoRT-reference capture:
+
+| # | Hypothesis | Outcome |
+|---|---|---|
+| 1 | Channel-index direction (PR #999) | FIX — required, but did not unwedge |
+| 2 | Replay corpus seq=0 vs seq=1 | DISPROVEN |
+| 3 | Drop pre-load CORE-CPU pings | DISPROVEN |
+| 4 | Longer post-BOOT_IRQ settle | DISPROVEN |
+| 5 | PMCSR cycle pre-load | DISPROVEN |
+| 6 | MSI fast-path vs polled completion | DISPROVEN (both wedge) |
+| 7 | BAR4 padding / mirror writes | DISPROVEN |
+| 8 | IOVA reachability (0x100xxx range) | DISCONFIRMED — fw DOES read CCWS at our IOVAs (ch=0 proc=0x006e006d) |
+| 9 | IN ring full pre-program (hyp-X, PR #1012) | DISPROVEN (kept as defensive parity) |
+| 10 | Last-descriptor LIRQ clear (hyp-Y, PR #1012) | DISPROVEN (side-finding: clearing LIRQ also suppresses the spurious `event_id=0 ETHERNET_RX_ERROR` d2h notification, which is a fw side-effect of LIRQ, not a wedge signal) |
+
+### The decisive new evidence
+
+The 2026-05-27 DMA-content byte-diff — planned in
+`docs/hailo-dma-content-diff-plan.md`, executed via PR
+[#1010](https://github.com/SLM-OS/SLM-Operating-System/pull/1010)
+(SLM-OS side) and the matching Linux `hailo_pci` patch — extended
+parity checking from the *wire* (MMIO writes) to the *host RAM that
+fw reads via DMA*:
+
+- CCWS payload at the cfg-channel IOVAs: byte-faithful.
+- Boundary IN descriptor-list payload (16 B × 32 slots = 512 B): byte-faithful.
+- Boundary OUT descriptor-list payload (16 B × 32 slots = 512 B): byte-faithful.
+
+Wedge persists. This is the most comprehensive negative result the
+project can produce on host hardware alone — every byte SLM-OS hands
+to firmware, by any observable path, matches HailoRT.
+
+### Where this leaves the project
+
+Phases 6 and 7 remain deferred. The chain is now exhausted across
+both passes (#682 → #1001). Remaining attack surfaces are all
+external to host-observable state: fw-memory BAR4 inspection
+(extending the PR #997 framework), Hailo vendor escalation, or
+HailoRT runtime decompilation. None are in scope before the
+capstone deadline.
+
+The Phase 8 work is presentable as a capstone result on its own
+terms — a multi-month bring-up against a fully-closed accelerator
+producing byte-faithful wire + DMA conformance to the vendor
+runtime, with a precisely characterized fw-side limit. See
+`docs/hailo-protocol-architecture.md` for the full architectural
+finding.
+
+---
+
+*Last updated: 2026-05-28 (Phase 8 second-pass closure, #1001 closed; DMA-content byte-diff exhausted)*


### PR DESCRIPTION
## Summary

The four canonical Hailo docs (`hailo-protocol-architecture.md`, `pi5-ai-hat-plan.md`, `hailo-lifecycle.md`, `hailo-dma-content-diff-plan.md`) were all dated 2026-05-12 and predated the entire #1001 byte-diff chain (10-hypothesis disconfirmation + DMA-content byte-diff, 2026-05-25 → 2026-05-28). This sweep updates each to reflect the second-pass closure.

## What's in the diff

- **`hailo-protocol-architecture.md`** — extended status header; new "Update 2026-05-28: DMA content byte-faithful, wedge persists" section; appended the new hypotheses (hyp-X full-ring pre-program, hyp-Y LIRQ clear, DMA-content byte-diff) to the ruled-out table; tightened the reopen criteria so a future RE attempt that only reproduces host wire + DMA content (already done, already exhausted) is explicitly out of scope.
- **`pi5-ai-hat-plan.md`** — updated header status block; added §10 "Phase 8 second-pass closure" with the 10-hypothesis table and the DMA-content-diff result; updated trailing \"Last updated\" line.
- **`hailo-lifecycle.md`** — §15 glossary expanded with hyp-X / hyp-Y / DMA content-diff outcomes; hyp-X-3 status changed from \"Open\" to \"Closed exhausted\"; trailing date updated.
- **`hailo-dma-content-diff-plan.md`** — added an EXECUTED status banner referencing PR #1010 and the 2026-05-27 capture so the plan is no longer presented as draft.

## Why this is one PR

All four docs cross-reference each other on the same wedge. Updating one without the others would leave dead links (\"see §X for Y\") that point at stale conclusions.

## Test plan

- [ ] No code changes — docs only
- [ ] Cross-references between the four files still resolve
- [ ] Dates/PR numbers cited match the actual merge artifacts (#999, #1004, #1007, #1008, #1010, #1012)

🤖 Generated with [Claude Code](https://claude.com/claude-code)