### PR TITLE
docs(hailo): record post-#332 wedge regression check

### DIFF
--- a/docs/hailo-protocol-architecture.md
+++ b/docs/hailo-protocol-architecture.md
@@ -117,6 +117,26 @@ This closes the host-observable surface area. Every byte SLM-OS hands to firmwar
 
 None of these can land before the SLM-OS capstone deadline. #1001 is closed and the chain accepted as the most thorough negative result the project can produce on host hardware alone.
 
+### Post-#332 regression confirmation (2026-05-28)
+
+After [#1018](https://github.com/SLM-OS/SLM-Operating-System/pull/1018) closed [#332](https://github.com/SLM-OS/SLM-Operating-System/issues/332) by rewriting the control-RPC `wait_for_response` to use a pi_mutex + MSI-driven blocking wait (`task_sleep_wake`), the wedge was re-verified on `pi-5-1` to rule out any possibility that the lock/wait rework moved the failure point. Sequence:
+
+```
+hailo probe → OK
+hailo boot → IDENTIFY round-trip OK (under new wait_for_response)
+hailo load /mnt/files/user.hef sched → context-switch load OK, all RPCs rc=0
+hailo runmodel 1
+  pre-submit CORE_IDENTIFY rc=0 latency=10022 us   ← #332-changed code, works
+  [vdma] ch=2 TIMEOUT proc_end=0x00000000 base_end=0x00022801   ← wedge
+  IN submit_and_wait rc=-4 (avail=2)
+  IN  desc[0..7] status=0x00  ← fw never touched
+  OUT desc[0..7] status=0x00  ← fw never touched
+```
+
+Byte-identical to the #1001 wedge signature documented above. `hailo_vdma_submit_and_wait` (where the wedge fires) was not modified by #332; `git show` against the merge commit (5a4e3f1c) confirms #332 touched only the control-RPC wait path. The pre-submit `CORE_IDENTIFY` immediately upstream of the wedge flowed cleanly through the new pi_mutex blocking wait at rc=0, confirming the new wait infrastructure works correctly and the wedge is independent of any host-thread state that #332 might have shifted. Two readings — "no control-plane timing change affects the wedge" (negative) and "wedge is purely fw-side, not gated on any pre-VDMA-submit host state" (positive) — both reinforce the chain-exhausted closure.
+
+See [#1001#issuecomment-4570908610](https://github.com/SLM-OS/SLM-Operating-System/issues/1001#issuecomment-4570908610) for the full hardware capture.
+
 ## Reopen criteria
 
 #682 should only be reopened if one of these conditions holds:


### PR DESCRIPTION
## Summary

Adds a §"Post-#332 regression confirmation (2026-05-28)" subsection to `docs/hailo-protocol-architecture.md` (inside the existing 2026-05-28 update block) noting that after PR #1018 closed #332 by rewriting `wait_for_response` to a pi_mutex + MSI-driven blocking wait, the #1001 wedge was re-verified on `pi-5-1` to fail byte-identically — confirming the rework did not move the failure point.

The note includes:
- The verification sequence (`hailo probe → boot → load sched → runmodel 1`)
- The wedge signature observed (ch=2 TIMEOUT, proc_end=0, all desc status=0) — matches the documented #1001 form line-for-line
- Confirmation that `hailo_vdma_submit_and_wait` was untouched by #332 (per `git show` against the #1018 merge commit 5a4e3f1c)
- A cross-link to [#1001#issuecomment-4570908610](https://github.com/SLM-OS/SLM-Operating-System/issues/1001#issuecomment-4570908610) for the full hardware capture

## Why this matters

Closes the loop on the "did the #332 lock/wait rework break anything" question, which I missed verifying before merging #1018. The construction-only argument I had before (different file, different code path) was correct but not load-bearing — actual hardware reproduction confirms it.

## Test plan

- [x] Docs only, no code change
- [x] Hardware capture already attached to #1001 as a tracker comment
- [x] Cross-link from the doc back to the comment resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)